### PR TITLE
fix(reading): P0 — LiveTutorControls TDZ crash 修復（逐段朗讀白屏）(Related to #2279)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -129,15 +129,11 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [isPlayingBack, setIsPlayingBack] = useState(false);
 
-  // Reset playback state when pending review ends
-  useEffect(() => {
-    if (!recordingPendingReview) {
-      stopPlaybackSync();
-    }
-  }, [recordingPendingReview, stopPlaybackSync]);
-
   /** Stop playback synchronously — used both by the toggle button and before
-   *  delegating 取消/重錄 so that clearRecording() doesn't revoke a live URL. */
+   *  delegating 取消/重錄 so that clearRecording() doesn't revoke a live URL.
+   *  NOTE: declared BEFORE the reset useEffect below — that effect lists
+   *  stopPlaybackSync in its deps, so a TDZ ReferenceError crashes the whole
+   *  逐段朗讀 step if this const is declared after it (Issue #2279 regression). */
   const stopPlaybackSync = useCallback(() => {
     if (audioRef.current) {
       audioRef.current.onended = null;
@@ -147,6 +143,13 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
     }
     setIsPlayingBack(false);
   }, []);
+
+  // Reset playback state when pending review ends
+  useEffect(() => {
+    if (!recordingPendingReview) {
+      stopPlaybackSync();
+    }
+  }, [recordingPendingReview, stopPlaybackSync]);
 
   const handlePlayback = useCallback(() => {
     if (!recordingAudioUrl) return;


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## P0 修復
#2279 把 `const stopPlaybackSync = useCallback(...)` 宣告在一個「deps 含 stopPlaybackSync」的 `useEffect` **之後** → 首次 render TDZ `ReferenceError: Cannot access 'stopPlaybackSync' before initialization` → **逐段朗讀步驟一進去就白屏崩潰**（已用 git blame + Node 重現 + staging 線上 minified bundle 三重證實）。

## 改動
把 `stopPlaybackSync` useCallback 移到 reset useEffect 之前。**純移位、無邏輯變更**。本機 `vite build` 通過。

## Test plan
- [ ] CI build / E2E
- [ ] merge 後 staging /learn/{id}/tutor 不再白屏（playwright 驗）