### PR TITLE
fix(teacher): include step_progress in session report API (Related to #2083)

### DIFF
--- a/backend/app/routes/teacher/teacher_student_reports.py
+++ b/backend/app/routes/teacher/teacher_student_reports.py
@@ -81,6 +81,7 @@ def get_teacher_session_report(
         teacher_reviewed_at=session.teacher_reviewed_at,
         started_at=session.started_at,
         completed_at=session.completed_at,
+        step_progress=session.step_progress,
     )
 
 


### PR DESCRIPTION
## Summary
- Follow-up to #2293: teacher report API now returns `step_progress` from DB
- Without this, `SpotlightStrategyRecord` never received reading-strategy answers

## Test plan
- [ ] curl teacher report session 584 → `step_progress.step_data.reading-strategy` present
- [ ] Staging: 李老師 → 小明 session 584 → 閱讀聚光燈 accordion visible

Made with [Cursor](https://cursor.com)