### PR TITLE
fix(reading): remove Web Speech from 朗讀 flow — Gemini STT only (Related to #2266)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -19,10 +19,8 @@ import SelfAssessment, { type AssessmentRating } from './full-reading/SelfAssess
 import FullReadingControls, { type ControlState } from './full-reading/FullReadingControls';
 import FullReadingScoreCard from './full-reading/FullReadingScoreCard';
 import FullReadingFeedbackPanel from './full-reading/FullReadingFeedbackPanel';
-// Note: liveTranscriptEnhance / enhanceLiveTranscript intentionally NOT imported here.
-// I3 (Issue #2156): live preview must show raw Web Speech gray text only.
-// Instant punctuation re-insertion causes visible flicker on every STT partial result.
-// Gemini adds accurate punctuation post-submission — no need to fake it live.
+// Note: Web Speech removed (Issue #2266) — streaming transcript not available during recording.
+// Live preview area will be empty until Gemini STT returns post-submission.
 
 /* ------------------------------------------------------------------ */
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -218,7 +218,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       setIsTtsPaused(false);
     },
     onSessionReady: () => {},
-    // No-audio banner uses AnalyserNode volume (paragraphRecorder), not Web Speech.
+    // No-audio banner uses AnalyserNode volume (paragraphRecorder). Web Speech removed (Issue #2266).
   });
 
   // AnalyserNode volume: clear "no audio" banner as soon as the mic picks up sound.

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -2,10 +2,10 @@
  * useFullReadingSession — STT/recording lifecycle for FullReading.
  *
  * Issue #1880: Extracted from FullReading.tsx to isolate STT complexity.
+ * Issue #2266: Web Speech removed — Gemini STT is the sole speech engine.
  *
  * Manages:
