### PR TITLE
feat(reading): PR1 reading audio replay — migration + student replay + IDOR fix (Fixes #2266)

### DIFF
--- a/backend/alembic/versions/a2b3c4d5e6f7_add_audio_gcs_path_to_attempts.py
+++ b/backend/alembic/versions/a2b3c4d5e6f7_add_audio_gcs_path_to_attempts.py
@@ -1,0 +1,69 @@
+"""add audio_gcs_path to reading_attempt_history and assignment_submissions
+
+Revision ID: a2b3c4d5e6f7
+Revises: 2ed91926c851
+Create Date: 2026-06-19
+
+Issue #2266: Store GCS blob path in DB so students can replay their reading
+audio and teachers can access it for audit.
+
+Two columns added (both nullable, no FK/index needed — queries go via session_id):
+  - reading_attempt_history.audio_gcs_path  VARCHAR(500) NULL
+  - assignment_submissions.audio_gcs_path   VARCHAR(500) NULL
+
+GCS path format: reading-audio/attempts/{attempt_id}.webm
+Signed URL generation is handled in the route layer; this column stores the
+private GCS path only — never a public URL.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a2b3c4d5e6f7"
+down_revision = "2ed91926c851"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # reading_attempt_history — idempotent (IF NOT EXISTS)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'reading_attempt_history'
+                  AND column_name = 'audio_gcs_path'
+            ) THEN
+                ALTER TABLE reading_attempt_history
+                    ADD COLUMN audio_gcs_path VARCHAR(500) NULL;
+            END IF;
+        END $$;
+    """)
+
+    # assignment_submissions — idempotent (IF NOT EXISTS)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'assignment_submissions'
+                  AND column_name = 'audio_gcs_path'
+            ) THEN
+                ALTER TABLE assignment_submissions
+                    ADD COLUMN audio_gcs_path VARCHAR(500) NULL;
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE reading_attempt_history
+            DROP COLUMN IF EXISTS audio_gcs_path;
+    """)
+    op.execute("""
+        ALTER TABLE assignment_submissions
+            DROP COLUMN IF EXISTS audio_gcs_path;
+    """)

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -92,6 +92,10 @@ class AssignmentSubmission(Base):
     submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     score: Mapped[float | None] = mapped_column(Float, nullable=True)  # from LearningSession accuracy
     teacher_feedback: Mapped[str | None] = mapped_column(Text, nullable=True)  # per-student teacher comment (Issue #424)
+    # Issue #2266: GCS blob path for assignment reading audio (private bucket).
+    # Format: reading-audio/submissions/{id}.webm  — Never a public URL.
+    # None = audio not available (non-assignment session or upload not yet done).
+    audio_gcs_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -53,6 +53,10 @@ class ReadingAttemptHistory(Base):
     # 1-based attempt counter; composite index enables fast "latest attempt" lookup
     attempt_no: Mapped[int] = mapped_column(Integer, nullable=False)
     reading_result: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    # Issue #2266: GCS blob path for student audio replay (private bucket).
+    # Format: reading-audio/attempts/{id}.webm  — Never a public URL.
+    # None = audio not yet uploaded or upload failed (non-fatal).
+    audio_gcs_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -17,6 +17,7 @@ Splits the original monolithic learning.py (1,881 lines) into focused sub-module
 - mcq_rescue.py                    — MCQ rescue AI tutor endpoints (Issue #1387)
 - mcq_attempt.py                   — MCQ attempt telemetry endpoint (Issue #1507)
 - toolbox.py                       — Practice toolbox session endpoints (Issue #1463 / #1460)
+- learning_audio_replay.py         — Student reading audio signed-URL replay (Issue #2266)
 
 The composed router is re-exported as `router` so that main.py's existing
 `app.include_router(learning.router, prefix="/api")` continues to work unchanged.
@@ -41,6 +42,7 @@ from .mcq_rescue import router as mcq_rescue_router
 from .mcq_attempt import router as mcq_attempt_router
 from .toolbox import router as toolbox_router
 from .learning_annotations import router as annotations_router
+from .learning_audio_replay import router as audio_replay_router
 
 router = APIRouter(tags=["learning"])
 
@@ -60,5 +62,6 @@ router.include_router(mcq_rescue_router)
 router.include_router(mcq_attempt_router)
 router.include_router(toolbox_router)
 router.include_router(annotations_router)
+router.include_router(audio_replay_router)
 
 __all__ = ["router"]

--- a/backend/app/routes/learning/learning_audio_replay.py
+++ b/backend/app/routes/learning/learning_audio_replay.py
@@ -1,0 +1,99 @@
+"""Student reading audio replay endpoint (Issue #2266).
+
+GET /api/learning/sessions/{session_id}/reading-audio/{attempt_id}
+  - Authorised student only (session_id owner check).
+  - Looks up ReadingAttemptHistory.audio_gcs_path.
+  - Returns a short-lived signed URL (10 min) for GCS playback.
+  - 404 if audio_gcs_path is None (not yet uploaded).
+  - 403 if session does not belong to current user.
+
+Security:
+  - Signed URL generated server-side; never stored or cached.
+  - Bucket stays private — no make_public call here.
+  - Only the session owner (student) can request a signed URL via this endpoint.
+    Teacher access is in PR2 (teacher route with role check).
+"""
+from __future__ import annotations
+
+import logging
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...database import get_db
+from ...models.session import LearningSession, ReadingAttemptHistory
+from ...models.user import User
+from ...services.audio_upload_service import generate_audio_signed_url
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+_SIGNED_URL_EXPIRY = 600  # 10 minutes
+
+
+class AudioReplayResponse(BaseModel):
+    signed_url: str
+    expires_in: int  # seconds
+
+
+@router.get(
+    "/learning/sessions/{session_id}/reading-audio/{attempt_id}",
+    response_model=AudioReplayResponse,
+    summary="Student reading audio replay signed URL (Issue #2266)",
+    description=(
+        "Generate a 10-minute signed URL for a student to replay their recorded "
+        "reading audio.  Only the session owner (student) may call this endpoint.\n\n"
+        "Returns 404 if no audio was recorded for the specified attempt.\n"
+        "Returns 403 if the session does not belong to the authenticated student.\n"
+        "Returns 503 if GCS signed URL generation fails.\n"
+    ),
+)
+def get_reading_audio_signed_url(
+    session_id: int,
+    attempt_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> AudioReplayResponse:
+    """Return a short-lived signed URL so the student can replay their audio."""
+    # 1. Validate session ownership
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your session")
+
+    # 2. Fetch the attempt
+    attempt = (
+        db.query(ReadingAttemptHistory)
+        .filter(
+            ReadingAttemptHistory.id == attempt_id,
+            ReadingAttemptHistory.session_id == session_id,
+        )
+        .first()
+    )
+    if attempt is None:
+        raise HTTPException(status_code=404, detail="Attempt not found")
+    if not attempt.audio_gcs_path:
+        raise HTTPException(status_code=404, detail="No audio recorded for this attempt")
+
+    # 3. Generate signed URL
+    signed_url = generate_audio_signed_url(
+        blob_path=attempt.audio_gcs_path,
+        expiration_seconds=_SIGNED_URL_EXPIRY,
+    )
+    if signed_url is None:
+        logger.error(
+            "Signed URL generation failed for attempt %d (path=%s)",
+            attempt_id,
+            attempt.audio_gcs_path,
+        )
+        raise HTTPException(status_code=503, detail="Audio replay temporarily unavailable")
+
+    logger.info(
+        "Audio signed URL issued: session=%d attempt=%d user=%d",
+        session_id,
+        attempt_id,
+        current_user.id,
+    )
+    return AudioReplayResponse(signed_url=signed_url, expires_in=_SIGNED_URL_EXPIRY)

--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -24,7 +24,11 @@ from ...services.reading_transcription_service import (
     ALLOWED_AUDIO_MIMES,
     transcribe_reading_audio,
 )
-from ...services.audio_upload_service import upload_reading_audio_to_gcs
+from ...models.session import ReadingAttemptHistory
+from ...services.audio_upload_service import (
+    upload_reading_audio_to_gcs,
+    upload_reading_audio_to_gcs_sync,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -485,6 +489,21 @@ async def evaluate_reading_endpoint(
 _MAX_AUDIO_BYTES = 10 * 1024 * 1024   # 10 MB
 _MAX_TARGET_CHARS = 3000               # ≈ longest G9 lesson
 
+# MIME → extension map used when constructing attempt-bound GCS paths
+_MIME_TO_EXT_SYNC: dict[str, str] = {
+    "audio/webm": ".webm",
+    "audio/mp4": ".mp4",
+    "audio/mpeg": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+}
+
+
+def _normalise_mime_for_path(mime_type: str) -> str:
+    """Strip codec suffix for extension lookup: 'audio/webm;codecs=opus' → 'audio/webm'."""
+    return mime_type.split(";")[0].strip()
+
 
 class TranscribeReadingResponse(BaseModel):
     """Response schema for POST /api/reading/transcribe."""
@@ -532,6 +551,14 @@ async def transcribe_reading_endpoint(
     duration_ms: int | None = Form(
         default=None,
         description="Recording duration in milliseconds (informational, optional)",
+    ),
+    session_id: int | None = Form(
+        default=None,
+        description=(
+            "Optional LearningSession DB id.  When provided the audio is "
+            "uploaded synchronously and the GCS path is written to the latest "
+            "ReadingAttemptHistory row for this session (Issue #2266)."
+        ),
     ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -599,21 +626,64 @@ async def transcribe_reading_endpoint(
     )
     latency_ms = int((time.monotonic() - start_time) * 1000)
 
-    # ── 4.5. Background: async upload audio to GCS for debug / replay ────────
-    # Fire-and-forget — FastAPI sends the HTTP response first, then runs this task.
-    # Upload failures are logged as WARNING only; never affect the student score.
-    # Security: bucket is private, no public ACL, blob path is NOT returned to client.
-    # Bucket: controlled by READING_AUDIO_GCS_BUCKET env var.  If not set, skipped.
-    # TODO (Issue #2266): Set GCS lifecycle/retention policy once product decides
-    #   how long audio should be kept (e.g. 30 days debug / 90 days training set).
-    background_tasks.add_task(
-        upload_reading_audio_to_gcs,
-        audio_bytes=audio_bytes,
-        mime_type=raw_mime,
-        user_id=current_user.id,
-        lesson_id=None,  # transcribe endpoint is stateless — no lesson context
-        duration_ms=duration_ms,
-    )
+    # ── 4.5. Upload audio to GCS for student replay (Issue #2266) ───────────
+    # When session_id is provided: sync upload → write blob path to DB.
+    # When session_id is absent:  fire-and-forget background upload (debug only).
+    # Upload failures are logged as WARNING; never affect the student score.
+    # Security: bucket is private, no public ACL, path NOT returned to client here.
+    if session_id is not None:
+        # Verify session belongs to the current user before touching DB
+        attempt = (
+            db.query(ReadingAttemptHistory)
+            .filter(ReadingAttemptHistory.session_id == session_id)
+            .order_by(ReadingAttemptHistory.attempt_no.desc())
+            .first()
+        )
+        if attempt is not None:
+            base_mime = _normalise_mime_for_path(raw_mime)
+            ext = _MIME_TO_EXT_SYNC.get(base_mime, ".audio")
+            blob_path = f"reading-audio/attempts/{attempt.id}{ext}"
+            stored_path = upload_reading_audio_to_gcs_sync(
+                audio_bytes=audio_bytes,
+                mime_type=raw_mime,
+                blob_path=blob_path,
+            )
+            if stored_path is not None:
+                attempt.audio_gcs_path = stored_path
+                try:
+                    db.commit()
+                except Exception as commit_exc:
+                    logger.warning(
+                        "Failed to persist audio_gcs_path for attempt %d: %s",
+                        attempt.id,
+                        commit_exc,
+                    )
+                    db.rollback()
+        else:
+            # No attempt row yet — fall back to fire-and-forget for debug
+            logger.info(
+                "transcribe: session_id=%d has no ReadingAttemptHistory yet; "
+                "falling back to fire-and-forget upload",
+                session_id,
+            )
+            background_tasks.add_task(
+                upload_reading_audio_to_gcs,
+                audio_bytes=audio_bytes,
+                mime_type=raw_mime,
+                user_id=current_user.id,
+                lesson_id=None,
+                duration_ms=duration_ms,
+            )
+    else:
+        # Stateless call — fire-and-forget for debug purposes only.
+        background_tasks.add_task(
+            upload_reading_audio_to_gcs,
+            audio_bytes=audio_bytes,
+            mime_type=raw_mime,
+            user_id=current_user.id,
+            lesson_id=None,  # transcribe endpoint has no lesson context here
+            duration_ms=duration_ms,
+        )
 
     # ── 5. Log usage when Gemini succeeded ───────────────────────────────────
     if result.get("method") == "gemini":

--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -632,48 +632,69 @@ async def transcribe_reading_endpoint(
     # Upload failures are logged as WARNING; never affect the student score.
     # Security: bucket is private, no public ACL, path NOT returned to client here.
     if session_id is not None:
-        # Verify session belongs to the current user before touching DB
-        attempt = (
-            db.query(ReadingAttemptHistory)
-            .filter(ReadingAttemptHistory.session_id == session_id)
-            .order_by(ReadingAttemptHistory.attempt_no.desc())
+        # ── SECURITY: verify session ownership BEFORE touching DB (IDOR fix) ──
+        # Without this check any authenticated user could write to another
+        # student's attempt row by supplying a different session_id.
+        owned_session = (
+            db.query(LearningSession)
+            .filter(
+                LearningSession.id == session_id,
+                LearningSession.student_id == current_user.id,
+            )
             .first()
         )
-        if attempt is not None:
-            base_mime = _normalise_mime_for_path(raw_mime)
-            ext = _MIME_TO_EXT_SYNC.get(base_mime, ".audio")
-            blob_path = f"reading-audio/attempts/{attempt.id}{ext}"
-            stored_path = upload_reading_audio_to_gcs_sync(
-                audio_bytes=audio_bytes,
-                mime_type=raw_mime,
-                blob_path=blob_path,
-            )
-            if stored_path is not None:
-                attempt.audio_gcs_path = stored_path
-                try:
-                    db.commit()
-                except Exception as commit_exc:
-                    logger.warning(
-                        "Failed to persist audio_gcs_path for attempt %d: %s",
-                        attempt.id,
-                        commit_exc,
-                    )
-                    db.rollback()
-        else:
-            # No attempt row yet — fall back to fire-and-forget for debug
-            logger.info(
-                "transcribe: session_id=%d has no ReadingAttemptHistory yet; "
-                "falling back to fire-and-forget upload",
+        if owned_session is None:
+            # Log but do NOT raise — audio upload failure must never block scoring.
+            logger.warning(
+                "transcribe: session_id=%d does not belong to user=%d; "
+                "skipping GCS audio upload",
                 session_id,
+                current_user.id,
             )
-            background_tasks.add_task(
-                upload_reading_audio_to_gcs,
-                audio_bytes=audio_bytes,
-                mime_type=raw_mime,
-                user_id=current_user.id,
-                lesson_id=None,
-                duration_ms=duration_ms,
+            # Fall through to return without uploading.
+        else:
+            attempt = (
+                db.query(ReadingAttemptHistory)
+                .filter(ReadingAttemptHistory.session_id == session_id)
+                .order_by(ReadingAttemptHistory.attempt_no.desc())
+                .first()
             )
+        if owned_session is not None:
+            if attempt is not None:
+                base_mime = _normalise_mime_for_path(raw_mime)
+                ext = _MIME_TO_EXT_SYNC.get(base_mime, ".audio")
+                blob_path = f"reading-audio/attempts/{attempt.id}{ext}"
+                stored_path = upload_reading_audio_to_gcs_sync(
+                    audio_bytes=audio_bytes,
+                    mime_type=raw_mime,
+                    blob_path=blob_path,
+                )
+                if stored_path is not None:
+                    attempt.audio_gcs_path = stored_path
+                    try:
+                        db.commit()
+                    except Exception as commit_exc:
+                        logger.warning(
+                            "Failed to persist audio_gcs_path for attempt %d: %s",
+                            attempt.id,
+                            commit_exc,
+                        )
+                        db.rollback()
+            else:
+                # Owned session but no attempt row yet — fire-and-forget for debug
+                logger.info(
+                    "transcribe: session_id=%d has no ReadingAttemptHistory yet; "
+                    "falling back to fire-and-forget upload",
+                    session_id,
+                )
+                background_tasks.add_task(
+                    upload_reading_audio_to_gcs,
+                    audio_bytes=audio_bytes,
+                    mime_type=raw_mime,
+                    user_id=current_user.id,
+                    lesson_id=None,
+                    duration_ms=duration_ms,
+                )
     else:
         # Stateless call — fire-and-forget for debug purposes only.
         background_tasks.add_task(

--- a/backend/app/services/audio_upload_service.py
+++ b/backend/app/services/audio_upload_service.py
@@ -1,11 +1,12 @@
-"""Async GCS upload service for reading audio files (Issue #2266).
+"""GCS upload / signed-URL service for reading audio files (Issue #2266).
 
 Responsibilities:
-- Fire-and-forget: upload audio bytes to GCS in background
-- NEVER block the transcription response
+- Fire-and-forget: upload audio bytes to GCS in background (legacy path)
+- Sync upload: upload and return blob path so callers can persist it to DB
+- Signed URL: generate short-lived (10 min) URL for student audio playback
 - NEVER set public ACL on blobs
 - NEVER log audio content or user PII beyond user_id + duration_ms
-- Fail silently: any upload error only logs WARNING
+- Fail silently: any upload/URL error only logs WARNING; returns None
 
 Bucket:
     Controlled by env var READING_AUDIO_GCS_BUCKET.
@@ -14,18 +15,20 @@ Bucket:
     (lingoleap-tts-cache) because mixing audio PII into the TTS bucket violates
     the principle of least privilege.
 
-    TODO (Issue #2266): Once the product team decides the retention policy
-    (e.g. 30 days for debug replay, 90 days for model training set), set a GCS
-    lifecycle rule on the bucket path reading-audio/** to auto-delete blobs.
-    Until then, blobs persist until manually deleted.
+Path convention (Issue #2266):
+    - Attempt-bound:    reading-audio/attempts/{attempt_id}{ext}
+    - Submission-bound: reading-audio/submissions/{submission_id}{ext}
+    - Legacy debug:     reading-audio/{lesson_id or unknown}/{user_id}/{ts}{ext}
 
 Privacy / security:
     - Bucket must be PRIVATE (no make_public / predefined_acl calls here).
-    - Blob path is NOT returned to the client or written to the DB.
-    - Path structure: reading-audio/{lesson_id or unknown}/{user_id}/{ts}{ext}
+    - Blob path is stored in DB; signed URLs are generated on demand and expire.
     - This service does NOT store user names, email, or any PII beyond user_id.
-    - The Cloud Run service account must have roles/storage.objectCreator on the
-      bucket; no broader permissions are required or granted here.
+    - The Cloud Run service account must have roles/storage.objectCreator +
+      roles/storage.objectViewer on the bucket.  For signed URL generation it
+      additionally needs iam.serviceAccounts.signBlob permission (available via
+      roles/iam.serviceAccountTokenCreator on the SA itself, or run on GCE/Cloud
+      Run where the SA can self-sign).
 
 Concurrency:
     Cloud Run instances default to concurrency=80.  The GCS Client() constructor
@@ -37,7 +40,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -135,9 +138,14 @@ def upload_reading_audio_to_gcs(
 
     GCS path: ``reading-audio/{lesson_id or 'unknown'}/{user_id}/{timestamp}{ext}``
 
-    TODO (Issue #2266): Retention policy — once product decides duration
-    (e.g. 30 days debug / 90 days training set), add a GCS lifecycle rule on
-    the bucket or path prefix so blobs auto-expire.
+    TODO (Issue #2266): Retention policy — audio linked from a DB record (any
+    ReadingAttemptHistory or AssignmentSubmission with a non-null audio_gcs_path)
+    is kept forever so students and teachers can always replay it.  Only three
+    "garbage" types are eligible for deletion: (1) discarded takes where no
+    evaluation was sent — skip the GCS upload entirely in the frontend; (2) GCS
+    orphans where the DB record no longer points to the blob — daily reconciliation
+    cron; (3) cascade-delete when the parent attempt/session/assignment is deleted.
+    Do NOT add time-based lifecycle rules (no 30-day / 90-day auto-expire).
     """
     bucket = _get_gcs_bucket()
     if bucket is None:
@@ -172,3 +180,100 @@ def upload_reading_audio_to_gcs(
             duration_ms,
             exc,
         )
+
+
+def upload_reading_audio_to_gcs_sync(
+    audio_bytes: bytes,
+    mime_type: str,
+    blob_path: str,
+) -> str | None:
+    """Synchronous GCS upload that returns the blob path on success.
+
+    Unlike the fire-and-forget variant, this function is designed to be called
+    inline (not via BackgroundTasks) so the caller can write the returned path
+    to the DB in the same request.
+
+    Args:
+        audio_bytes: Raw audio bytes.
+        mime_type:   MIME type string (e.g. 'audio/webm').
+        blob_path:   Pre-computed GCS object path (e.g.
+                     'reading-audio/attempts/42.webm').  The caller constructs
+                     the path from the DB id so it is deterministic.
+
+    Returns:
+        blob_path on success, None on any failure (already logged as WARNING).
+
+    Safety:
+        - NEVER sets public ACL.
+        - On any exception returns None (fail-open for the DB write).
+    """
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        return None  # Already warned at init; skip silently.
+
+    try:
+        base_mime = _normalise_mime(mime_type)
+        blob = bucket.blob(blob_path)
+        blob.upload_from_string(audio_bytes, content_type=base_mime)
+        logger.info(
+            "reading-audio GCS sync upload OK: bytes=%d path=%s",
+            len(audio_bytes),
+            blob_path,
+        )
+        return blob_path
+    except Exception as exc:
+        logger.warning(
+            "reading-audio GCS sync upload failed (non-fatal): bytes=%d path=%s error=%s",
+            len(audio_bytes),
+            blob_path,
+            exc,
+        )
+        return None
+
+
+def generate_audio_signed_url(
+    blob_path: str,
+    expiration_seconds: int = 600,
+) -> str | None:
+    """Generate a signed URL for private GCS audio playback.
+
+    The signed URL is short-lived (default 10 minutes) and allows the holder
+    to GET the object without any authentication.  It is generated server-side
+    and returned to the authorised student only — never cached or stored.
+
+    Args:
+        blob_path:          GCS object path stored in ReadingAttemptHistory.audio_gcs_path.
+        expiration_seconds: URL lifetime in seconds (default 600 = 10 min).
+
+    Returns:
+        Signed URL string on success, None on any failure.
+
+    Requirements:
+        The Cloud Run service account must be able to call
+        blob.generate_signed_url().  On GCE / Cloud Run this works automatically
+        when the SA has roles/iam.serviceAccountTokenCreator on itself.
+    """
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        return None
+
+    try:
+        blob = bucket.blob(blob_path)
+        url = blob.generate_signed_url(
+            expiration=timedelta(seconds=expiration_seconds),
+            method="GET",
+            version="v4",
+        )
+        logger.debug(
+            "reading-audio signed URL generated: path=%s expiry=%ds",
+            blob_path,
+            expiration_seconds,
+        )
+        return url
+    except Exception as exc:
+        logger.warning(
+            "reading-audio signed URL generation failed: path=%s error=%s",
+            blob_path,
+            exc,
+        )
+        return None

--- a/backend/tests/test_reading_audio_replay_student.py
+++ b/backend/tests/test_reading_audio_replay_student.py
@@ -1,0 +1,381 @@
+"""Tests for student reading audio replay endpoint (Issue #2266 PR1).
+
+Coverage:
+1. Happy path: student gets signed URL for their own attempt
+2. 403 when a different student tries to access
+3. 404 when session_id not found
+4. 404 when attempt_id not found
+5. 404 when audio_gcs_path is None (audio not yet uploaded)
+6. 503 when generate_audio_signed_url returns None (GCS failure)
+7. Transcribe with session_id writes audio_gcs_path to DB (PR1 binding test)
+
+KEY RULE: generate_audio_signed_url must be patched at the ROUTE MODULE import site:
+    "app.routes.learning.learning_audio_replay.generate_audio_signed_url"
+NOT at the service module (too late — route already holds the reference).
+
+Run:
+    cd backend
+    python -m pytest tests/test_reading_audio_replay_student.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.session import LearningSession, ReadingAttemptHistory
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# In-memory SQLite DB (no FK enforcement so we can skip User scaffolding)
+# Each test gets a BRAND NEW in-memory DB so there are no unique-constraint
+# collisions between tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_db():
+    """Create a fresh SQLite in-memory engine + session and initialise tables."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return Session()
+
+
+@pytest.fixture
+def db():
+    """Fresh in-memory DB per test — avoids unique-constraint collisions."""
+    session = _make_db()
+    yield session
+    session.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers to seed data
+# ─────────────────────────────────────────────────────────────────────────────
+
+_STUDENT_ID = 42
+_OTHER_STUDENT_ID = 99
+
+
+def _create_session(db, student_id: int = _STUDENT_ID) -> LearningSession:
+    sess = LearningSession(
+        student_id=student_id,
+        story_slug="test-replay-story",
+        status="in_progress",
+        current_step=1,
+        reading_result=None,
+        # full_reading_attempts has server_default '[]'::jsonb which SQLite can't
+        # apply; supply it explicitly so conftest JSON patch works correctly.
+        full_reading_attempts=[],
+    )
+    db.add(sess)
+    db.commit()
+    db.refresh(sess)
+    return sess
+
+
+def _create_attempt(
+    db,
+    session_id: int,
+    audio_gcs_path: str | None = "reading-audio/attempts/1.webm",
+) -> ReadingAttemptHistory:
+    attempt = ReadingAttemptHistory(
+        session_id=session_id,
+        attempt_no=1,
+        reading_result={"score": 85},
+        audio_gcs_path=audio_gcs_path,
+    )
+    db.add(attempt)
+    db.commit()
+    db.refresh(attempt)
+    return attempt
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# App builder
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _build_app(db_session, current_user_id: int = _STUDENT_ID) -> FastAPI:
+    """Minimal FastAPI app with the audio replay router; DB + auth mocked."""
+    from app.routes.learning.learning_audio_replay import router
+    from app.auth.dependencies import get_current_user
+    from app.database import get_db
+
+    app = FastAPI()
+
+    def _mock_user():
+        user = MagicMock()
+        user.id = current_user_id
+        return user
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[get_db] = _override_db
+    app.include_router(router, prefix="/api")
+    return app
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: GET /api/learning/sessions/{session_id}/reading-audio/{attempt_id}
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStudentAudioReplaySignedUrl:
+
+    def test_happy_path_returns_signed_url(self, db):
+        """Student gets signed URL for their own attempt."""
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        attempt = _create_attempt(db, session_id=learning_sess.id, audio_gcs_path="reading-audio/attempts/10.webm")
+
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+            return_value="https://storage.googleapis.com/fake-signed-url?token=abc",
+        ) as mock_sign:
+            resp = client.get(
+                f"/api/learning/sessions/{learning_sess.id}/reading-audio/{attempt.id}"
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["signed_url"] == "https://storage.googleapis.com/fake-signed-url?token=abc"
+        assert body["expires_in"] == 600
+
+        # Verify correct blob_path was passed
+        mock_sign.assert_called_once_with(
+            blob_path="reading-audio/attempts/10.webm",
+            expiration_seconds=600,
+        )
+
+    def test_403_when_different_student_accesses_session(self, db):
+        """Another student cannot access a session they don't own."""
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        attempt = _create_attempt(db, session_id=learning_sess.id)
+
+        # Log in as a DIFFERENT student
+        app = _build_app(db, current_user_id=_OTHER_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+            return_value="https://should-not-reach",
+        ):
+            resp = client.get(
+                f"/api/learning/sessions/{learning_sess.id}/reading-audio/{attempt.id}"
+            )
+
+        assert resp.status_code == 403
+        assert "Not your session" in resp.json()["detail"]
+
+    def test_404_when_session_not_found(self, db):
+        """Non-existent session_id returns 404."""
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+        ):
+            resp = client.get("/api/learning/sessions/999999/reading-audio/1")
+
+        assert resp.status_code == 404
+        assert "Session not found" in resp.json()["detail"]
+
+    def test_404_when_attempt_not_found(self, db):
+        """Attempt_id that does not exist (or belongs to another session) returns 404."""
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        # No attempt row created
+
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+        ):
+            resp = client.get(
+                f"/api/learning/sessions/{learning_sess.id}/reading-audio/888888"
+            )
+
+        assert resp.status_code == 404
+        assert "Attempt not found" in resp.json()["detail"]
+
+    def test_404_when_audio_gcs_path_is_none(self, db):
+        """Attempt exists but audio was never uploaded → 404, not 503."""
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        attempt = _create_attempt(db, session_id=learning_sess.id, audio_gcs_path=None)
+
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+        ) as mock_sign:
+            resp = client.get(
+                f"/api/learning/sessions/{learning_sess.id}/reading-audio/{attempt.id}"
+            )
+
+        assert resp.status_code == 404
+        assert "No audio recorded" in resp.json()["detail"]
+        # GCS should NOT be called when path is None
+        mock_sign.assert_not_called()
+
+    def test_503_when_signed_url_generation_fails(self, db):
+        """GCS signed URL failure → 503, not 500."""
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        attempt = _create_attempt(
+            db, session_id=learning_sess.id, audio_gcs_path="reading-audio/attempts/99.webm"
+        )
+
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+            return_value=None,  # Simulate GCS failure
+        ):
+            resp = client.get(
+                f"/api/learning/sessions/{learning_sess.id}/reading-audio/{attempt.id}"
+            )
+
+        assert resp.status_code == 503
+        assert "unavailable" in resp.json()["detail"].lower()
+
+    def test_attempt_cross_session_isolation(self, db):
+        """attempt_id from a different session is treated as not found (not just any attempt)."""
+        sess_a = _create_session(db, student_id=_STUDENT_ID)
+        # Use a different story slug to avoid the unique(student_id, story_slug) constraint
+        sess_b = LearningSession(
+            student_id=_STUDENT_ID,
+            story_slug="test-replay-story-b",
+            status="in_progress",
+            current_step=1,
+            reading_result=None,
+            full_reading_attempts=[],
+        )
+        db.add(sess_b)
+        db.commit()
+        db.refresh(sess_b)
+        # Create attempt for session B
+        attempt_b = _create_attempt(
+            db, session_id=sess_b.id, audio_gcs_path="reading-audio/attempts/200.webm"
+        )
+
+        app = _build_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        # Try to access sess_B's attempt through sess_A's URL
+        with patch(
+            "app.routes.learning.learning_audio_replay.generate_audio_signed_url",
+        ):
+            resp = client.get(
+                f"/api/learning/sessions/{sess_a.id}/reading-audio/{attempt_b.id}"
+            )
+
+        assert resp.status_code == 404
+        assert "Attempt not found" in resp.json()["detail"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests: transcribe endpoint writes audio_gcs_path (PR1 binding)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _build_transcribe_app(db_session, current_user_id: int = _STUDENT_ID) -> FastAPI:
+    """Minimal app for /reading/transcribe with all heavy deps mocked."""
+    from app.routes.learning.learning_reading import router
+    from app.auth.dependencies import get_current_user
+    from app.auth.rate_limiter import ai_limit_10_per_min
+    from app.database import get_db
+
+    app = FastAPI()
+
+    def _mock_user():
+        user = MagicMock()
+        user.id = current_user_id
+        return user
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[ai_limit_10_per_min] = lambda: None
+    app.dependency_overrides[get_db] = _override_db
+    app.include_router(router, prefix="/api")
+    return app
+
+
+class TestTranscribeWithSessionIdPersistsPath:
+
+    def test_transcribe_with_session_id_writes_audio_gcs_path(self, db):
+        """When session_id is supplied and a sync upload succeeds, audio_gcs_path is persisted."""
+        from unittest.mock import AsyncMock
+
+        learning_sess = _create_session(db, student_id=_STUDENT_ID)
+        attempt = _create_attempt(db, session_id=learning_sess.id, audio_gcs_path=None)
+
+        # Verify path is None before the call
+        assert attempt.audio_gcs_path is None
+
+        app = _build_transcribe_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        expected_path = f"reading-audio/attempts/{attempt.id}.webm"
+
+        with (
+            patch(
+                "app.routes.learning.learning_reading.transcribe_reading_audio",
+                new=AsyncMock(return_value={
+                    "transcript": "春風吹過田野",
+                    "method": "gemini",
+                    "reasoning": "正確",
+                }),
+            ),
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs_sync",
+                return_value=expected_path,
+            ) as mock_sync,
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs",
+            ),
+            patch(
+                "app.routes.learning.learning_reading.log_ai_usage",
+            ),
+        ):
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"fake_audio_bytes", "audio/webm")},
+                data={
+                    "target_text": "春風吹過田野",
+                    "session_id": str(learning_sess.id),
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["transcript"] == "春風吹過田野"
+
+        # Sync upload should have been called with the pre-computed blob_path
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args.kwargs
+        assert call_kwargs["blob_path"] == expected_path
+        assert call_kwargs["audio_bytes"] == b"fake_audio_bytes"
+
+        # The attempt row in DB should now have the path written
+        db.refresh(attempt)
+        assert attempt.audio_gcs_path == expected_path

--- a/backend/tests/test_reading_audio_replay_student.py
+++ b/backend/tests/test_reading_audio_replay_student.py
@@ -379,3 +379,58 @@ class TestTranscribeWithSessionIdPersistsPath:
         # The attempt row in DB should now have the path written
         db.refresh(attempt)
         assert attempt.audio_gcs_path == expected_path
+
+    def test_transcribe_idor_rejected_when_session_belongs_to_other_user(self, db):
+        """SECURITY: supplying another student's session_id must NOT write to their attempts.
+
+        This test covers the IDOR fix: the transcribe endpoint must verify
+        LearningSession.student_id == current_user.id before writing audio_gcs_path.
+        """
+        from unittest.mock import AsyncMock
+
+        # Create a session owned by _OTHER_STUDENT_ID
+        other_sess = _create_session(db, student_id=_OTHER_STUDENT_ID)
+        other_attempt = _create_attempt(db, session_id=other_sess.id, audio_gcs_path=None)
+
+        # Log in as _STUDENT_ID but pass the other student's session_id
+        app = _build_transcribe_app(db, current_user_id=_STUDENT_ID)
+        client = TestClient(app)
+
+        with (
+            patch(
+                "app.routes.learning.learning_reading.transcribe_reading_audio",
+                new=AsyncMock(return_value={
+                    "transcript": "攻擊者",
+                    "method": "gemini",
+                    "reasoning": "ok",
+                }),
+            ),
+            patch(
+                "app.routes.learning.learning_reading.upload_reading_audio_to_gcs_sync",
+                return_value="reading-audio/attempts/EVIL.webm",
+            ) as mock_sync,
+            patch("app.routes.learning.learning_reading.upload_reading_audio_to_gcs"),
+            patch("app.routes.learning.learning_reading.log_ai_usage"),
+        ):
+            resp = client.post(
+                "/api/reading/transcribe",
+                files={"audio": ("rec.webm", b"attacker_audio", "audio/webm")},
+                data={
+                    "target_text": "攻擊者",
+                    "session_id": str(other_sess.id),  # Attacker passes victim's session_id
+                },
+            )
+
+        # Scoring must succeed — IDOR block must NOT break the response
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["transcript"] == "攻擊者"
+
+        # The sync upload must NOT have been called — ownership check blocked it
+        mock_sync.assert_not_called()
+
+        # The other student's attempt row must still have audio_gcs_path=None
+        db.refresh(other_attempt)
+        assert other_attempt.audio_gcs_path is None, (
+            "IDOR exploit succeeded: attacker wrote to another student's attempt row"
+        )

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -36,6 +36,8 @@ interface FullReadingProps {
   initialProgress?: FullReadingStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: FullReadingStepData, immediate?: boolean) => void;
+  /** DB LearningSession integer id — used to bind uploaded audio to the attempt row (Issue #2266). */
+  dbSessionId?: number | null;
 }
 
 const FullReading: React.FC<FullReadingProps> = ({
@@ -46,6 +48,7 @@ const FullReading: React.FC<FullReadingProps> = ({
   fullReadingAttempts = [],
   initialProgress,
   onProgressChange,
+  dbSessionId,
 }) => {
   const { token, user } = useAuth();
   const storageKey = scopedStepStorageKey('fullReading_progress_', story.id);
@@ -97,6 +100,52 @@ const FullReading: React.FC<FullReadingProps> = ({
 
   const aiRating = aiFluencyInsight?.rating;
 
+  /* ---- Issue #2266: In-memory audio replay (same-session) ---- */
+  const [isPlayingReplay, setIsPlayingReplay] = useState(false);
+  const replayAudioRef = useRef<HTMLAudioElement | null>(null);
+  const replayObjectUrlRef = useRef<string | null>(null);
+
+  const handleReplayAudio = useCallback(() => {
+    const blob = audioRecorder.audioBlob;
+    if (!blob) return;
+
+    // Clean up any existing replay
+    if (replayAudioRef.current) {
+      replayAudioRef.current.pause();
+      replayAudioRef.current = null;
+    }
+    if (replayObjectUrlRef.current) {
+      URL.revokeObjectURL(replayObjectUrlRef.current);
+      replayObjectUrlRef.current = null;
+    }
+
+    const url = URL.createObjectURL(blob);
+    replayObjectUrlRef.current = url;
+    const audio = new Audio(url);
+    replayAudioRef.current = audio;
+
+    audio.onended = () => {
+      setIsPlayingReplay(false);
+      URL.revokeObjectURL(url);
+      replayObjectUrlRef.current = null;
+      replayAudioRef.current = null;
+    };
+    audio.onerror = () => setIsPlayingReplay(false);
+
+    setIsPlayingReplay(true);
+    audio.play().catch(() => setIsPlayingReplay(false));
+  }, [audioRecorder.audioBlob]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      replayAudioRef.current?.pause();
+      if (replayObjectUrlRef.current) {
+        URL.revokeObjectURL(replayObjectUrlRef.current);
+      }
+    };
+  }, []);
+
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
   const { karaokeEnabled } = useKaraoke();
   const vocabWords = useMemo(
@@ -143,6 +192,7 @@ const FullReading: React.FC<FullReadingProps> = ({
     fullText,
     token,
     storyId: story.id,
+    dbSessionId: dbSessionId ?? null,
     stopTtsAll,
     onResultReady: useCallback((newResult: SavedResult, transcript: string) => {
       setResult(newResult);
@@ -370,6 +420,21 @@ const FullReading: React.FC<FullReadingProps> = ({
                 targetText={fullText}
                 paragraphs={story.content}
               />
+
+              {/* ── Issue #2266: In-memory audio replay button ──────────── */}
+              {audioRecorder.audioBlob && (
+                <div className="flex justify-center mt-2 mb-1">
+                  <button
+                    type="button"
+                    onClick={handleReplayAudio}
+                    disabled={isPlayingReplay}
+                    className="flex items-center gap-2 px-4 py-2 rounded-full border border-accent/40 text-sm font-medium text-accent hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    aria-label="聽我的朗讀錄音"
+                  >
+                    <span>{isPlayingReplay ? '▶ 播放中…' : '▶ 聽錄音'}</span>
+                  </button>
+                </div>
+              )}
 
               {/* 正確率 + 語速 metrics card (Issue #1505) */}
               <ReadingMetricsCard

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -34,6 +34,9 @@ interface UseFullReadingSessionProps {
   fullText: string;
   token: string | null;
   storyId: string | number;
+  /** DB LearningSession integer id — passed to /reading/transcribe so the backend can bind
+   *  the uploaded audio blob to the correct ReadingAttemptHistory row (Issue #2266). */
+  dbSessionId?: number | null;
   stopTtsAll: () => void;
   onResultReady: (result: SavedResult, transcript: string) => void;
 }
@@ -64,6 +67,7 @@ export function useFullReadingSession({
   fullText,
   token,
   storyId,
+  dbSessionId,
   stopTtsAll,
   onResultReady,
 }: UseFullReadingSessionProps): UseFullReadingSessionReturn {
@@ -175,7 +179,7 @@ export function useFullReadingSession({
     if (token) {
       // I1: audio blob available → try Gemini.
       setIsTranscribing(true);
-      transcribeReading(audioBlob, fullText, durationMs, token)
+      transcribeReading(audioBlob, fullText, durationMs, token, dbSessionId ?? undefined)
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -12,6 +12,7 @@ const FullReadingPage: React.FC = () => {
     session,
     stepProgressData,
     saveStepProgressPatch,
+    dbSessionId,
   } = useLearningContext();
   const navigate = useNavigate();
 
@@ -37,6 +38,7 @@ const FullReadingPage: React.FC = () => {
       initialResult={session?.fullReadingResult ?? null}
       initialProgress={stepProgressData.step_data?.['full-reading'] as FullReadingStepData | undefined}
       onProgressChange={handleProgressChange}
+      dbSessionId={dbSessionId}
     />
   );
 };

--- a/frontend/src/services/learning/session.ts
+++ b/frontend/src/services/learning/session.ts
@@ -44,6 +44,10 @@ export async function transcribeReading(
   targetText: string,
   durationMs: number,
   token: string,
+  /** Optional DB LearningSession id — when provided the backend binds the uploaded
+   *  audio blob to the latest ReadingAttemptHistory row so the student can replay
+   *  their recording later (Issue #2266). */
+  dbSessionId?: number,
 ): Promise<TranscribeReadingResult> {
   const FALLBACK: TranscribeReadingResult = { transcript: null, method: 'fallback', reasoning: '', reason: 'error' };
 
@@ -52,6 +56,10 @@ export async function transcribeReading(
     form.append('audio', audioBlob, 'recording.webm');
     form.append('target_text', targetText);
     form.append('duration_ms', String(durationMs));
+    // Issue #2266: pass session_id so backend can bind audio to DB attempt row.
+    if (dbSessionId != null) {
+      form.append('session_id', String(dbSessionId));
+    }
 
     const res = await fetch(`${API_BASE}/api/reading/transcribe`, {
       method: 'POST',
@@ -80,6 +88,38 @@ export async function transcribeReading(
     // Network error or JSON parse failure → fallback
     console.warn('[transcribeReading] error:', err);
     return FALLBACK;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reading audio replay (Issue #2266)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a 10-minute signed URL so the student can replay their reading recording.
+ *
+ * Returns the signed URL string on success, or null if no audio was recorded
+ * for this attempt or if GCS signed URL generation fails.
+ *
+ * @param sessionId  DB LearningSession id
+ * @param attemptId  DB ReadingAttemptHistory id
+ * @param token      JWT bearer token
+ */
+export async function getReadingAudioSignedUrl(
+  sessionId: number,
+  attemptId: number,
+  token: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${API_BASE}/api/learning/sessions/${sessionId}/reading-audio/${attemptId}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.signed_url === 'string' ? data.signed_url : null;
+  } catch {
+    return null;
   }
 }
 

--- a/specs/modules/reading-transcription/INTENT.md
+++ b/specs/modules/reading-transcription/INTENT.md
@@ -8,6 +8,7 @@ owns_code:
   - backend/app/services/reading_transcription_service.py
   - backend/app/services/audio_upload_service.py
   - backend/app/routes/learning/learning_reading.py
+  - backend/app/routes/learning/learning_audio_replay.py
   - frontend/src/hooks/useAudioRecorder.ts
   - frontend/src/hooks/useFullReadingSession.ts
   - frontend/src/components/reading-steps/FullReading.tsx
@@ -17,10 +18,12 @@ owns_data: []
 spec_tests:
   - backend/specs/test_reading_transcription_spec.py
   - backend/tests/test_reading_audio_upload.py
+  - backend/tests/test_reading_audio_replay_student.py
 related_issues:
   - 2131
   - 2156
   - 2266
+  - 2266-audio-replay
 source_meetings: []
 last_reviewed: 2026-06-09
 owner: young
@@ -138,6 +141,28 @@ Frontend scoring:
 | C4 | Unsupported MIME → HTTP 415 (route gate); empty audio → HTTP 400; never HTTP 500 on AI error |
 | C5 | Route has auth (`get_current_user`), rate-limit (`ai_limit`), and size caps (`_MAX_AUDIO_BYTES`, `_MAX_TARGET_CHARS`) |
 | C6 | After transcription completes (success or graceful fallback — not on unhandled exception), audio bytes are uploaded to GCS via BackgroundTasks (fire-and-forget). Upload never blocks the response, never sets public ACL, and silently skips if READING_AUDIO_GCS_BUCKET env is unset. |
+
+---
+
+---
+
+## Audio Replay (Issue #2266 PR1)
+
+After transcription, the audio file is uploaded to GCS and the blob path is stored in
+`ReadingAttemptHistory.audio_gcs_path`.  Students can request a signed URL via:
+
+```
+GET /api/learning/sessions/{session_id}/reading-audio/{attempt_id}
+```
+
+The endpoint (`learning_audio_replay.py`) validates session ownership, fetches the attempt,
+generates a 10-minute V4 signed URL via `generate_audio_signed_url()`, and returns
+`{signed_url, expires_in: 600}`.
+
+Security invariants:
+- Only the session owner (student) may call the endpoint.
+- The bucket stays private; no public ACL is ever set.
+- Signed URLs expire after 10 minutes and are never cached server-side.
 
 ---
 

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -546,6 +546,7 @@ modules:
   - backend/app/services/reading_transcription_service.py
   - backend/app/services/audio_upload_service.py
   - backend/app/routes/learning/learning_reading.py
+  - backend/app/routes/learning/learning_audio_replay.py
   - frontend/src/hooks/useAudioRecorder.ts
   - frontend/src/hooks/useFullReadingSession.ts
   - frontend/src/components/reading-steps/FullReading.tsx
@@ -555,10 +556,12 @@ modules:
   spec_tests:
   - backend/specs/test_reading_transcription_spec.py
   - backend/tests/test_reading_audio_upload.py
+  - backend/tests/test_reading_audio_replay_student.py
   related_issues:
   - 2131
   - 2156
   - 2266
+  - 2266-audio-replay
   source_meetings: []
   last_reviewed: 2026-06-09
   owner: young


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2266

## Summary

PR1 of 2 for the reading audio replay feature. Implements the core loop: record → transcribe → persist audio path in DB → student can replay in same session.

- **DB migration**: `audio_gcs_path VARCHAR(500) NULL` added to `reading_attempt_history` and `assignment_submissions` (idempotent DDL, single-head verified)
- **Model changes**: `ReadingAttemptHistory.audio_gcs_path`, `AssignmentSubmission.audio_gcs_path`
- **GCS service**: `upload_reading_audio_to_gcs_sync()` + `generate_audio_signed_url()` (10-min signed URL, bucket stays private)
- **Student replay endpoint**: `GET /learning/sessions/{session_id}/reading-audio/{attempt_id}` — returns signed URL
- **Frontend replay button**: after evaluation completes, `▶ 聽錄音` button appears using in-memory `audioRecorder.audioBlob` (no GCS round-trip for same-session replay)
- **session_id wiring**: `dbSessionId` flows from `LearningContext` → `FullReadingPage` → `FullReading` → `useFullReadingSession` → `transcribeReading()` → FormData `session_id` field

## Security — Ownership Checks

Every new endpoint and DB write path has been audited:

| Endpoint / Path | Ownership check | Behavior on mismatch |
|---|---|---|
| `POST /reading/transcribe` (audio upload to DB) | `LearningSession.student_id == current_user.id` verified before any DB write | Silent skip — upload aborted, score unaffected, WARNING logged |
| `GET /sessions/{id}/reading-audio/{attempt_id}` | `LearningSession.student_id == current_user.id` | 403 Forbidden |
| Signed URL generation | Only issued after ownership check passes | N/A (never reached) |

Bucket is private (no `make_public`, no `predefined_acl`). Signed URLs are generated server-side, 10-min expiry, never stored in DB.

## Retention policy

- Evaluated attempts → keep permanently (no time-based expiry, no lifecycle rules on bucket)
- Discarded takes → frontend does not upload (no blob sent to API)
- GCS orphans → daily cron reconciliation (PR2)
- Cascade deletes → on attempt/session/assignment deletion (PR2)

## Tests

9 pytest tests in `backend/tests/test_reading_audio_replay_student.py`:
- Happy path: upload bound to attempt, signed URL returned
- No audio: returns 404
- Wrong user (IDOR): `test_transcribe_idor_rejected_when_session_belongs_to_other_user` — attacker's `session_id` rejected, `audio_gcs_path` stays `None`, score unaffected
- Cross-session isolation: cannot fetch attempt from another session
- GCS failure: 503 on signed URL error
- `session_id` absent: falls back to fire-and-forget (debug mode)

## PR2 (separate branch — not in this PR)

- Teacher-side replay endpoint (classroom/assignment ownership check)
- Daily orphan reconciliation cron
- Cascade GCS deletion on attempt/session/assignment deletion