### PR TITLE
feat(spotlight): wire test15 fixtures into spotlight_v2 loader (Related to #2205)

### DIFF
--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -105,6 +105,8 @@ ENRICHMENT_FIELDS = (
     # 紙本表格 (#1685): some Layer-2 lessons (G7-L28, G7-L30) carry extracted
     # tables; copy onto matching Layer-1 entries to preserve back-compat.
     "tables",
+    # Block-sequence spotlight v2 (#2205) — Layer-2 fixture onto Layer-1 back-compat slots
+    "spotlight_v2",
 )
 
 
@@ -275,6 +277,8 @@ def load_layer1_lessons() -> list[dict]:
             ),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
             "tables": data.get("tables"),
+            # Block-sequence spotlight v2 (#2205 dev7 + test15)
+            "spotlight_v2": load_spotlight_v2(data.get("grade_code", "")),
             "_layer": 1,
         }
         lessons.append(lesson)

--- a/backend/app/services/spotlight_contract.py
+++ b/backend/app/services/spotlight_contract.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import yaml
 
+from app.services.lesson_code_normalization import normalize_manifest_code
 from app.services.spotlight_block_model import eval_g6_l22_acceptance
 
 _DATA_ROOT = Path(__file__).resolve().parent.parent.parent / "data" / "lessons"
@@ -46,6 +47,25 @@ TEST15_LESSONS = (
     "G8-SL8",
     "G9-SL9",
 )