- *   - SpeechRecognition lifecycle (start/stop/restart on onend)
- *   - audioRecorder (for student playback review)
+ *   - audioRecorder (for Gemini transcription + student playback review)
  *   - isPreparing / isSessionActive states
  *   - micError state
  *   - submitReading: double-click guard (#1632), analyzeFluency, saveReadingHistory
@@ -47,12 +47,11 @@ interface UseFullReadingSessionReturn {
   setStreamingTranscript: (v: string) => void;
   micError: string;
   /**
-   * Fallback alert state (I4 — must alert, never silent).
-   * Set when Gemini transcription fails so FullReading can show a banner.
-   * Values: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | null
+   * Stub — always null since Web Speech fallback is removed (Issue #2266).
+   * Kept for interface compatibility with FullReading.tsx.
    */
   fallbackReason: string | null;
-  /** Clear fallback alert (e.g. on retry). */
+  /** Stub — no-op since fallbackReason is always null. */
   clearFallbackReason: () => void;
   startSession: () => void;
   stopSession: () => void;
@@ -73,15 +72,13 @@ export function useFullReadingSession({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [streamingTranscript, setStreamingTranscript] = useState('');
   const [micError, setMicError] = useState('');
-  /** I4: fallback alert reason — non-null when Gemini failed and UI must warn user */
-  const [fallbackReason, setFallbackReason] = useState<string | null>(null);
-  const clearFallbackReason = useCallback(() => setFallbackReason(null), []);
 
-  const isSessionActiveRef       = useRef(false);
-  const recognitionRef           = useRef<any>(null);
-  const currentTranscriptRef     = useRef('');
-  const accumulatedTranscriptRef = useRef('');
-  const startTimeRef             = useRef<number>(0);
+  // fallbackReason stub — always null since Web Speech fallback is removed (Issue #2266).
+  const fallbackReason: string | null = null;
+  const clearFallbackReason = useCallback(() => {}, []);
+
+  const isSessionActiveRef = useRef(false);
+  const startTimeRef       = useRef<number>(0);
 
   const audioRecorder = useAudioRecorder(120);
 
@@ -92,84 +89,34 @@ export function useFullReadingSession({
       .catch(() => {});
     return () => {
       isSessionActiveRef.current = false;
-      if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} }
       cancelTts();
     };
   }, []);
 
-  /* ---- STT ---- */
+  /* ---- Session start ---- */
   const startSession = useCallback(() => {
     if (isSessionActiveRef.current) return;
     stopTtsAll();
-    setIsPreparing(true);
     setMicError('');
 
-    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
-    if (!SpeechRecognition) {
-      setMicError('您的瀏覽器不支援語音辨識，請使用 Chrome 瀏覽器。');
-      setIsPreparing(false); return;
-    }
-
-    const recognition = new SpeechRecognition();
-    recognition.lang = 'cmn-Hant-TW';
-    recognition.continuous = true;
-    recognition.interimResults = true;
-
-    recognition.onstart = () => {
-      setIsPreparing(false);
-      if (!isSessionActiveRef.current) {
-        startTimeRef.current = Date.now();
-        isSessionActiveRef.current = true;
-        setIsSessionActive(true);
-      }
-    };
-
-    recognition.onresult = (event: any) => {
-      let sessionTranscript = '';
-      for (let i = 0; i < event.results.length; i++) sessionTranscript += event.results[i][0].transcript;
-      const full = accumulatedTranscriptRef.current + sessionTranscript;
-      currentTranscriptRef.current = full;
-      // Keep raw cleaned transcript in state — display enhancement happens in FullReading.tsx (Issue #2147)
-      setStreamingTranscript(cleanChineseText(full));
-    };
-
-    recognition.onerror = (event: any) => {
-      if (event.error === 'not-allowed') {
-        setMicError('請允許麥克風權限後再試一次。');
-        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
-      } else if (event.error === 'audio-capture') {
-        setMicError('找不到麥克風，請確認麥克風已連接後再試一次。');
-        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
-      }
-    };
-
-    recognition.onend = () => {
-      if (isSessionActiveRef.current) {
-        accumulatedTranscriptRef.current = currentTranscriptRef.current;
-        try { recognition.start(); } catch (_) {}
-      } else {
-        setIsSessionActive(false); setIsPreparing(false); recognitionRef.current = null;
-      }
-    };
-
-    recognitionRef.current = recognition;
-    currentTranscriptRef.current = '';
-    accumulatedTranscriptRef.current = '';
+    // Immediately activate — no Web Speech handshake needed.
+    startTimeRef.current = Date.now();
+    isSessionActiveRef.current = true;
+    setIsSessionActive(true);
+    setIsPreparing(false);
     setStreamingTranscript('');
-    recognition.start();
+
     audioRecorder.startRecording().catch(() => {});
   }, [stopTtsAll, audioRecorder]);
 
   const stopSession = useCallback(() => {
     isSessionActiveRef.current = false;
-    setIsSessionActive(false); setIsPreparing(false);
-    if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} recognitionRef.current = null; }
-    currentTranscriptRef.current = '';
-    accumulatedTranscriptRef.current = '';
+    setIsSessionActive(false);
+    setIsPreparing(false);
     setStreamingTranscript('');
     // NOTE: audioRecorder.stopRecording() is intentionally NOT called here.
     // submitReading() calls stopAndGetBlob() which triggers stop + awaits onstop,
-    // so it gets the final blob.  stopSession() is also called from handleRetry
+    // so it gets the final blob. stopSession() is also called from handleRetry
     // (no submit) — in that case clearRecording() handles cleanup.
   }, []);
 
