### PR TITLE
feat(live-tutor): animated eval progress panel (Fixes #2266 UX)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -2,6 +2,14 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { DiffToken } from '../../../types';
 import { formatTime } from '../../../utils/formatTime';
 
+/** Eval progress steps — defined outside component to avoid per-render allocation. */
+const EVAL_STEPS = [
+  { icon: '📖', label: '掃描課文中…',    minMs: 0     },
+  { icon: '🎙️', label: '辨識你的朗讀…', minMs: 2500  },
+  { icon: '🔍', label: '逐字比對對錯…', minMs: 10000 },
+  { icon: '📊', label: '計算正確率…',   minMs: 15000 },
+] as const;
+
 interface LiveTutorControlsProps {
   // Session state
   isSessionActive: boolean;
@@ -163,19 +171,32 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
     setIsPlayingBack(true);
   }, [recordingAudioUrl, isPlayingBack, stopPlaybackSync]);
 
-  /* ── Painpoint 1: awaiting-Gemini banner — elapsed counter ── */
+  /* ── Eval progress animation: step sequence + elapsed counter ── */
   const [awaitingSecs, setAwaitingSecs] = useState(0);
+  const [evalStepIdx, setEvalStepIdx] = useState(0);
+
   useEffect(() => {
-    if (!isAwaitingGemini) {
+    if (!isSubmittingSentence) {
       setAwaitingSecs(0);
+      setEvalStepIdx(0);
       return;
     }
-    const id = setInterval(() => setAwaitingSecs(s => s + 1), 1000);
+    const start = Date.now();
+    const id = setInterval(() => {
+      const elapsedMs = Date.now() - start;
+      const secs = Math.floor(elapsedMs / 1000);
+      setAwaitingSecs(secs);
+      // Advance to the highest step whose minMs has been reached;
+      // cap at last step (stays there until result arrives).
+      let nextIdx = 0;
+      for (let i = EVAL_STEPS.length - 1; i >= 0; i--) {
+        if (elapsedMs >= EVAL_STEPS[i].minMs) { nextIdx = i; break; }
+      }
+      setEvalStepIdx(nextIdx);
+    }, 300);
     return () => clearInterval(id);
-  }, [isAwaitingGemini]);
+  }, [isSubmittingSentence]);
 
-  /* ── Painpoint 1: isSubmittingSentence wraps both STT + Gemini eval.
-     Show elapsed time so student sees progress, not a frozen screen. ── */
   const evalElapsedSecs = isSubmittingSentence ? awaitingSecs : 0;
 
   return (
@@ -291,20 +312,78 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                 </div>
               </>
             ) : isSubmittingSentence ? (
-              /* Painpoint 1: eval loading state with elapsed seconds */
-              <div className="w-full flex flex-col items-center gap-1.5">
-                <button
-                  type="button"
-                  disabled
-                  className="w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 text-white opacity-90 cursor-wait shadow-[0_12px_48px_rgba(0,105,71,0.3)]"
-                  style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
-                >
-                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                  評估中…
-                </button>
+              /* Eval progress animation — step-by-step with scanning line */
+              <div className="w-full flex flex-col items-center gap-3">
+                {/* Main card */}
+                <div className="w-full rounded-2xl overflow-hidden shadow-[0_12px_48px_rgba(0,105,71,0.2)] bg-gradient-to-br from-[#006947] to-[#34d399]">
+                  {/* Scanning progress bar */}
+                  <div className="relative h-1.5 bg-white/20">
+                    <div
+                      className="absolute inset-y-0 left-0 bg-white/80 rounded-full"
+                      style={{
+                        width: `${Math.min(95, (evalStepIdx / (EVAL_STEPS.length - 1)) * 100)}%`,
+                        transition: 'width 0.6s ease-in-out',
+                      }}
+                    />
+                    {/* Glowing scanner dot */}
+                    <div
+                      className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-white shadow-[0_0_8px_4px_rgba(255,255,255,0.5)]"
+                      style={{
+                        left: `calc(${Math.min(95, (evalStepIdx / (EVAL_STEPS.length - 1)) * 100)}% - 4px)`,
+                        transition: 'left 0.6s ease-in-out',
+                      }}
+                    />
+                  </div>
+
+                  {/* Step messages */}
+                  <div className="px-5 py-4 flex flex-col gap-2.5">
+                    {EVAL_STEPS.map((step, idx) => {
+                      const isActive = idx === evalStepIdx;
+                      const isDone = idx < evalStepIdx;
+                      return (
+                        <div
+                          key={step.label}
+                          className="flex items-center gap-3 transition-opacity duration-500"
+                          style={{ opacity: isDone ? 0.45 : isActive ? 1 : 0.25 }}
+                        >
+                          <span
+                            className="text-lg leading-none select-none"
+                            style={{ filter: isActive ? 'none' : 'grayscale(0.5)' }}
+                          >
+                            {step.icon}
+                          </span>
+                          <span
+                            className={`text-sm font-bold transition-colors duration-300 ${
+                              isActive ? 'text-white' : isDone ? 'text-white/60 line-through decoration-white/40' : 'text-white/40'
+                            }`}
+                          >
+                            {step.label}
+                          </span>
+                          {isActive && (
+                            <div className="ml-auto flex items-end gap-1 h-4">
+                              {[0, 1, 2].map(i => (
+                                <div
+                                  key={i}
+                                  className="w-1.5 h-1.5 rounded-full bg-white animate-bounce"
+                                  style={{ animationDelay: `${i * 0.15}s` }}
+                                />
+                              ))}
+                            </div>
+                          )}
+                          {isDone && (
+                            <span className="ml-auto text-sm text-white/60">✓</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Elapsed time hint */}
                 <p className="text-xs text-on-surface-variant tabular-nums">
-                  AI 正在分析朗讀音訊，約需 10–20 秒
-                  {evalElapsedSecs > 0 && `（已等待 ${evalElapsedSecs} 秒）`}
+                  {evalElapsedSecs > 0
+                    ? `已等待 ${evalElapsedSecs} 秒，AI 正在分析中…`
+                    : 'AI 正在分析朗讀音訊，約需 10–20 秒'}
                 </p>
               </div>
             ) : (


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## Summary

- Replace the static "評估中…" loading button with a 4-step animated progress card during `isSubmittingSentence`
- Steps advance on a calibrated timer (0s / 2.5s / 10s / 15s) corresponding to the real backend flow: scan → STT transcribe → DP align → score
- Last step holds until result arrives; card disappears instantly when evaluation completes
- Only `LiveTutorControls.tsx` modified — zero changes to scoring logic, VoiceInputButton, or useSpeechRecognition

## Visual behaviour

| Time | Active step | Notes |
|------|-------------|-------|
| 0s   | 📖 掃描課文中… | |
| ~2.5s | 🎙️ 辨識你的朗讀… | longest phase (real STT 16–25s) |
| ~10s | 🔍 逐字比對對錯… | |
| ~15s | 📊 計算正確率… | **holds here** until result arrives |

Completed steps get strikethrough + ✓; active step shows bounce dots + glow progress bar dot.

## Test plan

- [ ] Open PR preview, navigate to a lesson, click 學生 小明 login
- [ ] Start a paragraph recording, tap 完成 then 評估
- [ ] Observe: green card appears with step 1 active → advances through steps → holds at step 4 → card disappears when score shows
- [ ] Elapsed seconds counter updates below the card
- [ ] build passes: `npx vite build` ✓ (no TS errors)
- [ ] Only `LiveTutorControls.tsx` changed (1 file, ~98 lines added)

## Related

Related to #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)