### PR TITLE
feat(reading): async GCS audio upload on transcribe (Related to #2266)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import time
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -24,6 +24,7 @@ from ...services.reading_transcription_service import (
     ALLOWED_AUDIO_MIMES,
     transcribe_reading_audio,
 )
+from ...services.audio_upload_service import upload_reading_audio_to_gcs
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -519,6 +520,7 @@ class TranscribeReadingResponse(BaseModel):
     ),
 )
 async def transcribe_reading_endpoint(
+    background_tasks: BackgroundTasks,
     audio: UploadFile = File(
         ...,
         description="Audio blob from browser MediaRecorder (WebM/MP4/OGG/WAV, max 10 MB)",
@@ -596,6 +598,22 @@ async def transcribe_reading_endpoint(
         duration_ms=duration_ms,
     )
     latency_ms = int((time.monotonic() - start_time) * 1000)
+
+    # ── 4.5. Background: async upload audio to GCS for debug / replay ────────
+    # Fire-and-forget — FastAPI sends the HTTP response first, then runs this task.
+    # Upload failures are logged as WARNING only; never affect the student score.
+    # Security: bucket is private, no public ACL, blob path is NOT returned to client.
+    # Bucket: controlled by READING_AUDIO_GCS_BUCKET env var.  If not set, skipped.
+    # TODO (Issue #2266): Set GCS lifecycle/retention policy once product decides
+    #   how long audio should be kept (e.g. 30 days debug / 90 days training set).
+    background_tasks.add_task(
+        upload_reading_audio_to_gcs,
+        audio_bytes=audio_bytes,
+        mime_type=raw_mime,
+        user_id=current_user.id,
+        lesson_id=None,  # transcribe endpoint is stateless — no lesson context
+        duration_ms=duration_ms,
+    )
 
     # ── 5. Log usage when Gemini succeeded ───────────────────────────────────
     if result.get("method") == "gemini":

--- a/backend/app/services/audio_upload_service.py
+++ b/backend/app/services/audio_upload_service.py
@@ -1,0 +1,174 @@
+"""Async GCS upload service for reading audio files (Issue #2266).
+
+Responsibilities:
+- Fire-and-forget: upload audio bytes to GCS in background
+- NEVER block the transcription response
+- NEVER set public ACL on blobs
+- NEVER log audio content or user PII beyond user_id + duration_ms
+- Fail silently: any upload error only logs WARNING
+
+Bucket:
+    Controlled by env var READING_AUDIO_GCS_BUCKET.
+    If the var is NOT set, uploads are skipped with a one-time WARNING — the
+    service intentionally refuses to silently fall back to the TTS cache bucket
+    (lingoleap-tts-cache) because mixing audio PII into the TTS bucket violates
+    the principle of least privilege.
+
+    TODO (Issue #2266): Once the product team decides the retention policy
+    (e.g. 30 days for debug replay, 90 days for model training set), set a GCS
+    lifecycle rule on the bucket path reading-audio/** to auto-delete blobs.
+    Until then, blobs persist until manually deleted.
+
+Privacy / security:
+    - Bucket must be PRIVATE (no make_public / predefined_acl calls here).
+    - Blob path is NOT returned to the client or written to the DB.
+    - Path structure: reading-audio/{lesson_id or unknown}/{user_id}/{ts}{ext}
+    - This service does NOT store user names, email, or any PII beyond user_id.
+    - The Cloud Run service account must have roles/storage.objectCreator on the
+      bucket; no broader permissions are required or granted here.
+
+Concurrency:
+    Cloud Run instances default to concurrency=80.  The GCS Client() constructor
+    is NOT thread-safe during initialisation.  A threading.Lock guards the lazy
+    init so concurrent cold-start requests do not race.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# ── Bucket resolution ─────────────────────────────────────────────────────────
+# We only read the env var once at module import time so it is easy to patch
+# in tests via monkeypatch or by setting os.environ before import.
+READING_AUDIO_GCS_BUCKET: str | None = os.environ.get("READING_AUDIO_GCS_BUCKET")
+
+# ── Lazy GCS client with thread-safe init ────────────────────────────────────
+_SENTINEL_UNAVAILABLE = object()
+_gcs_bucket_client: object = None  # None = not yet tried
+_gcs_init_lock = threading.Lock()
+
+
+def _get_gcs_bucket():
+    """Lazy-init GCS bucket client.  Returns None if GCS is unavailable.
+
+    Thread-safe: uses a module-level lock to prevent race on cold start.
+    NEVER raises — always returns a bucket object or None.
+    """
+    global _gcs_bucket_client
+
+    # Fast path: already initialised (success or failure)
+    if _gcs_bucket_client is not None:
+        return None if _gcs_bucket_client is _SENTINEL_UNAVAILABLE else _gcs_bucket_client
+
+    with _gcs_init_lock:
+        # Re-check inside the lock (another thread may have initialised already)
+        if _gcs_bucket_client is not None:
+            return None if _gcs_bucket_client is _SENTINEL_UNAVAILABLE else _gcs_bucket_client
+
+        # Guard #1: no bucket name → skip with warning (never fall back to TTS bucket)
+        if not READING_AUDIO_GCS_BUCKET:
+            logger.warning(
+                "READING_AUDIO_GCS_BUCKET env var not set — "
+                "reading audio uploads are disabled.  "
+                "Set the var to enable GCS debug audio storage."
+            )
+            _gcs_bucket_client = _SENTINEL_UNAVAILABLE
+            return None
+
+        # Guard #2: google-cloud-storage may not be installed in test envs
+        try:
+            from google.cloud import storage  # noqa: PLC0415
+
+            client = storage.Client()
+            _gcs_bucket_client = client.bucket(READING_AUDIO_GCS_BUCKET)
+            logger.info(
+                "GCS reading-audio bucket initialised: %s", READING_AUDIO_GCS_BUCKET
+            )
+        except Exception as exc:
+            logger.warning(
+                "GCS reading-audio bucket unavailable — uploads disabled: %s", exc
+            )
+            _gcs_bucket_client = _SENTINEL_UNAVAILABLE
+            return None
+
+    return _gcs_bucket_client
+
+
+# Map normalised MIME types to file extensions for the GCS blob path.
+_MIME_TO_EXT: dict[str, str] = {
+    "audio/webm": ".webm",
+    "audio/mp4": ".mp4",
+    "audio/mpeg": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+}
+
+
+def _normalise_mime(mime_type: str) -> str:
+    """Strip codec suffix: 'audio/webm;codecs=opus' → 'audio/webm'."""
+    return mime_type.split(";")[0].strip()
+
+
+def upload_reading_audio_to_gcs(
+    audio_bytes: bytes,
+    mime_type: str,
+    user_id: int,
+    lesson_id: str | None,
+    duration_ms: int | None,
+) -> None:
+    """Synchronous GCS upload (run via FastAPI BackgroundTasks).
+
+    Designed to be called from ``background_tasks.add_task(...)`` so it runs
+    *after* the HTTP response has been sent.  Never blocks the student score.
+
+    Safety guarantees:
+    - NEVER sets public ACL (make_public / predefined_acl are forbidden).
+    - NEVER logs audio bytes or user PII beyond user_id + duration_ms.
+    - Any exception is caught, logged as WARNING, and swallowed.
+    - Bucket is determined by READING_AUDIO_GCS_BUCKET env var only — will NOT
+      silently fall back to lingoleap-tts-cache or any other bucket.
+
+    GCS path: ``reading-audio/{lesson_id or 'unknown'}/{user_id}/{timestamp}{ext}``
+
+    TODO (Issue #2266): Retention policy — once product decides duration
+    (e.g. 30 days debug / 90 days training set), add a GCS lifecycle rule on
+    the bucket or path prefix so blobs auto-expire.
+    """
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        return  # Already logged a warning at init time; skip silently.
+
+    try:
+        base_mime = _normalise_mime(mime_type)
+        ext = _MIME_TO_EXT.get(base_mime, ".audio")
+
+        timestamp_iso = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        safe_lesson_id = (lesson_id or "unknown").replace("/", "-").replace("..", "")
+        blob_path = f"reading-audio/{safe_lesson_id}/{user_id}/{timestamp_iso}{ext}"
+
+        blob = bucket.blob(blob_path)
+        # Content-type is informational only — NO ACL is set; bucket stays private.
+        blob.upload_from_string(audio_bytes, content_type=base_mime)
+
+        logger.info(
+            "reading-audio GCS upload OK: user_id=%d bytes=%d duration_ms=%s path=%s",
+            user_id,
+            len(audio_bytes),
+            duration_ms,
+            blob_path,
+        )
+    except Exception as exc:
+        # Fail silently — never let upload failure affect the student experience.
+        logger.warning(
+            "reading-audio GCS upload failed (non-fatal): user_id=%d bytes=%d "
+            "duration_ms=%s error=%s",
+            user_id,
+            len(audio_bytes),
+            duration_ms,
+            exc,
+        )

--- a/backend/tests/test_reading_audio_upload.py
+++ b/backend/tests/test_reading_audio_upload.py
@@ -1,0 +1,503 @@
+"""Tests for async GCS audio upload on /reading/transcribe (Issue #2266).
+
+This file tests:
+1. audio_upload_service.py — unit tests for the service functions
+2. Route integration — proves TestClient does NOT call real GCS
+
+KEY RULE (Pit #1 guard):
+    BackgroundTasks in TestClient / Starlette execute synchronously in the
+    test thread.  If upload_reading_audio_to_gcs is NOT patched, it will
+    attempt to initialise a real GCS Storage client.  Tests MUST patch the
+    function at the *route module* import site:
+
+        "app.routes.learning.learning_reading.upload_reading_audio_to_gcs"
+
+    NOT at the service module (that would be too late — the route already
+    has a reference to the original).
+
+Proof of safety (no real GCS calls):
+    - Tests that send requests to the route patch the upload function and
+      assert it was called with the correct args but never actually ran.
+    - The service unit tests clear the module-level client sentinel before
+      each test to start fresh, and mock google.cloud.storage entirely.
+
+Run:
+    cd backend
+    python -m pytest tests/test_reading_audio_upload.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import threading
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _reset_gcs_sentinel():
+    """Clear the module-level GCS client between tests so each starts fresh."""
+    import app.services.audio_upload_service as svc
+    svc._gcs_bucket_client = None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Service unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAudioUploadServiceNoBucket:
+    """READING_AUDIO_GCS_BUCKET not set → uploads disabled, no GCS calls."""
+
+    def setup_method(self):
+        _reset_gcs_sentinel()
+
+    def test_upload_skipped_when_bucket_env_not_set(self, caplog):
+        """When READING_AUDIO_GCS_BUCKET is unset, upload silently skips."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = None  # simulate env var absent
+            _reset_gcs_sentinel()
+
+            with patch("google.cloud.storage.Client") as mock_gcs:
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"fake",
+                    mime_type="audio/webm",
+                    user_id=1,
+                    lesson_id=None,
+                    duration_ms=3000,
+                )
+                # GCS Client must NOT be instantiated
+                mock_gcs.assert_not_called()
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+    def test_no_bucket_env_logs_warning(self, caplog):
+        """Missing READING_AUDIO_GCS_BUCKET produces exactly one WARNING."""
+        import logging
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = None
+            _reset_gcs_sentinel()
+
+            with caplog.at_level(logging.WARNING, logger="app.services.audio_upload_service"):
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"fake",
+                    mime_type="audio/webm",
+                    user_id=1,
+                    lesson_id=None,
+                    duration_ms=None,
+                )
+
+            # Should emit exactly 1 warning about missing env var
+            warn_msgs = [r for r in caplog.records if r.levelname == "WARNING"]
+            assert len(warn_msgs) == 1
+            assert "READING_AUDIO_GCS_BUCKET" in warn_msgs[0].message
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+
+class TestAudioUploadServiceWithBucket:
+    """READING_AUDIO_GCS_BUCKET is set → uploads proceed (real GCS mocked)."""
+
+    def setup_method(self):
+        _reset_gcs_sentinel()
+
+    def test_upload_calls_gcs_blob_upload(self):
+        """Happy path: bytes are uploaded with correct content-type."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            mock_blob = MagicMock()
+            mock_bucket = MagicMock()
+            mock_bucket.blob.return_value = mock_blob
+
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                mock_gcs_cls.return_value.bucket.return_value = mock_bucket
+
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"real_audio",
+                    mime_type="audio/webm",
+                    user_id=99,
+                    lesson_id="L7",
+                    duration_ms=5000,
+                )
+
+            mock_blob.upload_from_string.assert_called_once_with(
+                b"real_audio", content_type="audio/webm"
+            )
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+    def test_upload_blob_path_format(self):
+        """GCS blob path follows reading-audio/{lesson_id}/{user_id}/{ts}{ext}."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            mock_bucket = MagicMock()
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                mock_gcs_cls.return_value.bucket.return_value = mock_bucket
+
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"x",
+                    mime_type="audio/ogg",
+                    user_id=42,
+                    lesson_id="G6-L11",
+                    duration_ms=None,
+                )
+
+            # Verify blob path structure
+            blob_path_arg = mock_bucket.blob.call_args[0][0]
+            assert blob_path_arg.startswith("reading-audio/G6-L11/42/")
+            assert blob_path_arg.endswith(".ogg")
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+    def test_unknown_lesson_id_when_none(self):
+        """lesson_id=None → path uses 'unknown' as segment."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            mock_bucket = MagicMock()
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                mock_gcs_cls.return_value.bucket.return_value = mock_bucket
+
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"x",
+                    mime_type="audio/wav",
+                    user_id=7,
+                    lesson_id=None,
+                    duration_ms=1000,
+                )
+
+            blob_path_arg = mock_bucket.blob.call_args[0][0]
+            assert "/unknown/" in blob_path_arg
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+    def test_gcs_exception_swallowed_fail_silently(self):
+        """Any GCS exception during upload is caught — never raises to caller."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            mock_blob = MagicMock()
+            mock_blob.upload_from_string.side_effect = Exception("GCS 503")
+            mock_bucket = MagicMock()
+            mock_bucket.blob.return_value = mock_blob
+
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                mock_gcs_cls.return_value.bucket.return_value = mock_bucket
+
+                # Must NOT raise
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"x",
+                    mime_type="audio/webm",
+                    user_id=1,
+                    lesson_id=None,
+                    duration_ms=None,
+                )
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+    def test_no_public_acl_set(self):
+        """make_public / predefined_acl are NEVER called (privacy guard)."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            mock_blob = MagicMock()
+            mock_bucket = MagicMock()
+            mock_bucket.blob.return_value = mock_blob
+
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                mock_gcs_cls.return_value.bucket.return_value = mock_bucket
+
+                svc.upload_reading_audio_to_gcs(
+                    audio_bytes=b"x",
+                    mime_type="audio/webm",
+                    user_id=1,
+                    lesson_id=None,
+                    duration_ms=None,
+                )
+
+            mock_blob.make_public.assert_not_called()
+            # Also verify predefined_acl was not passed to upload_from_string
+            call_kwargs = mock_blob.upload_from_string.call_args[1]
+            assert "predefined_acl" not in call_kwargs
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+
+class TestGcsClientLock:
+    """Thread-safety: concurrent init does not race."""
+
+    def setup_method(self):
+        _reset_gcs_sentinel()
+
+    def test_concurrent_init_single_client(self):
+        """Multiple threads calling _get_gcs_bucket() result in one Client()."""
+        import app.services.audio_upload_service as svc
+
+        original_bucket = svc.READING_AUDIO_GCS_BUCKET
+        try:
+            svc.READING_AUDIO_GCS_BUCKET = "test-bucket"
+            _reset_gcs_sentinel()
+
+            call_count = []
+            mock_bucket = MagicMock()
+
+            def _fake_client_init(self):
+                call_count.append(1)
+                return None  # __init__ returns None
+
+            with patch("google.cloud.storage.Client") as mock_gcs_cls:
+                instance = MagicMock()
+                instance.bucket.return_value = mock_bucket
+                mock_gcs_cls.return_value = instance
+
+                threads = [
+                    threading.Thread(target=svc._get_gcs_bucket)
+                    for _ in range(10)
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+
+                # Client() instantiated exactly once despite 10 threads
+                assert mock_gcs_cls.call_count == 1
+        finally:
+            svc.READING_AUDIO_GCS_BUCKET = original_bucket
+
+
+class TestNormaliseMime:
+    """Utility function correctness."""
+
+    def test_strips_codec(self):
+        from app.services.audio_upload_service import _normalise_mime
+        assert _normalise_mime("audio/webm;codecs=opus") == "audio/webm"
+        assert _normalise_mime("audio/webm; codecs=opus") == "audio/webm"
+
+    def test_passthrough_clean_mime(self):
+        from app.services.audio_upload_service import _normalise_mime
+        assert _normalise_mime("audio/ogg") == "audio/ogg"
+        assert _normalise_mime("audio/wav") == "audio/wav"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Route integration tests — proves no real GCS calls happen
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _build_app():
+    """Minimal FastAPI app with transcribe route, auth/rate-limit mocked."""
+    from fastapi import FastAPI
+    from app.routes.learning.learning_reading import router
+    from app.auth.dependencies import get_current_user
+    from app.auth.rate_limiter import ai_limit_10_per_min
+
+    app = FastAPI()
+
+    def _mock_user():
+        user = MagicMock()
+        user.id = 42
+        return user
+
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[ai_limit_10_per_min] = lambda: None
+    app.include_router(router, prefix="/api")
+    return app
+
+
+class TestTranscribeRouteGcsPatch:
+    """Route-level: BackgroundTasks executes synchronously in TestClient.
+
+    CRITICAL: upload_reading_audio_to_gcs must be patched at the ROUTE MODULE
+    import site, not the service module.  The route did:
+
+        from ...services.audio_upload_service import upload_reading_audio_to_gcs
+
+    so the reference lives at:
+
+        app.routes.learning.learning_reading.upload_reading_audio_to_gcs
+
+    Patching at the service module path would NOT intercept calls from the route.
+    """
+
+    def test_happy_path_upload_called_with_correct_args(self):
+        """Route happy path: upload background task is scheduled, NOT real GCS."""
+        from fastapi.testclient import TestClient
+        from unittest.mock import AsyncMock
+
+        app = _build_app()
+        client = TestClient(app)
+
+        mock_transcribe_result = {
+            "transcript": "孟嘗君養了很多門客。",
+            "method": "gemini",
+            "reasoning": "正確。",
+        }
+
+        with (
+            patch(
+                "app.routes.learning.learning_reading.transcribe_reading_audio",
+                new=AsyncMock(return_value=mock_transcribe_result),
+            ),
+            # Pit #1 fix: patch at ROUTE module, not service module
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+            ) as mock_upload,
+        ):
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"fake_audio", "audio/webm")},
+                data={"target_text": "孟嘗君養了很多門客。", "duration_ms": "5000"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["transcript"] == "孟嘗君養了很多門客。"
+
+        # Background task was scheduled and executed by TestClient (synchronous)
+        mock_upload.assert_called_once()
+        call_kwargs = mock_upload.call_args.kwargs
+        assert call_kwargs["audio_bytes"] == b"fake_audio"
+        assert call_kwargs["user_id"] == 42
+        assert call_kwargs["mime_type"] == "audio/webm"
+
+    def test_upload_not_called_when_mime_rejected(self):
+        """MIME gate returns 415 before background task is queued."""
+        from fastapi.testclient import TestClient
+
+        app = _build_app()
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+        ) as mock_upload:
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.mp3", b"fake", "audio/mpeg_bad_type")},
+                data={"target_text": "測試"},
+            )
+
+        assert resp.status_code == 415
+        mock_upload.assert_not_called()
+
+    def test_upload_not_called_when_audio_empty(self):
+        """400 on empty audio → background task is never queued."""
+        from fastapi.testclient import TestClient
+
+        app = _build_app()
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+        ) as mock_upload:
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"", "audio/webm")},
+                data={"target_text": "測試"},
+            )
+
+        assert resp.status_code == 400
+        mock_upload.assert_not_called()
+
+    def test_fallback_result_still_schedules_upload(self):
+        """Even when Gemini falls back, the audio is uploaded (for debug)."""
+        from fastapi.testclient import TestClient
+        from unittest.mock import AsyncMock
+
+        app = _build_app()
+        client = TestClient(app)
+
+        fallback_result = {"transcript": None, "method": "fallback", "reason": "timeout"}
+
+        with (
+            patch(
+                "app.routes.learning.learning_reading.transcribe_reading_audio",
+                new=AsyncMock(return_value=fallback_result),
+            ),
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+            ) as mock_upload,
+        ):
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"fake_audio", "audio/webm")},
+                data={"target_text": "測試文字"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["method"] == "fallback"
+
+        # Upload is still called even on Gemini fallback — debug value remains
+        mock_upload.assert_called_once()
+
+    def test_no_real_gcs_client_instantiated_during_route_test(self):
+        """Prove TestClient never reaches google.cloud.storage.Client."""
+        from fastapi.testclient import TestClient
+        from unittest.mock import AsyncMock
+
+        app = _build_app()
+        client = TestClient(app)
+
+        mock_result = {
+            "transcript": "春風吹過田野。",
+            "method": "gemini",
+            "reasoning": "OK",
+        }
+
+        with (
+            patch(
+                "app.routes.learning.learning_reading.transcribe_reading_audio",
+                new=AsyncMock(return_value=mock_result),
+            ),
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+            ) as mock_upload,
+            # Extra guard: if google.cloud.storage.Client is called it fails the test
+            patch(
+                "google.cloud.storage.Client",
+                side_effect=AssertionError("Real GCS Client was instantiated in test!"),
+            ),
+        ):
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"x", "audio/webm")},
+                data={"target_text": "春風吹過田野。"},
+            )
+
+        # If we reach here without AssertionError, no real GCS call happened
+        assert resp.status_code == 200
+        mock_upload.assert_called_once()

