### PR TITLE
fix(qa): G7-L6 parser_gap tier (151 pass, 1 known gap)

### DIFF
--- a/backend/app/services/story_structure_qa_lib.py
+++ b/backend/app/services/story_structure_qa_lib.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 
 # Known parser gaps — resolved lessons removed as fixes land
-PARSER_GAP_LESSONS = frozenset()
+PARSER_GAP_LESSONS = frozenset({"G7-L6"})
 
 # Parsed ids where □ in plain text was not yet interactive_type checkbox (fixed in stories.py)
 CHECKBOX_GAP_LESSONS = frozenset()

--- a/backend/data/curriculum_qa/keypoints_manifest.json
+++ b/backend/data/curriculum_qa/keypoints_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-18T14:28:09.592712+00:00",
+  "generated_at": "2026-06-18T14:56:04.878722+00:00",
   "smoke_only": false,
   "gates_included": [
     "L1",
@@ -9,9 +9,10 @@
   ],
   "summary": {
     "total": 151,
-    "pass": 150,
-    "fail": 1,
-    "failure_count": 1
+    "pass": 151,
+    "fail": 0,
+    "known_gap_count": 1,
+    "failure_count": 0
   },
   "lessons": [
     {
@@ -19,6 +20,7 @@
       "title": "贏得喝󠇡采的輸家",
       "story_id": 1001,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -64,6 +66,7 @@
       "title": "美好的一天",
       "story_id": 1010,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -107,6 +110,7 @@
       "title": "誤會",
       "story_id": 1011,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -150,6 +154,7 @@
       "title": "黃絲帶",
       "story_id": 1012,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -193,6 +198,7 @@
       "title": "第一百碗麵",
       "story_id": 6,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -236,6 +242,7 @@
       "title": "白牙的最後一戰",
       "story_id": 1014,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -279,6 +286,7 @@
       "title": "感情小日記1──是友情還是愛情？",
       "story_id": 1015,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -322,6 +330,7 @@
       "title": "感情小日記2──喜歡是什麼？",
       "story_id": 1016,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -365,6 +374,7 @@
       "title": "把球打好，就夠了嗎？ ──阿耀與健豪學長的通信（一）",
       "story_id": 1017,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -408,6 +418,7 @@
       "title": "想讀書，該從哪裡著手？ ──阿耀與健豪學長的通信（二）",
       "story_id": 1018,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -451,6 +462,7 @@
       "title": "救援大隊的好幫手",
       "story_id": 1019,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -494,6 +506,7 @@
       "title": "十秒的背後",
       "story_id": 2,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -537,6 +550,7 @@
       "title": "物以稀為貴： 從「供給」和「需求」談物價波動",
       "story_id": 1020,
       "tier": "no_structure",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -565,6 +579,7 @@
       "title": "心，也要一起練",
       "story_id": 1023,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -608,6 +623,7 @@
       "title": "成為身體的最佳夥伴",
       "story_id": 1024,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -651,6 +667,7 @@
       "title": "身體，謝謝你",
       "story_id": 1025,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -694,6 +711,7 @@
       "title": "專注當下：關掉內心的批評噪音",
       "story_id": 1026,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -737,6 +755,7 @@
       "title": "從白熊到藍海豚：學習與念頭和平相處",
       "story_id": 1027,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -780,6 +799,7 @@
       "title": "長高的祕密",
       "story_id": 3,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -823,6 +843,7 @@
       "title": "運動科學",
       "story_id": 4,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -866,6 +887,7 @@
       "title": "穿越極限的跑者",
       "story_id": 5,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -909,6 +931,7 @@
       "title": "這是什麼「意思」？",
       "story_id": 1006,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -937,6 +960,7 @@
       "title": "正太與小豬：武僧的養成之路",
       "story_id": 1007,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -980,6 +1004,7 @@
       "title": "最美的畫面",
       "story_id": 1008,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1023,6 +1048,7 @@
       "title": "大自然的氣象小幫手",
       "story_id": 1009,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1051,6 +1077,7 @@
       "title": "兵來將擋，水來土掩",
       "story_id": 1028,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1094,6 +1121,7 @@
       "title": "從童工到大學教授之路",
       "story_id": 10,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1137,6 +1165,7 @@
       "title": "「拳」力出擊──陳念琴",
       "story_id": 1038,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1180,6 +1209,7 @@
       "title": "六塊肌、六塊雞",
       "story_id": 1039,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1223,6 +1253,7 @@
       "title": "小丑醫生",
       "story_id": 1040,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1266,6 +1297,7 @@
       "title": "垃圾食物的誘惑與代價",
       "story_id": 1041,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1309,6 +1341,7 @@
       "title": "信件的力量──寫信馬拉松",
       "story_id": 1042,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1352,6 +1385,7 @@
       "title": "臺灣棒球先驅──來自花蓮的能高團",
       "story_id": 1043,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1395,6 +1429,7 @@
       "title": "掃雷英雄馬嘎瓦",
       "story_id": 1044,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1438,6 +1473,7 @@
       "title": "魚來了，叮咚叮咚請開門",
       "story_id": 1045,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1481,6 +1517,7 @@
       "title": "感情小日記3──吃醋的滋味",
       "story_id": 1046,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1524,6 +1561,7 @@
       "title": "以植物為師的科學",
       "story_id": 1029,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1567,6 +1605,7 @@
       "title": "感情小日記4──我被告白了",
       "story_id": 1047,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1610,6 +1649,7 @@
       "title": "抗拒指尖上的誘惑",
       "story_id": 1048,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1653,6 +1693,7 @@
       "title": "我有一個棒球夢",
       "story_id": 12,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1696,6 +1737,7 @@
       "title": "我的電競夢：從熬夜打遊戲到拿下全國冠軍",
       "story_id": 1050,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1739,6 +1781,7 @@
       "title": "牧羊少年的逆轉勝",
       "story_id": 1051,
       "tier": "no_structure",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1767,6 +1810,7 @@
       "title": "數字記憶的奧秘",
       "story_id": 1053,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1810,6 +1854,7 @@
       "title": "重複朗讀的重要性：柳丁和文旦的比喻",
       "story_id": 1054,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1853,6 +1898,7 @@
       "title": "工地大嫂",
       "story_id": 1030,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1896,6 +1942,7 @@
       "title": "災難預言準不準？",
       "story_id": 1031,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1939,6 +1986,7 @@
       "title": "比運氣更重要的事：《長腿叔叔》的啟發",
       "story_id": 1032,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -1982,6 +2030,7 @@
       "title": "堅持到底的棒球人生──周思齊(前篇)",
       "story_id": 1033,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2025,6 +2074,7 @@
       "title": "堅持到底的棒球人生──周思齊(後篇)",
       "story_id": 1034,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2068,6 +2118,7 @@
       "title": "奧運銀牌的自我鍛鍊",
       "story_id": 8,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2111,6 +2162,7 @@
       "title": "周天成的一天──頂尖選手的養成",
       "story_id": 9,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2154,6 +2206,7 @@
       "title": "運動傷害，怎麼辦？",
       "story_id": 1055,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2197,6 +2250,7 @@
       "title": "末日種子庫",
       "story_id": 20,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2240,6 +2294,7 @@
       "title": "古代畫家心中的仙境",
       "story_id": 1065,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2283,6 +2338,7 @@
       "title": "愛冒險逞強的雄性動物",
       "story_id": 1066,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2326,6 +2382,7 @@
       "title": "森林大軍的守護者",
       "story_id": 21,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2369,6 +2426,7 @@
       "title": "植物獵人",
       "story_id": 22,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2412,6 +2470,7 @@
       "title": "小藍鯨之死",
       "story_id": 23,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2455,6 +2514,7 @@
       "title": "奇蹟行動",
       "story_id": 26,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2498,6 +2558,7 @@
       "title": "給神明發會診單",
       "story_id": 25,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2541,6 +2602,7 @@
       "title": "把手上的餅吃香一點！",
       "story_id": 1072,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2584,6 +2646,7 @@
       "title": "紅領帶",
       "story_id": 28,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2627,6 +2690,7 @@
       "title": "與小學說再見",
       "story_id": 1056,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2670,6 +2734,7 @@
       "title": "感情小日記5──我該告白嗎？",
       "story_id": 1074,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2713,6 +2778,7 @@
       "title": "感情小日記6──我失戀了",
       "story_id": 1075,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2756,6 +2822,7 @@
       "title": "小兵立大功：雞鳴狗盜的故事",
       "story_id": 1076,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2799,6 +2866,7 @@
       "title": "老鷹紅豆的故事",
       "story_id": 1077,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2842,6 +2910,7 @@
       "title": "白鯨救援：一場人與自然的協奏曲",
       "story_id": 1078,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2885,6 +2954,7 @@
       "title": "荷蘭東印度公司：全世界第一張股票的誕生",
       "story_id": 1079,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2928,6 +2998,7 @@
       "title": "昆蟲會思考嗎?",
       "story_id": 1057,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -2971,6 +3042,7 @@
       "title": "兩千五百歲的酷老師",
       "story_id": 15,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3014,6 +3086,7 @@
       "title": "卡通人氣王票選政見發表會",
       "story_id": 16,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3042,6 +3115,7 @@
       "title": "心理出狀況，是壞事導致的嗎？",
       "story_id": 17,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3085,6 +3159,7 @@
       "title": "黑猩猩的守護者",
       "story_id": 7,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3128,6 +3203,7 @@
       "title": "動物談情說愛的方式",
       "story_id": 18,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3156,6 +3232,7 @@
       "title": "祝你好眠",
       "story_id": 19,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3199,6 +3276,7 @@
       "title": "長大後，我才讀懂〈夏夜〉",
       "story_id": 1080,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3242,6 +3320,7 @@
       "title": "塑膠，好用不好甩",
       "story_id": 1089,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3270,6 +3349,7 @@
       "title": "AI什麼都會，我們還要學什麼？",
       "story_id": 1090,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3298,6 +3378,7 @@
       "title": "你以為的浪漫可能是跟騷",
       "story_id": 1091,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3341,6 +3422,7 @@
       "title": "綠色賽事",
       "story_id": 34,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3384,6 +3466,7 @@
       "title": "隱藏在日常對話中的微歧視",
       "story_id": 1093,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3427,6 +3510,7 @@
       "title": "看到了嗎？然後呢？",
       "story_id": 1094,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3470,6 +3554,7 @@
       "title": "果醬男孩",
       "story_id": 36,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3513,6 +3598,7 @@
       "title": "用科學方法伸張正義的神探",
       "story_id": 37,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3556,6 +3642,7 @@
       "title": "一封向醫師求助的信",
       "story_id": 1097,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3599,6 +3686,7 @@
       "title": "「背影」讀書會",
       "story_id": 1098,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3642,6 +3730,7 @@
       "title": "澳洲奧運金牌的X機密",
       "story_id": 29,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3685,6 +3774,7 @@
       "title": "網紅的電子煙實驗：偽科學的陷阱",
       "story_id": 39,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3728,6 +3818,7 @@
       "title": "別上「誘餌式標題」的鉤",
       "story_id": 40,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3771,6 +3862,7 @@
       "title": "信眾與教主",
       "story_id": 41,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3814,6 +3906,7 @@
       "title": "最後一隻旅人鴿",
       "story_id": 1103,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3842,6 +3935,7 @@
       "title": "未來的農夫",
       "story_id": 1104,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3885,6 +3979,7 @@
       "title": "當全世界都在笑你，你可以怎麼做？",
       "story_id": 1105,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3913,6 +4008,7 @@
       "title": "小米酒的祝福",
       "story_id": 1106,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3941,6 +4037,7 @@
       "title": "帶著「血拼清單」閱讀",
       "story_id": 1107,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -3969,6 +4066,7 @@
       "title": "看不見的兇手:以實驗破解肉湯腐敗之謎",
       "story_id": 1108,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4012,6 +4110,7 @@
       "title": "從四張圖，看地球暖化的現象",
       "story_id": 1109,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4052,6 +4151,7 @@
       "title": "女性太空人登月",
       "story_id": 30,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4095,6 +4195,7 @@
       "title": "都是八哥，為什麼命運不一樣？",
       "story_id": 1110,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4135,6 +4236,7 @@
       "title": "從〈螞蟻與蟋蟀〉看生命的多樣性",
       "story_id": 1083,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4178,6 +4280,7 @@
       "title": "爺爺奶奶來了以後",
       "story_id": 1084,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4220,31 +4323,15 @@
       "lesson_id": "G7-L6",
       "title": "奧運性別平等這條路",
       "story_id": 31,
-      "tier": "docx_keypoints",
-      "overall_pass": false,
-      "overall_status": "fail",
+      "tier": "parser_gap",
+      "known_data_gap": true,
+      "overall_pass": true,
+      "overall_status": "pass",
       "gates": {
-        "L1": {
-          "gate": "L1",
-          "pass": true,
-          "issues": []
-        },
-        "L2": {
-          "gate": "L2",
-          "pass": true,
-          "issues": []
-        },
-        "L3_catalog": {
-          "gate": "L3_catalog",
-          "pass": true,
-          "issues": []
-        },
         "L3": {
           "gate": "L3",
-          "pass": false,
-          "issues": [
-            "docx has blanks but mode is display_only"
-          ]
+          "pass": true,
+          "issues": []
         }
       },
       "layout": {
@@ -4266,6 +4353,7 @@
       "title": "你看見時代的灰犀牛了嗎？談人口負成長",
       "story_id": 1086,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4309,6 +4397,7 @@
       "title": "科學怪人",
       "story_id": 32,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4352,6 +4441,7 @@
       "title": "吐瓦魯：逐漸被淹沒的島國",
       "story_id": 33,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4395,6 +4485,7 @@
       "title": "致台東：一封過客的情書",
       "story_id": 1111,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4438,6 +4529,7 @@
       "title": "「按讚」背後的真相",
       "story_id": 1120,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4481,6 +4573,7 @@
       "title": "虎襲事件的真相：誰才是受害者？",
       "story_id": 1121,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4524,6 +4617,7 @@
       "title": "語言的足跡：從臺北萬華到南太平洋的航海之路",
       "story_id": 1122,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4567,6 +4661,7 @@
       "title": "構樹：南島祖先「出台灣說」的植物證據",
       "story_id": 1123,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4607,6 +4702,7 @@
       "title": "科學辦案：破解蝴蝶蘭的花期密碼",
       "story_id": 1124,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4647,6 +4743,7 @@
       "title": "球場上的另類指揮家",
       "story_id": 1125,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4690,6 +4787,7 @@
       "title": "我的阿嬤",
       "story_id": 1126,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4733,6 +4831,7 @@
       "title": "我能不能選擇告別方式?",
       "story_id": 1127,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4776,6 +4875,7 @@
       "title": "石虎保育：遷移與否的兩難",
       "story_id": 1128,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4819,6 +4919,7 @@
       "title": "核能的兩難抉擇",
       "story_id": 1129,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4862,6 +4963,7 @@
       "title": "爸爸的恩人們",
       "story_id": 1112,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4905,6 +5007,7 @@
       "title": "當壞事已不可逆轉：集中營裡的一門課",
       "story_id": 1113,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4948,6 +5051,7 @@
       "title": "新奇!「植物肉」你聽過嗎?",
       "story_id": 1114,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -4991,6 +5095,7 @@
       "title": "好心沒好報玻璃娃娃爭議事件",
       "story_id": 1115,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5034,6 +5139,7 @@
       "title": "戲院、賭場、檳榔攤：在時代夾縫中成長的我",
       "story_id": 1116,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5077,6 +5183,7 @@
       "title": "讓你口中的甜蜜成為遠方農民的希望",
       "story_id": 1117,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5120,6 +5227,7 @@
       "title": "隱形的征服者",
       "story_id": 1118,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5163,6 +5271,7 @@
       "title": "讓黑猩猩被看見的人",
       "story_id": 1119,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5206,6 +5315,7 @@
       "title": "盡信書不如無書：從一件殺人案談起",
       "story_id": 48,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5249,6 +5359,7 @@
       "title": "高地訓練有助於運動表現嗎?",
       "story_id": 1139,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5294,6 +5405,7 @@
       "title": "見前人所未見—達爾文與長喙天蛾的故事",
       "story_id": 1140,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5337,6 +5449,7 @@
       "title": "臺灣的太空之眼",
       "story_id": 1141,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5380,6 +5493,7 @@
       "title": "樂觀者勝：向NBA球員學習「詮釋失敗」的智慧",
       "story_id": 1142,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5423,6 +5537,7 @@
       "title": "焚而不毀的倫敦",
       "story_id": 1143,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5466,6 +5581,7 @@
       "title": "未解之謎──石頭的祕密（一）：巨石陣",
       "story_id": 1144,
       "tier": "no_structure",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5494,6 +5610,7 @@
       "title": "馬拉松王者──基普喬吉 (記敘文)",
       "story_id": 1146,
       "tier": "no_structure",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5522,6 +5639,7 @@
       "title": "帝國家書：一個普通家庭的生與死",
       "story_id": 1131,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5565,6 +5683,7 @@
       "title": "國高中數學課當然可以使用計算機！",
       "story_id": 1132,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5608,6 +5727,7 @@
       "title": "預防近視？多點戶外活動就對了！",
       "story_id": 49,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5651,6 +5771,7 @@
       "title": "#MeToo運動與我們的權利",
       "story_id": 50,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5694,6 +5815,7 @@
       "title": "靈異與科學",
       "story_id": 51,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5737,6 +5859,7 @@
       "title": "從基因來的特別禮物",
       "story_id": 52,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5780,6 +5903,7 @@
       "title": "臺灣學生的閱讀力：美麗與哀愁",
       "story_id": 53,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5823,6 +5947,7 @@
       "title": "力與美表現的競技體操",
       "story_id": 54,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5866,6 +5991,7 @@
       "title": "這是假新聞嗎？--以「鞭虎救弟記」為例",
       "story_id": 1149,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5909,6 +6035,7 @@
       "title": "荒野救亡記",
       "story_id": 1158,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5952,6 +6079,7 @@
       "title": "文言文怎麼讀？-以「鞭虎救弟記」為例",
       "story_id": 1150,
       "tier": "ai_fallback",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -5980,6 +6108,7 @@
       "title": "文-L3",
       "story_id": null,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6013,6 +6142,7 @@
       "title": "文-L4",
       "story_id": null,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6046,6 +6176,7 @@
       "title": "重義的荀巨伯",
       "story_id": 1153,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6089,6 +6220,7 @@
       "title": "江乙媽媽告御狀",
       "story_id": 1154,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6132,6 +6264,7 @@
       "title": "相隔千里的約定",
       "story_id": 1155,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6175,6 +6308,7 @@
       "title": "文-L8",
       "story_id": null,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6208,6 +6342,7 @@
       "title": "文-L9",
       "story_id": null,
       "tier": "docx_keypoints",
+      "known_data_gap": false,
       "overall_pass": true,
       "overall_status": "pass",
       "gates": {
@@ -6237,13 +6372,5 @@
       "yaml_path": "/Users/young/project/chinese-literacy-platform/backend/data/lessons/_parsed_2026-05-01/文-L9.yml"
     }
   ],
-  "raw_failures": [
-    {
-      "lesson_id": "G7-L6",
-      "gate": "L3",
-      "issues": [
-        "docx has blanks but mode is display_only"
-      ]
-    }
-  ]
+  "raw_failures": []
 }

--- a/frontend/src/pages/admin/KeypointsQADashboard.tsx
+++ b/frontend/src/pages/admin/KeypointsQADashboard.tsx
@@ -269,6 +269,7 @@ const KeypointsTab: React.FC<{ token: string }> = ({ token }) => {
       {summary && (
         <div className="px-6 py-3 border-b border-gray-100 bg-gray-50 text-sm">
           共 {summary.total} 課 · 通過 {summary.pass} · 失敗 {summary.fail}
+          {(summary.known_gap_count ?? 0) > 0 ? ` · 已知 gap ${summary.known_gap_count}` : ''}
           {manifest?.smoke_only ? ' （smoke）' : ''}
           <div className="flex gap-2 mt-2">
             {(['all', 'pass', 'fail'] as const).map((f) => (
@@ -304,7 +305,12 @@ const KeypointsTab: React.FC<{ token: string }> = ({ token }) => {
                     <td className="px-4 py-3"><OverallDot pass={lesson.overall_pass} /></td>
                     <td className="px-4 py-3 font-mono text-xs">{lesson.lesson_id}</td>
                     <td className="px-4 py-3 max-w-[200px] truncate">{lesson.title}</td>
-                    <td className="px-4 py-3 text-xs">{lesson.tier}</td>
+                    <td className="px-4 py-3 text-xs">
+                      {lesson.tier}
+                      {lesson.known_data_gap ? (
+                        <span className="ml-1 text-amber-600">(known)</span>
+                      ) : null}
+                    </td>
                     <td className="px-4 py-3"><GateBadge gate="L1" result={lesson.gates.L1} /></td>
                     <td className="px-4 py-3"><GateBadge gate="L2" result={lesson.gates.L2} /></td>
                     <td className="px-4 py-3"><GateBadge gate="L3" result={lesson.gates.L3} /></td>

--- a/frontend/src/services/curriculumQaApi.ts
+++ b/frontend/src/services/curriculumQaApi.ts
@@ -15,6 +15,7 @@ export interface KeypointsLessonSummary {
   title: string;
   story_id: number | null;
   tier: string;
+  known_data_gap?: boolean;
   overall_pass: boolean;
   overall_status: string;
   gates: Record<string, GateResult>;
@@ -42,6 +43,7 @@ export interface KeypointsManifest {
     total: number;
     pass: number;
     fail: number;
+    known_gap_count?: number;
     failure_count?: number;
   };
   lessons: KeypointsLessonSummary[];

--- a/scripts/build_keypoints_qa_manifest.py
+++ b/scripts/build_keypoints_qa_manifest.py
@@ -123,11 +123,14 @@ def build_manifest(*, smoke_only: bool, schema_dir: Path) -> dict:
 
         profile = rec.get("profile") or (structure or {}).get("interaction_profile") or {}
 
+        tier = rec.get("tier")
+        known_gap = tier == "parser_gap"
         lessons_out.append({
             "lesson_id": lesson_id,
             "title": (loader or {}).get("title") or lesson_id,
             "story_id": rec.get("story_id") or (loader or {}).get("id"),
-            "tier": rec.get("tier"),
+            "tier": tier,
+            "known_data_gap": known_gap,
             "overall_pass": overall,
             "overall_status": _gate_status(gates),
             "gates": gates,
@@ -148,6 +151,7 @@ def build_manifest(*, smoke_only: bool, schema_dir: Path) -> dict:
 
     lessons_out.sort(key=lambda x: x["lesson_id"])
 
+    known_gap_count = sum(1 for l in lessons_out if l.get("known_data_gap"))
     return {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -157,6 +161,7 @@ def build_manifest(*, smoke_only: bool, schema_dir: Path) -> dict:
             "total": len(lessons_out),
             "pass": pass_count,
             "fail": len(lessons_out) - pass_count,
+            "known_gap_count": known_gap_count,
             "failure_count": qa.get("summary", {}).get("failure_count", 0),
         },
         "lessons": lessons_out,


### PR DESCRIPTION
## Summary
- Restore `PARSER_GAP_LESSONS = {G7-L6}` (aligns with contract test + verification standard)
- Regenerate keypoints manifest: **151 pass / 0 fail / 1 known gap**
- Dashboard shows `known_gap_count` and `(known)` on parser_gap tier

## Test plan
- [ ] staging admin 重點表: 0 失敗, G7-L6 tier=parser_gap (known)
- [ ] `pytest tests/test_story_structure_qa_contract.py` passes

Made with [Cursor](https://cursor.com)