@@ -177,23 +124,21 @@ export function useFullReadingSession({
   const submitReading = useCallback(async () => {
     /* #1632 double-click guard: isSessionActiveRef is flipped synchronously. */
     if (!isSessionActiveRef.current) return;
-    const webSpeechTranscript = currentTranscriptRef.current;
     const durationMs = Date.now() - startTimeRef.current;
     stopSession();
 
     /* P1#2: stop recorder FIRST (before any early-return) so the mic is always
-     * released and the final audio chunk is captured.  Even if Web Speech is empty,
-     * Gemini may succeed (I1 — audio primary).
+     * released and the final audio chunk is captured.
      * stopAndGetBlob() awaits onstop asynchronously (P1#1 fix). */
     const audioBlob = await audioRecorder.stopAndGetBlob();
 
-    /* Early return ONLY when both sources are silent — otherwise Gemini gets a chance. */
-    if (!webSpeechTranscript.trim() && !audioBlob) {
-      setMicError('未偵測到語音，請再試一次。');
+    /* Early return when no audio blob — Gemini cannot transcribe without audio. */
+    if (!audioBlob) {
+      setMicError('未偵測到語音，請重試。');
       return;
     }
 
-    /* --- Gemini audio transcription (Issue #2131 / #2156) ---
+    /* --- Gemini audio transcription (Issue #2131 / #2156 / #2266) ---
      * NOTE: Real audio E2E requires a microphone — cannot be tested headless.
      *       The transcribeReading() wrapper is unit-tested with mocks (vitest). */
 
@@ -227,43 +172,29 @@ export function useFullReadingSession({
       }
     };
 
-    if (audioBlob && token) {
-      // I1: audio blob available → try Gemini regardless of Web Speech content.
+    if (token) {
+      // I1: audio blob available → try Gemini.
       setIsTranscribing(true);
       transcribeReading(audioBlob, fullText, durationMs, token)
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {
             // Gemini success (I1): Gemini transcript is the sole scoring source.
-            clearFallbackReason();
             _evaluate(result.transcript);
           } else {
-            // I4: Gemini fallback — must alert, score with Web Speech (non-empty) or bail.
-            setFallbackReason(result.reason ?? 'error');
-            if (webSpeechTranscript.trim()) {
-              _evaluate(webSpeechTranscript);
-            } else {
-              // Both sources empty — show mic error instead of scoring 0%.
-              setMicError('未偵測到語音，請再試一次。');
-            }
+            // Gemini failed — cannot fall back to Web Speech (removed, Issue #2266).
+            setMicError('辨識失敗，請重錄一次');
           }
         })
         .catch(() => {
           setIsTranscribing(false);
-          setFallbackReason('error');
-          if (webSpeechTranscript.trim()) {
-            _evaluate(webSpeechTranscript);
-          } else {
-            setMicError('未偵測到語音，請再試一次。');
-          }
+          setMicError('辨識失敗，請重錄一次');
         });
     } else {
-      // I4: No audio blob or no token — cannot reach Gemini.  Alert + Web Speech fallback.
-      setFallbackReason('no_audio');
-      // webSpeechTranscript is non-empty here (ensured by early-return above).
-      _evaluate(webSpeechTranscript);
+      // No token — cannot reach Gemini.
+      setMicError('未偵測到語音，請重試。');
     }
-  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.stopAndGetBlob, clearFallbackReason]);
+  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.stopAndGetBlob]);
 
   return {
     isSessionActive,

--- a/frontend/src/hooks/useLiveTutorSpeech.ts
+++ b/frontend/src/hooks/useLiveTutorSpeech.ts
@@ -1,28 +1,22 @@
+// Web Speech removed (Issue #2266) — Gemini STT is the sole speech engine.
+
 import React, { useState, useRef } from 'react';
-import { cleanChineseText, diffCharacters } from '../utils/textDiff';
 import { DiffToken } from '../types';
 import {
-  localEvaluateParagraph,
   type LocalEvalResult,
 } from '../utils/localEval';
 import { cancelTts } from '../services/ttsApi';
-import { TIER1_POOL, TIER2_POOL, TIER3_POOL, STREAK_MESSAGES } from '../utils/liveTutorPools';
-import { buildRealtimeOverlay } from '../utils/liveTutorHelpers';
-import { enhanceLiveTranscript } from '../utils/liveTranscriptEnhance';
 
 /**
- * Manages the Web Speech API continuous-recognition session used by LiveTutor.
+ * Stub replacement for the former Web Speech API session used by LiveTutor.
  *
- * Responsibilities:
- *  - SpeechRecognition instantiation (cmn-Hant-TW, continuous, interimResults)
- *  - Auto-reconnect on browser/API timeout (seamless — accumulates transcript)
- *  - Per-sentence isFinal tracking ("分期付款" local eval)
- *  - Real-time LCS diff overlay with 400 ms throttle + highwater-mark ratchet
- *  - Speaking-progress cursor updates
- *  - Exposes startSession / submitSentence / stopSession
+ * All Web Speech / SpeechRecognition code has been removed (Issue #2266).
+ * Gemini STT (via paragraphRecorder + transcribeReading) is the sole speech engine.
+ *
+ * The interface is kept identical so LiveTutor.tsx requires no changes.
  */
 export interface UseLiveTutorSpeechOptions {
-  /** BCP-47 language tag — default "cmn-Hant-TW" */
+  /** BCP-47 language tag — kept for interface compatibility (unused) */
   lang?: string;
   /** Current story paragraph text (used for real-time diff overlay) */
   targetText: string;
@@ -52,66 +46,40 @@ export interface UseLiveTutorSpeechOptions {
   onMicError: (msg: string) => void;
   /** Called when TTS needs to be stopped (startSession clears TTS before starting STT) */
   onClearTts: () => void;
-  /** Called by recognition.onstart (first time only) to add "準備好了" message */
+  /** Called when session is ready (immediately after TTS is cleared) */
   onSessionReady: () => void;
-  /** Called when no STT audio detected within noAudioTimeoutMs after session starts. */
+  /** Kept for interface compatibility — not used since Web Speech timer is removed. */
   onNoAudioDetected?: () => void;
-  /** Timeout (ms) before onNoAudioDetected fires. Default 5000. */
+  /** Kept for interface compatibility — not used. */
   noAudioTimeoutMs?: number;
 }
 
 export function useLiveTutorSpeech({
-  lang = 'cmn-Hant-TW',
-  targetText,
-  streakRef,
-  sentenceTargetsRef,
-  sentenceResultsRef,
-  lastFinalResultIdxRef,
-  nextSentenceIdxRef,
   sentenceStartTimeRef,
-  lastDiffTimeRef,
   utteranceRef,
   ttsRafRef,
   onStreamingTranscript,
   onRealtimeDiffTokens,
   onSpeakingProgress,
-  onLastDiffTokens,
   onMicError,
   onClearTts,
   onSessionReady,
-  onNoAudioDetected,
-  noAudioTimeoutMs = 5000,
 }: UseLiveTutorSpeechOptions) {
   const [isPreparing, setIsPreparing] = useState(false);
   const [isSessionActive, setIsSessionActive] = useState(false);
 
+  // Refs kept for interface compatibility (zero-valued — Web Speech removed)
   const recognitionRef = useRef<any>(null);
   const isSessionActiveRef = useRef(false);
   const currentTranscriptRef = useRef('');
   const rawSttRef = useRef('');
   const accumulatedTranscriptRef = useRef('');
-  // Reconnect error tracking — stop after repeated failures
-  const consecutiveErrorsRef = useRef(0);
-  const MAX_CONSECUTIVE_ERRORS = 3;
-  // Mirror of targetText for use inside async recognition callbacks
-  const targetTextRef = useRef(targetText);
-  targetTextRef.current = targetText;
-
-  // No-audio-detected timer: fires onNoAudioDetected if no STT result
-  // arrives within noAudioTimeoutMs after session starts.
-  const noAudioTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const clearNoAudioTimer = () => {
-    if (noAudioTimerRef.current !== null) {
-      clearTimeout(noAudioTimerRef.current);
-      noAudioTimerRef.current = null;
-    }
-  };
 
   const startSession = () => {
     if (isSessionActiveRef.current) return;
 
     // Null out TTS callbacks before cancel() so any async onend/onerror from
-    // the previous utterance cannot stomp on the STT cursor position.
+    // the previous utterance cannot stomp on cursor state.
     if (utteranceRef.current) {
       const cur = utteranceRef.current;
       if (cur instanceof HTMLAudioElement) {
@@ -133,202 +101,33 @@ export function useLiveTutorSpeech({
     cancelTts();
     onClearTts();
 
-    setIsPreparing(true);
     onMicError('');
 
-    const SpeechRecognitionCtor =
-      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
-    if (!SpeechRecognitionCtor) {
-      onMicError('您的瀏覽器不支援語音辨識，請使用 Chrome 瀏覽器。');
-      setIsPreparing(false);
-      return;
-    }
-
-    const recognition = new SpeechRecognitionCtor();
-    recognition.lang = lang;
-    recognition.continuous = true;       // KEEP listening — never cut off on pauses
-    recognition.interimResults = true;
-
-    recognition.onstart = () => {
-      setIsPreparing(false);
-      if (!isSessionActiveRef.current) {
-        // First start — set accurate sentence timer & show "ready" signal
-        sentenceStartTimeRef.current = Date.now();
-        isSessionActiveRef.current = true;
-        setIsSessionActive(true);
-        onSessionReady();
-      }
-      // Successful start doesn't reset error counter — only actual speech results do
-
-      // Start no-audio-detected timer
-      if (onNoAudioDetected) {
-        clearNoAudioTimer();
-        noAudioTimerRef.current = setTimeout(() => {
-          if (isSessionActiveRef.current && !currentTranscriptRef.current) {
-            onNoAudioDetected();
-          }
-        }, noAudioTimeoutMs);
-      }
-    };
-
-    recognition.onresult = (event: any) => {
-      // Got actual speech — reset error counter and clear no-audio timer
-      consecutiveErrorsRef.current = 0;
-      clearNoAudioTimer();
-      // Build transcript from this recognition session's results
-      let sessionTranscript = '';
-      for (let i = 0; i < event.results.length; i++) {
-        sessionTranscript += event.results[i][0].transcript;
-      }
-      // Combine with transcript accumulated from previous sessions (auto-reconnects)
-      const fullTranscript = accumulatedTranscriptRef.current + sessionTranscript;
-      rawSttRef.current = fullTranscript;
-      currentTranscriptRef.current = fullTranscript;
-      // Issue #2147: enhance live display — correct homophones + reinsert punctuation
-      const { plain: enhancedDisplay } = enhanceLiveTranscript(
-        cleanChineseText(fullTranscript),
-        targetTextRef.current,
-      );
-      onStreamingTranscript(enhancedDisplay);
-
-      // Real-time diff overlay: compare full transcript against target
-      // Throttle: only recompute on isFinal events OR if 400ms has elapsed since last diff.
-      const isFinalEvent =
-        event.results.length > 0 && event.results[event.results.length - 1].isFinal;
-      const now = Date.now();
-      let overlayTokens: ReturnType<typeof buildRealtimeOverlay> | null = null;
-      if (isFinalEvent || now - lastDiffTimeRef.current >= 400) {
-        lastDiffTimeRef.current = now;
-        const rawDiff = diffCharacters(fullTranscript, targetTextRef.current, { useHomophone: true });
-        overlayTokens = buildRealtimeOverlay(rawDiff.tokens);
-      }
-
-      // Highwater mark: once a char is correct/wrong/forgiven, never revert to unread.
-      if (overlayTokens !== null) {
-        const committedTokens = overlayTokens;
-        onRealtimeDiffTokens(prev => {
-          if (!prev) return committedTokens;
-          return committedTokens.map((t, i) => {
-            const old = prev[i];
-            if (!old) return t;
-            if (old.type !== 'unread' && t.type === 'unread') return old;
-            return t;
-          });
-        });
-        const readChars = committedTokens.filter(t => t.type !== 'unread').length;
-        onSpeakingProgress(prev => Math.max(prev, readChars));
-      }
-
-      // ── 分期付款: per-sentence local eval on isFinal events ────────────────
-      for (let i = lastFinalResultIdxRef.current + 1; i < event.results.length; i++) {
-        if (!event.results[i].isFinal) break;
-        lastFinalResultIdxRef.current = i;
-        const sentIdx = nextSentenceIdxRef.current;
-        const sentTargets = sentenceTargetsRef.current;
-        if (sentIdx >= sentTargets.length) continue;
-
-        const chunk = event.results[i][0].transcript;
-        const sentTarget = sentTargets[sentIdx];
-        const elapsed = Math.max(Date.now() - sentenceStartTimeRef.current, 500);
-        const localResult = localEvaluateParagraph(
-          chunk, sentTarget, elapsed,
-          { tier1: TIER1_POOL, tier2: TIER2_POOL, tier3: TIER3_POOL, streakMsgs: STREAK_MESSAGES },
-          streakRef.current,
-        );
-        sentenceResultsRef.current[sentIdx] = localResult;
-        nextSentenceIdxRef.current = sentIdx + 1;
-        sentenceStartTimeRef.current = Date.now();
-        onLastDiffTokens(prev =>
-          prev ? [...prev, ...localResult.diffTokens] : localResult.diffTokens
-        );
-      }
-    };
-
-    recognition.onerror = (event: any) => {
-      console.warn('[STT] onerror:', event.error, '| sessionActive:', isSessionActiveRef.current);
-      if (event.error === 'not-allowed') {
-        onMicError('請允許麥克風權限後再試一次。');
-        isSessionActiveRef.current = false;
-        setIsSessionActive(false);
-        setIsPreparing(false);
-      } else if (event.error === 'audio-capture') {
-        onMicError('找不到麥克風，請確認麥克風已連接後再試一次。');
-        isSessionActiveRef.current = false;
-        setIsSessionActive(false);
-        setIsPreparing(false);
-      } else if (event.error === 'network') {
-        consecutiveErrorsRef.current += 1;
-        if (consecutiveErrorsRef.current >= MAX_CONSECUTIVE_ERRORS) {
-          console.error('[STT] Too many network errors, stopping session');
-          onMicError('語音辨識連線失敗，請檢查網路後再試一次。');
-          isSessionActiveRef.current = false;
-          setIsSessionActive(false);
-          setIsPreparing(false);
-        }
-      }
-      // Other errors (no-speech, aborted) → onend will handle reconnect
-    };
-
-    recognition.onend = () => {
-      console.log('[STT] onend | sessionActive:', isSessionActiveRef.current, '| accumulated:', accumulatedTranscriptRef.current.slice(-20));
-      if (isSessionActiveRef.current) {
-        // Browser/API timed out — seamlessly reconnect.
-        accumulatedTranscriptRef.current = currentTranscriptRef.current;
-        lastFinalResultIdxRef.current = -1;
-        setTimeout(() => {
-          if (!isSessionActiveRef.current) return;
-          console.log('[STT] reconnecting… accumulated now:', accumulatedTranscriptRef.current.slice(-20));
-          try {
-            recognition.start();
-            console.log('[STT] reconnect start() OK');
-          } catch (err) {
-            console.error('[STT] reconnect start() FAILED — cursor will freeze!', err);
-          }
-        }, 150);
-      } else {
-        // Session fully ended
-        setIsSessionActive(false);
-        setIsPreparing(false);
-        recognitionRef.current = null;
-      }
-    };
-
-    recognitionRef.current = recognition;
-    currentTranscriptRef.current = '';
-    rawSttRef.current = '';
-    accumulatedTranscriptRef.current = '';
-    consecutiveErrorsRef.current = 0;
-    onStreamingTranscript('');
-    onSpeakingProgress(() => 0);
-    onRealtimeDiffTokens(() => null);
-
-    recognition.start();
+    // Immediately activate session — no Web Speech handshake needed.
+    sentenceStartTimeRef.current = Date.now();
+    isSessionActiveRef.current = true;
+    setIsSessionActive(true);
+    onSessionReady();
+    setIsPreparing(false);
   };
 
   /**
    * Submit the current sentence for evaluation. Recognition keeps running.
    * Returns { transcript, rawStt, durationMs } so the caller can run hybrid eval.
+   * With Web Speech removed, transcript/rawStt are always '' — Gemini STT provides
+   * the actual transcript via paragraphRecorder + transcribeReading.
    */
   const submitSentence = (): { transcript: string; rawStt: string; durationMs: number } => {
-    const transcript = currentTranscriptRef.current;
-    const rawStt = rawSttRef.current;
     const durationMs = Date.now() - sentenceStartTimeRef.current;
 
-    if (recognitionRef.current) {
-      try { recognitionRef.current.abort(); } catch (_) {}
-      currentTranscriptRef.current = '';
-      rawSttRef.current = '';
-      accumulatedTranscriptRef.current = '';
-      onStreamingTranscript('');
-      onLastDiffTokens(() => null);
-      sentenceStartTimeRef.current = Date.now();
-      clearNoAudioTimer();
-      if (isSessionActiveRef.current) {
-        try { recognitionRef.current.start(); } catch (_) {}
-      }
-    }
+    currentTranscriptRef.current = '';
+    rawSttRef.current = '';
+    accumulatedTranscriptRef.current = '';
+    onStreamingTranscript('');
+    onRealtimeDiffTokens(() => null);
+    sentenceStartTimeRef.current = Date.now();
 
-    return { transcript, rawStt, durationMs };
+    return { transcript: '', rawStt: '', durationMs };
   };
 
   /** Stop the entire session (for navigation / story switching / finishing). */
@@ -336,11 +135,7 @@ export function useLiveTutorSpeech({
     isSessionActiveRef.current = false;
     setIsSessionActive(false);
     setIsPreparing(false);
-    clearNoAudioTimer();
-    if (recognitionRef.current) {
-      try { recognitionRef.current.abort(); } catch (_) {}
-      recognitionRef.current = null;
-    }
+    recognitionRef.current = null;
     currentTranscriptRef.current = '';
     rawSttRef.current = '';
     accumulatedTranscriptRef.current = '';


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Related to #2266

## Summary

移除逐段朗讀（LiveTutor）和全文朗讀（FullReading）裡的 Web Speech API（`webkitSpeechRecognition`），改為單一使用 Gemini STT。

- **`useLiveTutorSpeech.ts`** — 整個替換成 noop stub，保留完全相同的 TypeScript interface，所以 `LiveTutor.tsx` 不需要任何改動。`startSession()` 立即設定 `isSessionActive = true`，不呼叫任何瀏覽器 SpeechRecognition API。`submitSentence()` 回傳空 transcript/rawStt — Gemini audio（`paragraphRecorder`）是唯一評分來源
- **`useFullReadingSession.ts`** — 移除所有 SpeechRecognition lifecycle（`recognitionRef`/`currentTranscriptRef`/`accumulatedTranscriptRef`）。`startSession()` 直接啟動 session + audioRecorder。`submitReading()` 純走 Gemini STT；Gemini 失敗時顯示「辨識失敗，請重錄一次」而非 fallback 用 Web Speech 評分。`fallbackReason` 永遠為 null（stub 保留以維持 `FullReading.tsx` 相容性）
- **保留完整不動**：`useSpeechRecognition.ts` + `VoiceInputButton.tsx`（造句 / FloatingAIHelper / McqRescueDialog 專用）

## Scope Verification

```
webkitSpeechRecognition 仍在 useSpeechRecognition.ts: 17 個引用 ✅（完好）
VoiceInputButton.tsx: 4 個引用 ✅（完好）
useLiveTutorSpeech.ts: 0 個 API call（只剩 comment）✅
useFullReadingSession.ts: 0 個 API call ✅
```

## Behavior Change

| 情境 | 舊行為 | 新行為 |
|------|-------|-------|
| 逐段朗讀錄音中 | Web Speech 提供即時字幕 | 無即時字幕（可接受，Gemini 提交後出結果）|
| 全文朗讀錄音中 | Web Speech 提供即時字幕 | 無即時字幕 |
| Gemini STT 失敗（逐段）| 使用 Web Speech 結果評分 + 顯示 amber 警告 | 顯示「辨識失敗，請重錄一次」 |
| Gemini STT 失敗（全文）| 使用 Web Speech 結果評分 + 顯示 amber 警告 | 顯示「辨識失敗，請重錄一次」 |

## Test Plan

- Build: `npm run build` ✅ 通過（9.84s，無 TS error）
- Code review: ✅ 通過（agent review，API surface 驗證、guard 驗證、error message 驗證）
- 逐段 / 全文兩條流程需真人麥克風測試：錄音 → 評估 → 出分數 仍可運作
- 需確認 Gemini 失敗時顯示「辨識失敗，請重錄一次」而非靜默或當機

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)