+
+# Eval fixture id (G*-SL*) → platform catalog lesson_code.
+# G8 sub-letter slots differ from naive SL→L numbering (#2205).
+TEST15_FIXTURE_TO_CATALOG: dict[str, str] = {
+    "G4-SL10": "G4-L10",
+    "G4-SL13": "G4-L13",
+    "G5-SL7": "G5-L7",
+    "G5-SL10": "G5-L10",
+    "G5-SL26": "G5-L26",
+    "G6-SL3": "G6-L3",
+    "G6-SL8": "G6-L8",
+    "G6-SL14": "G6-L14",
+    "G7-SL9": "G7-L9",
+    "G7-SL17": "G7-L17",
+    "G7-SL19": "G7-L19",
+    "G8-SL4": "G8-L3b",
+    "G8-SL8": "G8-L6b",
+    "G9-SL9": "G9-L9",
+}
 
 DEV7_LESSONS = (
     "G6-L22",
@@ -151,6 +171,23 @@ def load_spotlight_yaml(path: Path) -> dict[str, Any]:
 
 def load_gold_manifest() -> dict[str, Any]:
     return json.loads(GOLD_MANIFEST.read_text(encoding="utf-8"))
+
+
+def load_test15_gold_manifest() -> dict[str, Any]:
+    return json.loads(TEST15_GOLD_MANIFEST.read_text(encoding="utf-8"))
+
+
+_CATALOG_TO_TEST15_FIXTURE: dict[str, str] = {
+    normalize_manifest_code(catalog): fixture
+    for fixture, catalog in TEST15_FIXTURE_TO_CATALOG.items()
+}
+
+TEST15_CATALOG_CODES = frozenset(_CATALOG_TO_TEST15_FIXTURE.keys())
+
+
+def test15_fixture_for_catalog(catalog_code: str) -> str | None:
+    """Map platform lesson_code → test15 fixture id (G*-SL*), or None."""
+    return _CATALOG_TO_TEST15_FIXTURE.get(normalize_manifest_code(catalog_code))
 
 
 def fingerprint_spotlight(spotlight: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/spotlight_v2_loader.py
+++ b/backend/app/services/spotlight_v2_loader.py
@@ -1,15 +1,27 @@
 """
-spotlight_v2_loader.py — load checked-in block-sequence spotlight schemas (dev7).
+spotlight_v2_loader.py — load checked-in block-sequence spotlight schemas (dev7 + test15).
 """
 
-from app.services.spotlight_contract import DEV7_LESSONS, load_dev7_spotlight
+from app.services.lesson_code_normalization import normalize_manifest_code
+from app.services.spotlight_contract import (
+    DEV7_LESSONS,
+    TEST15_CATALOG_CODES,
+    load_dev7_spotlight,
+    load_test15_spotlight,
+    test15_fixture_for_catalog,
+)
 
 
 def is_spotlight_v2_lesson(lesson_code: str) -> bool:
-    return lesson_code in DEV7_LESSONS
+    norm = normalize_manifest_code(lesson_code)
+    return norm in DEV7_LESSONS or norm in TEST15_CATALOG_CODES
 
 
 def load_spotlight_v2(lesson_code: str) -> dict | None:
-    if not is_spotlight_v2_lesson(lesson_code):
-        return None
-    return load_dev7_spotlight(lesson_code)
+    norm = normalize_manifest_code(lesson_code)
+    if norm in DEV7_LESSONS:
+        return load_dev7_spotlight(norm)
+    fixture_id = test15_fixture_for_catalog(norm)
+    if fixture_id:
+        return load_test15_spotlight(fixture_id)
+    return None

--- a/backend/specs/test_spotlight_v2_spec.py
+++ b/backend/specs/test_spotlight_v2_spec.py
@@ -13,11 +13,15 @@ import pytest
 
 from app.services.spotlight_contract import (
     DEV7_LESSONS,
+    TEST15_CATALOG_CODES,
+    TEST15_LESSONS,
     compare_to_gold,
     count_mcq_option_guides,
     eval_spotlight_v2,
     load_dev7_spotlight,
     load_gold_manifest,
+    load_test15_gold_manifest,
+    load_test15_spotlight,
     semantic_eval_spotlight,
     validate_block_structure,
 )
@@ -27,6 +31,11 @@ from app.services.spotlight_v2_loader import is_spotlight_v2_lesson, load_spotli
 @pytest.fixture(scope="module")
 def gold_manifest() -> dict:
     return load_gold_manifest()
+
+
+@pytest.fixture(scope="module")
+def test15_gold_manifest() -> dict:
+    return load_test15_gold_manifest()
 
 
 @pytest.mark.parametrize("lesson_id", DEV7_LESSONS)
@@ -107,6 +116,67 @@ def test_non_dev7_lesson_returns_none():
     assert load_spotlight_v2("G4-L1") is None
 
 
+@pytest.mark.parametrize("catalog_code", sorted(TEST15_CATALOG_CODES))
+def test_test15_loader_exposes_spotlight_v2(catalog_code: str):
+    assert is_spotlight_v2_lesson(catalog_code)
+    loaded = load_spotlight_v2(catalog_code)
+    assert loaded is not None
+    assert loaded.get("strategy_type")
+    assert loaded.get("blocks")
+
+
+@pytest.mark.parametrize("fixture_id", TEST15_LESSONS)
+def test_test15_fixture_exists(fixture_id: str):
+    sp = load_test15_spotlight(fixture_id)
+    assert sp is not None, f"missing fixture {fixture_id}.spotlight.yml"
+    assert sp.get("blocks"), f"{fixture_id}: empty blocks"
+
+
+@pytest.mark.parametrize("fixture_id", TEST15_LESSONS)
+def test_test15_gold_fingerprint(fixture_id: str, test15_gold_manifest: dict):
+    sp = load_test15_spotlight(fixture_id)
+    result = compare_to_gold(
+        fixture_id,
+        sp,
+        test15_gold_manifest["lessons"][fixture_id],
+    )
+    assert result["match"], f"{fixture_id} gold drift: {result.get('diffs')}"
+
+
+@pytest.mark.parametrize("fixture_id", TEST15_LESSONS)
+def test_test15_eval_passes(fixture_id: str):
+    sp = load_test15_spotlight(fixture_id)
+    ev = eval_spotlight_v2(sp, fixture_id)
+    assert ev["guide_retained"], f"{fixture_id}: no guide blocks"
+    assert ev["mcq_leakage"] == 0, f"{fixture_id}: MCQ leaked into spotlight"
+    assert ev["answer_recall"] >= 0.99, f"{fixture_id}: null answers in single/multi"
+    assert ev["pass"], (
+        f"{fixture_id}: struct/semantic errors "
+        f"{ev.get('struct_errors')} {ev.get('semantic')}"
+    )
+
+
+def test_g4_l10_catalog_code_loads_test15_fixture():
+    loaded = load_spotlight_v2("G4-L10")
+    assert loaded is not None
+    assert "美好的一天" in " ".join(
+        " ".join(b.get("paragraphs") or [])
+        for b in loaded.get("blocks") or []
+        if b.get("type") == "passage"
+    ) or any(
+        "情緒" in (b.get("text") or "")
+        for b in loaded.get("blocks") or []
+        if b.get("type") == "guide"
+    )
+
+
+def test_g8_l3b_maps_to_test15_plant_meat_fixture():
+    loaded = load_spotlight_v2("G8-L3b")
+    assert loaded is not None
+    guides = [b.get("text", "") for b in loaded["blocks"] if b["type"] == "guide"]
+    assert any("植物肉" in g for g in guides)
+
+
 def test_validate_rejects_empty_guide():
     errors = validate_block_structure([{"type": "guide", "text": "  "}])
     assert any("guide missing text" in e for e in errors)
@@ -114,3 +184,7 @@ def test_validate_rejects_empty_guide():
 
 def test_gold_manifest_covers_all_dev7(gold_manifest: dict):
     assert set(gold_manifest["lessons"].keys()) == set(DEV7_LESSONS)
+
+
+def test_test15_gold_manifest_covers_all_test15(test15_gold_manifest: dict):
+    assert set(test15_gold_manifest["lessons"].keys()) == set(TEST15_LESSONS)

--- a/backend/specs/test_spotlight_v2_spec.py
+++ b/backend/specs/test_spotlight_v2_spec.py
@@ -177,6 +177,16 @@ def test_g8_l3b_maps_to_test15_plant_meat_fixture():
     assert any("植物肉" in g for g in guides)
 
 
+def test_layer1_g6_l03_lesson_dict_has_spotlight_v2():
+    from app.services.lesson_loader import get_lesson_by_code
+
+    lesson = get_lesson_by_code("G6-L03")
+    assert lesson is not None
+    sp = lesson.get("spotlight_v2")
+    assert sp is not None
+    assert sp.get("strategy_type") == "scientific_inquiry"
+
+
 def test_validate_rejects_empty_guide():
     errors = validate_block_structure([{"type": "guide", "text": "  "}])
     assert any("guide missing text" in e for e in errors)

--- a/scripts/run_spotlight_dev_gate.sh
+++ b/scripts/run_spotlight_dev_gate.sh
@@ -28,8 +28,11 @@ if not r['pass']:
     sys.exit(1)
 "
 
-echo "=== [2/4] Gold contract (dev7 checked-in fixtures) ==="
+echo "=== [2/6] Gold contract (dev7 checked-in fixtures) ==="
 python3 scripts/spotlight_contract.py --dev7
+
+echo "=== [2b/6] Gold contract (test15 checked-in fixtures) ==="
+python3 scripts/spotlight_contract.py --test15
 
 echo "=== [3/6] Backend pytest (spotlight block model TDD) ==="
 cd backend && python -m pytest specs/test_spotlight_block_model_spec.py -q --tb=short


### PR DESCRIPTION
## Summary
- Extend `spotlight_v2_loader` to serve 14 TEST-set lessons (not just dev7)
- Add explicit `TEST15_FIXTURE_TO_CATALOG` map (G8 sub-letter slots need manual mapping)
- Add loader/gold/eval pytest coverage + `--test15` step in dev gate script

## Test plan
- [x] `python3 scripts/spotlight_contract.py --test15` → 14/14 PASS
- [x] `cd backend && python -m pytest specs/test_spotlight_v2_spec.py -q` → 94 passed
- [ ] Staging: 小明 → G4-L10 `/learn/{id}/reading-strategy` → BlockSequenceRenderer (not legacy StrategyExercise)
- [ ] Staging: G8-L3b 植物肉 lesson loads test15 fixture


Made with [Cursor](https://cursor.com)