### PR TITLE
fix(live-tutor): 4 朗讀 UX 痛點修復 — loading/mic/playback/side-by-side (Related to #2266)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -721,12 +721,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
       </div>
 
-      {/* Mic error */}
-      {micError && (
-        <div className="absolute bottom-52 left-1/2 -translate-x-1/2 px-5 py-2 bg-tertiary-container/20 rounded-full z-20">
-          <span className="text-sm text-tertiary">{micError}</span>
-        </div>
-      )}
+      {/* Mic error is now shown as a prominent card inside LiveTutorControls (Painpoint 2).
+          The old floating pill is removed. micError is passed via props below. */}
 
       {/* No-audio-detected banner */}
       {noAudioDetected && paragraphRecorder.status === 'recording' && (
@@ -780,6 +776,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         recordingPendingReview={recordingPendingReview}
         hasDetectedAudio={hasDetectedAudio}
         volumeLevel={paragraphRecorder.volumeLevel}
+        micError={micError || undefined}
+        recordingAudioUrl={recordingPendingReview ? paragraphRecorder.audioUrl : null}
         lastDiffTokens={displayLastDiffTokens}
         retryCount={evalState.retryCount}
         ttsError={ttsError}
@@ -794,6 +792,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         onPauseResumeTts={isTtsPaused ? resumeTts : pauseTts}
         onStopTts={stopTts}
         onFinish={() => handleFinish(stopSession)}
+        onRequestMicPermission={startSession}
       />
 
       {/* Background decoration */}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { DiffToken } from '../../../types';
 import { formatTime } from '../../../utils/formatTime';
 
@@ -19,6 +19,16 @@ interface LiveTutorControlsProps {
   hasDetectedAudio?: boolean;
   /** 0–1 mic volume for recording indicator bars. */
   volumeLevel?: number;
+  /**
+   * Painpoint 2: current mic error string (from LiveTutor.micError state).
+   * When set and no session is active, show prominent card + allow-mic button.
+   */
+  micError?: string;
+  /**
+   * Painpoint 3: object URL of the just-recorded audio blob.
+   * Passed from LiveTutor via paragraphRecorder.audioUrl during recordingPendingReview.
+   */
+  recordingAudioUrl?: string | null;
   // Content state
   lastDiffTokens: DiffToken[] | null;
   retryCount: number;
@@ -39,6 +49,8 @@ interface LiveTutorControlsProps {
   onPauseResumeTts: () => void;
   onStopTts: () => void;
   onFinish: () => void;
+  /** Painpoint 2: trigger getUserMedia to prompt browser permission dialog. */
+  onRequestMicPermission?: () => void;
 }
 
 /**
@@ -46,7 +58,12 @@ interface LiveTutorControlsProps {
  * Renders the correct button state based on session phase.
  *
  * Recording state (isSessionActive): pulsing red mic + elapsed timer + green 完成 button.
- * After 完成: 評估 / 重錄 / 取消 — only 評估 triggers API scoring.
+ * After 完成: 評估 / 重錄 / 取消 / ▶播放 — only 評估 triggers API scoring.
+ *
+ * Painpoints fixed (2266):
+ *   P1 — isAwaitingGemini shows "評估中…（約 15 秒）" full-width banner.
+ *   P2 — micError shows a prominent card with a 允許麥克風 button.
+ *   P3 — recordingPendingReview row adds ▶ 播放 button to review recording.
  */
 const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   isSessionActive,
@@ -60,6 +77,8 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   recordingPendingReview = false,
   hasDetectedAudio = false,
   volumeLevel = 0,
+  micError,
+  recordingAudioUrl,
   lastDiffTokens,
   retryCount,
   ttsError,
@@ -74,6 +93,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   onPauseResumeTts,
   onStopTts,
   onFinish,
+  onRequestMicPermission,
 }) => {
   const isAllDone = completedCount === totalLines;
 
@@ -97,12 +117,96 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
     !isAwaitingGemini &&
     (hasDetectedAudio || recordingSecs >= 2 || !!lastDiffTokens);
 
+  /* ── Painpoint 3: playback state for the recorded audio ── */
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlayingBack, setIsPlayingBack] = useState(false);
+
+  // Reset playback state when pending review ends
+  useEffect(() => {
+    if (!recordingPendingReview) {
+      stopPlaybackSync();
+    }
+  }, [recordingPendingReview, stopPlaybackSync]);
+
+  /** Stop playback synchronously — used both by the toggle button and before
+   *  delegating 取消/重錄 so that clearRecording() doesn't revoke a live URL. */
+  const stopPlaybackSync = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    setIsPlayingBack(false);
+  }, []);
+
+  const handlePlayback = useCallback(() => {
+    if (!recordingAudioUrl) return;
+    if (isPlayingBack) {
+      stopPlaybackSync();
+      return;
+    }
+    const audio = new Audio(recordingAudioUrl);
+    audioRef.current = audio;
+    audio.onended = () => {
+      setIsPlayingBack(false);
+      audioRef.current = null;
+    };
+    audio.onerror = () => {
+      setIsPlayingBack(false);
+      audioRef.current = null;
+    };
+    audio.play().catch(() => {
+      setIsPlayingBack(false);
+      audioRef.current = null;
+    });
+    setIsPlayingBack(true);
+  }, [recordingAudioUrl, isPlayingBack, stopPlaybackSync]);
+
+  /* ── Painpoint 1: awaiting-Gemini banner — elapsed counter ── */
+  const [awaitingSecs, setAwaitingSecs] = useState(0);
+  useEffect(() => {
+    if (!isAwaitingGemini) {
+      setAwaitingSecs(0);
+      return;
+    }
+    const id = setInterval(() => setAwaitingSecs(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isAwaitingGemini]);
+
+  /* ── Painpoint 1: isSubmittingSentence wraps both STT + Gemini eval.
+     Show elapsed time so student sees progress, not a frozen screen. ── */
+  const evalElapsedSecs = isSubmittingSentence ? awaitingSecs : 0;
+
   return (
     <div
       className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
       style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}
     >
       <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">
+
+        {/* ── Painpoint 2: mic error prominent card — shown above other buttons ── */}
+        {micError && !isSessionActive && !isSubmittingSentence && !recordingPendingReview && (
+          <div className="w-full p-4 rounded-2xl bg-amber-50 border border-amber-300 shadow-md flex flex-col gap-3">
+            <div className="flex items-start gap-3">
+              <span className="material-symbols-outlined text-amber-600 shrink-0 mt-0.5">mic_off</span>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-amber-800">麥克風需要授權</p>
+                <p className="text-xs text-amber-700 mt-0.5">
+                  請點擊下方按鈕，在瀏覽器彈出視窗中選擇「允許」以開啟麥克風。
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onRequestMicPermission ?? onStartSession}
+              className="w-full h-11 rounded-full font-headline font-bold text-base bg-amber-600 text-white hover:bg-amber-700 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+            >
+              <span className="material-symbols-outlined text-lg" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+              允許麥克風
+            </button>
+          </div>
+        )}
 
         {/* All paragraphs done — final report */}
         {isAllDone ? (
@@ -145,10 +249,23 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                 <p className="text-sm text-on-surface-variant text-center">
                   錄音已暫停。滿意請按評估；想再錄按重錄；不要這次錄音請按取消。
                 </p>
+                {/* Painpoint 3: playback row above action buttons */}
+                {recordingAudioUrl && (
+                  <button
+                    type="button"
+                    onClick={handlePlayback}
+                    className="flex items-center gap-2 px-5 py-2 rounded-full text-sm font-bold bg-surface-container-high text-on-surface hover:bg-surface-container-highest active:scale-[0.98] transition-all"
+                  >
+                    <span className="material-symbols-outlined text-base" style={{ fontVariationSettings: "'FILL' 1" }}>
+                      {isPlayingBack ? 'stop_circle' : 'play_circle'}
+                    </span>
+                    {isPlayingBack ? '停止播放' : '▶ 播放錄音'}
+                  </button>
+                )}
                 <div className="w-full flex gap-2">
                   <button
                     type="button"
-                    onClick={onConfirmCancel}
+                    onClick={() => { stopPlaybackSync(); onConfirmCancel(); }}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-base bg-surface-container-lowest shadow-editorial text-on-surface-variant hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-1.5"
                   >
                     <span className="material-symbols-outlined text-lg">close</span>
@@ -156,7 +273,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                   </button>
                   <button
                     type="button"
-                    onClick={onConfirmRerecord}
+                    onClick={() => { stopPlaybackSync(); onConfirmRerecord(); }}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-base bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-1.5"
                   >
                     <span className="material-symbols-outlined text-lg">replay</span>
@@ -174,15 +291,22 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                 </div>
               </>
             ) : isSubmittingSentence ? (
-              <button
-                type="button"
-                disabled
-                className="w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 text-white opacity-80 cursor-wait shadow-[0_12px_48px_rgba(0,105,71,0.3)]"
-                style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
-              >
-                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                評分中…
-              </button>
+              /* Painpoint 1: eval loading state with elapsed seconds */
+              <div className="w-full flex flex-col items-center gap-1.5">
+                <button
+                  type="button"
+                  disabled
+                  className="w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 text-white opacity-90 cursor-wait shadow-[0_12px_48px_rgba(0,105,71,0.3)]"
+                  style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
+                >
+                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  評估中…
+                </button>
+                <p className="text-xs text-on-surface-variant tabular-nums">
+                  AI 正在分析朗讀音訊，約需 10–20 秒
+                  {evalElapsedSecs > 0 && `（已等待 ${evalElapsedSecs} 秒）`}
+                </p>
+              </div>
             ) : (
               <button
                 type="button"

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -244,27 +244,53 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
         </div>
       )}
 
-      {/* ── Diff token display (color-coded reading result) ────────── */}
+      {/* ── Painpoint 4: 原文 vs 朗讀結果 — 左右並陳（桌機），上下排（手機） ── */}
       {readingResultTokens && !isSessionActive && (
-        <div className="mt-6 p-4 bg-surface-container-low rounded-2xl">
-          <p className="text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-2">朗讀結果</p>
-          <p className="text-lg leading-relaxed">
-            {readingResultTokens.map((t, i) => (
-              <span
-                key={i}
-                className={
-                  t.type === 'punctuation' ? 'text-on-surface' :
-                  t.type === 'correct' ? 'text-emerald-600 font-medium' :
-                  t.type === 'forgiven' ? 'text-blue-500' :
-                  t.type === 'wrong' ? 'text-tertiary line-through' :
-                  t.type === 'missing' || t.type === 'unread' ? 'text-on-surface-variant/30' :
-                  'text-on-surface'
-                }
-              >
-                {t.char}
-              </span>
-            ))}
-          </p>
+        <div className="mt-6 rounded-2xl bg-surface-container-low overflow-hidden">
+          {/* 圖例說明 */}
+          <div className="px-4 pt-3 pb-2 flex flex-wrap gap-x-4 gap-y-1 border-b border-on-surface/5">
+            <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">朗讀對照</span>
+            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
+              <span className="text-emerald-600 font-bold">●</span> 正確
+            </span>
+            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
+              <span className="text-tertiary font-bold">●</span> 唸錯
+            </span>
+            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
+              <span className="text-on-surface-variant/40 font-bold">●</span> 漏念
+            </span>
+          </div>
+          {/* 左右並陳 (md+) / 上下排 (sm) */}
+          <div className="flex flex-col md:flex-row divide-y md:divide-y-0 md:divide-x divide-on-surface/8">
+            {/* 左欄：課文原文 */}
+            <div className="flex-1 p-4">
+              <p className="text-xs font-bold text-on-surface-variant mb-2">課文原文</p>
+              <p className="text-base leading-relaxed text-on-surface/90">
+                {line}
+              </p>
+            </div>
+            {/* 右欄：朗讀轉譯（色碼）*/}
+            <div className="flex-1 p-4">
+              <p className="text-xs font-bold text-on-surface-variant mb-2">朗讀結果</p>
+              <p className="text-base leading-relaxed">
+                {readingResultTokens.map((t, i) => (
+                  <span
+                    key={i}
+                    className={
+                      t.type === 'punctuation' ? 'text-on-surface' :
+                      t.type === 'correct' ? 'text-emerald-600 font-medium' :
+                      t.type === 'forgiven' ? 'text-blue-500' :
+                      t.type === 'wrong' ? 'text-tertiary line-through' :
+                      t.type === 'missing' || t.type === 'unread' ? 'text-on-surface-variant/30' :
+                      'text-on-surface'
+                    }
+                  >
+                    {t.char}
+                  </span>
+                ))}
+              </p>
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Related to #2266

## Summary

修復方大哥回報的 4 個逐段朗讀（LiveTutor）UX 痛點：

- **痛點 1（評估等待無提示）**: isSubmittingSentence 狀態改顯示「評估中…（約 10–20 秒）」+ 已等待秒數計數器，學生知道 AI 正在跑不是當機
- **痛點 2（麥克風權限提示太小）**: 小字 pill 改成明顯的 amber 卡片，加「允許麥克風」按鈕直接觸發 getUserMedia 權限請求
- **痛點 3（錄音後無法回聽）**: recordingPendingReview 狀態（取消/重錄/評估 三按鈕列上方）加「▶ 播放錄音」鈕，使用 paragraphRecorder.audioUrl。修復 object-URL revocation race：stopPlaybackSync() 在 清錄音/取消/重錄 前同步停止 Audio
- **痛點 4（原文 vs 轉譯難比對）**: 朗讀對照改成桌機左右並陳（md:flex-row）、手機上下排，同字級，加圖例列（正確/唸錯/漏念）

## Files Changed

- `frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx` — 痛點 1/2/3
- `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` — 傳 micError/recordingAudioUrl/onRequestMicPermission 新 props
- `frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx` — 痛點 4

**Not touched**: useSpeechRecognition.ts, VoiceInputButton（確認無改動）

## Test plan

- [ ] Preview URL 部署後：登入學生帳號 → 進逐段朗讀 → 確認按「評估」後出現 spinner + 秒數
- [ ] 拒絕麥克風權限 → 確認 amber 卡片出現，「允許麥克風」按鈕可觸發瀏覽器彈窗
- [ ] 錄完按「完成」→ 確認「▶ 播放錄音」按鈕出現，可播放，按「重錄/取消」時播放停止
- [ ] 評估完成後 → 確認桌機左右並陳（原文/朗讀結果），手機上下排
- [ ] npm run build: 無 TypeScript error（本機已驗）