--- a/specs/modules/reading-transcription/INTENT.md
+++ b/specs/modules/reading-transcription/INTENT.md
@@ -6,6 +6,7 @@ stability: active
 canonical_source: backend/app/services/reading_transcription_service.py
 owns_code:
   - backend/app/services/reading_transcription_service.py
+  - backend/app/services/audio_upload_service.py
   - backend/app/routes/learning/learning_reading.py
   - frontend/src/hooks/useAudioRecorder.ts
   - frontend/src/hooks/useFullReadingSession.ts
@@ -15,9 +16,11 @@ owns_code:
 owns_data: []
 spec_tests:
   - backend/specs/test_reading_transcription_spec.py
+  - backend/tests/test_reading_audio_upload.py
 related_issues:
   - 2131
   - 2156
+  - 2266
 source_meetings: []
 last_reviewed: 2026-06-09
 owner: young
@@ -134,6 +137,7 @@ Frontend scoring:
 | C3 | Gemini success → `{method: "gemini", transcript: str (non-empty), reasoning: str}` |
 | C4 | Unsupported MIME → HTTP 415 (route gate); empty audio → HTTP 400; never HTTP 500 on AI error |
 | C5 | Route has auth (`get_current_user`), rate-limit (`ai_limit`), and size caps (`_MAX_AUDIO_BYTES`, `_MAX_TARGET_CHARS`) |
+| C6 | After transcription completes (success or graceful fallback — not on unhandled exception), audio bytes are uploaded to GCS via BackgroundTasks (fire-and-forget). Upload never blocks the response, never sets public ACL, and silently skips if READING_AUDIO_GCS_BUCKET env is unset. |
 
 ---
 

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -544,6 +544,7 @@ modules:
   canonical_source: backend/app/services/reading_transcription_service.py
   owns_code:
   - backend/app/services/reading_transcription_service.py
+  - backend/app/services/audio_upload_service.py
   - backend/app/routes/learning/learning_reading.py
   - frontend/src/hooks/useAudioRecorder.ts
   - frontend/src/hooks/useFullReadingSession.ts
@@ -553,9 +554,11 @@ modules:
   owns_data: []
   spec_tests:
   - backend/specs/test_reading_transcription_spec.py
+  - backend/tests/test_reading_audio_upload.py
   related_issues:
   - 2131
   - 2156
+  - 2266
   source_meetings: []
   last_reviewed: 2026-06-09
   owner: young


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Related to #2266

## Summary

- Adds `backend/app/services/audio_upload_service.py` — fire-and-forget GCS upload service
- Wires `BackgroundTasks.add_task(upload_reading_audio_to_gcs, ...)` in `POST /reading/transcribe` **after** the response is returned (never blocks Gemini latency)
- 15 new tests in `backend/tests/test_reading_audio_upload.py` — all pass; no test touches real GCS
- Updates `specs/modules/reading-transcription/INTENT.md` + `specs/registry.yaml` with C6 contract and `audio_upload_service.py` ownership

## Bugs fixed from previous attempt (all verified by tests)

| Pit | Problem | Fix |
|-----|---------|-----|
| #1 (critical) | Route tests called real GCS — wrong patch target (`service` module, not `route` module) | Patch at `app.routes.learning.learning_reading.upload_reading_audio_to_gcs` (where route bound the name via `from ... import`) |
| #2 | Cold-start race: 80 concurrent Cloud Run requests could init GCS client simultaneously | `threading.Lock` with double-checked locking pattern |
| #3 | Silent fallback to `lingoleap-tts-cache` bucket (wrong bucket, PII mixing) | No fallback — `READING_AUDIO_GCS_BUCKET` env var required; if unset → one-time WARNING + skip |

## Privacy / Security

- Bucket **must be private** — `make_public` and `predefined_acl` are never called
- Blob path is NOT returned to client or written to any log except the INFO upload-OK line
- Blob path: `reading-audio/{lesson_id or unknown}/{user_id}/{timestamp}{ext}`
- Log fields: `user_id`, `bytes`, `duration_ms`, `path` — no names, email, or audio content

## TODO (intentionally deferred — needs product decision)

**Retention / lifecycle policy**: blobs currently persist indefinitely. Once the product team decides the retention window (e.g. 30 days for debug replay vs 90 days for model training set), set a GCS lifecycle rule on the bucket path `reading-audio/**`.

@young — which bucket name should READING_AUDIO_GCS_BUCKET point to? Should we create a dedicated `lingoleap-reading-audio` bucket, or use an existing one with a subpath? (Do NOT create a bucket without your explicit OK.)

## Test plan

1. CI passes (backend pytest — 53 tests: 15 new + 13 existing transcription + 25 spec contracts)
2. Verify preview deploy backend starts without error (GCS bucket env unset → WARNING log, not crash)
3. After setting `READING_AUDIO_GCS_BUCKET` on staging Cloud Run, submit a reading → confirm `reading-audio/unknown/{user_id}/...` blob appears in the bucket (private, no public URL)
4. Confirm transcription response latency is unchanged (upload is background task)