### PR TITLE
fix: 音檔上傳時機 — 評分後才上傳，不擋分數顯示 (Fixes #2297)

### DIFF
--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -18,6 +18,7 @@ Splits the original monolithic learning.py (1,881 lines) into focused sub-module
 - mcq_attempt.py                   — MCQ attempt telemetry endpoint (Issue #1507)
 - toolbox.py                       — Practice toolbox session endpoints (Issue #1463 / #1460)
 - learning_audio_replay.py         — Student reading audio signed-URL replay (Issue #2266)
+- learning_save_audio.py           — Deferred GCS upload for accepted reading takes (Issue #2297)
 
 The composed router is re-exported as `router` so that main.py's existing
 `app.include_router(learning.router, prefix="/api")` continues to work unchanged.
@@ -44,6 +45,7 @@ from .mcq_attempt import router as mcq_attempt_router
 from .toolbox import router as toolbox_router
 from .learning_annotations import router as annotations_router
 from .learning_audio_replay import router as audio_replay_router
+from .learning_save_audio import router as save_audio_router
 
 router = APIRouter(tags=["learning"])
 
@@ -65,5 +67,6 @@ router.include_router(mcq_attempt_router)
 router.include_router(toolbox_router)
 router.include_router(annotations_router)
 router.include_router(audio_replay_router)
+router.include_router(save_audio_router)
 
 __all__ = ["router"]

--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import time
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -23,11 +23,6 @@ from pypinyin import Style, lazy_pinyin
 from ...services.reading_transcription_service import (
     ALLOWED_AUDIO_MIMES,
     transcribe_reading_audio,
-)
-from ...models.session import ReadingAttemptHistory
-from ...services.audio_upload_service import (
-    upload_reading_audio_to_gcs,
-    upload_reading_audio_to_gcs_sync,
 )
 
 router = APIRouter()
@@ -489,21 +484,6 @@ async def evaluate_reading_endpoint(
 _MAX_AUDIO_BYTES = 10 * 1024 * 1024   # 10 MB
 _MAX_TARGET_CHARS = 3000               # ≈ longest G9 lesson
 
-# MIME → extension map used when constructing attempt-bound GCS paths
-_MIME_TO_EXT_SYNC: dict[str, str] = {
-    "audio/webm": ".webm",
-    "audio/mp4": ".mp4",
-    "audio/mpeg": ".mp3",
-    "audio/ogg": ".ogg",
-    "audio/wav": ".wav",
-    "audio/x-wav": ".wav",
-}
-
-
-def _normalise_mime_for_path(mime_type: str) -> str:
-    """Strip codec suffix for extension lookup: 'audio/webm;codecs=opus' → 'audio/webm'."""
-    return mime_type.split(";")[0].strip()
-
 
 class TranscribeReadingResponse(BaseModel):
     """Response schema for POST /api/reading/transcribe."""
@@ -535,11 +515,13 @@ class TranscribeReadingResponse(BaseModel):
         "reason: <timeout|safety|decode|empty|error>} (HTTP 200) so the frontend can show "
         "a fallback alert and use the Web Speech transcript.\n"
         "Rate-limited: 10 requests per minute per user.\n"
-        "Audio: ≤10 MB, ≤120 s; MIME: audio/webm, audio/mp4, audio/ogg, audio/wav."
+        "Audio: ≤10 MB, ≤120 s; MIME: audio/webm, audio/mp4, audio/ogg, audio/wav.\n\n"
+        "NOTE (Issue #2297): GCS audio upload is NO LONGER done here.  The frontend\n"
+        "must call POST /reading/save-audio after the score is accepted to persist the\n"
+        "audio blob.  The session_id parameter is kept for API compatibility but ignored."
     ),
 )
 async def transcribe_reading_endpoint(
-    background_tasks: BackgroundTasks,
     audio: UploadFile = File(
         ...,
         description="Audio blob from browser MediaRecorder (WebM/MP4/OGG/WAV, max 10 MB)",
@@ -552,12 +534,11 @@ async def transcribe_reading_endpoint(
         default=None,
         description="Recording duration in milliseconds (informational, optional)",
     ),
-    session_id: int | None = Form(
+    session_id: int | None = Form(  # noqa: ARG001  # kept for API compat, ignored (Issue #2297)
         default=None,
         description=(
-            "Optional LearningSession DB id.  When provided the audio is "
-            "uploaded synchronously and the GCS path is written to the latest "
-            "ReadingAttemptHistory row for this session (Issue #2266)."
+            "DEPRECATED (Issue #2297): no longer used.  GCS upload is deferred to "
+            "POST /reading/save-audio which is called only after score is accepted."
         ),
     ),
     current_user: User = Depends(get_current_user),
@@ -571,6 +552,10 @@ async def transcribe_reading_endpoint(
     root cause fix for Issue #2156 (Chrome records webm; Gemini only accepts ogg/wav/etc).
     On any Gemini failure the route returns HTTP 200 with method='fallback' and a reason
     field so the frontend can display the fallback alert banner (I4).
+
+    Issue #2297: GCS audio upload has been removed from this endpoint.
+    Only the Gemini transcription is performed here.  The frontend calls
+    POST /reading/save-audio after the student accepts the score.
     """
     # ── 1. Validate MIME type (cheap, before reading bytes) ──────────────────
     raw_mime = audio.content_type or "audio/webm"
@@ -626,85 +611,15 @@ async def transcribe_reading_endpoint(
     )
     latency_ms = int((time.monotonic() - start_time) * 1000)
 
-    # ── 4.5. Upload audio to GCS for student replay (Issue #2266) ───────────
-    # When session_id is provided: sync upload → write blob path to DB.
-    # When session_id is absent:  fire-and-forget background upload (debug only).
-    # Upload failures are logged as WARNING; never affect the student score.
-    # Security: bucket is private, no public ACL, path NOT returned to client here.
-    if session_id is not None:
-        # ── SECURITY: verify session ownership BEFORE touching DB (IDOR fix) ──
-        # Without this check any authenticated user could write to another
-        # student's attempt row by supplying a different session_id.
-        owned_session = (
-            db.query(LearningSession)
-            .filter(
-                LearningSession.id == session_id,
-                LearningSession.student_id == current_user.id,
-            )
-            .first()
-        )
-        if owned_session is None:
-            # Log but do NOT raise — audio upload failure must never block scoring.
-            logger.warning(
-                "transcribe: session_id=%d does not belong to user=%d; "
-                "skipping GCS audio upload",
-                session_id,
-                current_user.id,
-            )
-            # Fall through to return without uploading.
-        else:
-            attempt = (
-                db.query(ReadingAttemptHistory)
-                .filter(ReadingAttemptHistory.session_id == session_id)
-                .order_by(ReadingAttemptHistory.attempt_no.desc())
-                .first()
-            )
-        if owned_session is not None:
-            if attempt is not None:
-                base_mime = _normalise_mime_for_path(raw_mime)
-                ext = _MIME_TO_EXT_SYNC.get(base_mime, ".audio")
-                blob_path = f"reading-audio/attempts/{attempt.id}{ext}"
-                stored_path = upload_reading_audio_to_gcs_sync(
-                    audio_bytes=audio_bytes,
-                    mime_type=raw_mime,
-                    blob_path=blob_path,
-                )
-                if stored_path is not None:
-                    attempt.audio_gcs_path = stored_path
-                    try:
-                        db.commit()
-                    except Exception as commit_exc:
-                        logger.warning(
-                            "Failed to persist audio_gcs_path for attempt %d: %s",
-                            attempt.id,
-                            commit_exc,
-                        )
-                        db.rollback()
-            else:
-                # Owned session but no attempt row yet — fire-and-forget for debug
-                logger.info(
-                    "transcribe: session_id=%d has no ReadingAttemptHistory yet; "
-                    "falling back to fire-and-forget upload",
-                    session_id,
-                )
-                background_tasks.add_task(
-                    upload_reading_audio_to_gcs,
-                    audio_bytes=audio_bytes,
-                    mime_type=raw_mime,
-                    user_id=current_user.id,
-                    lesson_id=None,
-                    duration_ms=duration_ms,
-                )
-    else:
-        # Stateless call — fire-and-forget for debug purposes only.
-        background_tasks.add_task(
-            upload_reading_audio_to_gcs,
-            audio_bytes=audio_bytes,
-            mime_type=raw_mime,
-            user_id=current_user.id,
-            lesson_id=None,  # transcribe endpoint has no lesson context here
-            duration_ms=duration_ms,
-        )
+    # ── 4.5. GCS audio upload deferred to POST /reading/save-audio (Issue #2297) ──
+    # Audio is now uploaded only after the student accepts the score, not at
+    # transcription time.  This prevents orphaned blobs from discarded takes.
+    logger.debug(
+        "transcribe: upload deferred to /reading/save-audio endpoint (Issue #2297); "
+        "user=%d session_id=%s",
+        current_user.id,
+        session_id,
+    )
 
     # ── 5. Log usage when Gemini succeeded ───────────────────────────────────
     if result.get("method") == "gemini":

--- a/backend/app/routes/learning/learning_save_audio.py
+++ b/backend/app/routes/learning/learning_save_audio.py
@@ -1,0 +1,204 @@
+"""POST /reading/save-audio — deferred GCS upload for accepted reading takes (Issue #2297).
+
+Design rationale (Issue #2297):
+  Previously, audio was uploaded to GCS inside /reading/transcribe at STT time.
+  This caused orphaned blobs whenever a student re-recorded, abandoned, or hit an
+  STT error — the audio was already in GCS with no corresponding accepted score.
+
+  New flow:
+    1. Student records → POST /reading/transcribe  (STT only, NO GCS upload)
+    2. Frontend receives score and shows result to student
+    3. Student accepts (does NOT re-record) → frontend calls POST /reading/save-audio
+       with the same audio blob + session_id
+    4. This endpoint performs the GCS upload and writes audio_gcs_path to the DB
+
+  Result:  only accepted takes ever reach GCS.
+
+Security:
+  - session_id ownership is checked (IDOR prevention).
+  - Bucket is private; no public ACL is set here.
+  - Upload failure returns {"ok": false} — NEVER raises (non-fatal).
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...auth.rate_limiter import ai_limit_10_per_min
+from ...database import get_db
+from ...models.session import LearningSession, ReadingAttemptHistory
+from ...models.user import User
+from ...services.audio_upload_service import upload_reading_audio_to_gcs_sync
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Re-use the same MIME → extension map as the service layer.
+_MIME_TO_EXT: dict[str, str] = {
+    "audio/webm": ".webm",
+    "audio/mp4": ".mp4",
+    "audio/mpeg": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+}
+
+_MAX_AUDIO_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _normalise_mime(mime_type: str) -> str:
+    """Strip codec suffix: 'audio/webm;codecs=opus' → 'audio/webm'."""
+    return mime_type.split(";")[0].strip()
+
+
+class SaveAudioResponse(BaseModel):
+    ok: bool
+    audio_gcs_path: str | None = None
+    reason: str | None = None
+
+
+@router.post(
+    "/reading/save-audio",
+    response_model=SaveAudioResponse,
+    dependencies=[Depends(ai_limit_10_per_min)],
+    summary="Upload accepted reading take audio to GCS (Issue #2297)",
+    description=(
+        "Called by the frontend AFTER the student accepts a reading score.\n"
+        "Uploads the audio blob to GCS and writes the path to the latest\n"
+        "ReadingAttemptHistory row for this session.\n\n"
+        "Upload failure returns {ok: false} — never raises (non-fatal).\n"
+        "IDOR: session must belong to current_user.\n"
+        "Audio: ≤10 MB; MIME: audio/webm, audio/mp4, audio/ogg, audio/wav, audio/mpeg."
+    ),
+)
+async def save_reading_audio(
+    audio: UploadFile = File(
+        ...,
+        description="Audio blob from browser MediaRecorder (the same blob as used for transcription)",
+    ),
+    session_id: int = Form(
+        ...,
+        description="DB LearningSession id — used to locate the ReadingAttemptHistory row",
+    ),
+    attempt_id: int | None = Form(
+        default=None,
+        description=(
+            "Optional ReadingAttemptHistory id.  When provided, that specific row is "
+            "updated.  When omitted, the latest row for this session is used."
+        ),
+    ),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SaveAudioResponse:
+    """Upload an accepted student reading take to GCS and bind it to the DB attempt row.
+
+    Fail-safe: any upload or DB error is logged as WARNING and returns {ok: false}.
+    This endpoint never raises HTTPException for upload/DB failures so a network
+    hiccup cannot prevent the student from seeing their score.
+
+    IDOR protection: the session_id must belong to current_user.  A mismatch is
+    logged as WARNING and returns {ok: false} without revealing session existence.
+    """
+    # ── 1. Read and size-cap audio ────────────────────────────────────────────
+    audio_bytes = await audio.read()
+    if len(audio_bytes) == 0 or len(audio_bytes) > _MAX_AUDIO_BYTES:
+        logger.warning(
+            "save-audio: invalid audio size %d bytes for user=%d session=%d",
+            len(audio_bytes),
+            current_user.id,
+            session_id,
+        )
+        return SaveAudioResponse(ok=False, reason="invalid_audio_size")
+
+    raw_mime = audio.content_type or "audio/webm"
+
+    # ── 2. IDOR: verify session ownership ────────────────────────────────────
+    owned_session = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.id == session_id,
+            LearningSession.student_id == current_user.id,
+        )
+        .first()
+    )
+    if owned_session is None:
+        logger.warning(
+            "save-audio: session_id=%d does not belong to user=%d; skipping upload",
+            session_id,
+            current_user.id,
+        )
+        return SaveAudioResponse(ok=False, reason="session_not_found")
+
+    # ── 3. Locate the ReadingAttemptHistory row ───────────────────────────────
+    if attempt_id is not None:
+        attempt = (
+            db.query(ReadingAttemptHistory)
+            .filter(
+                ReadingAttemptHistory.id == attempt_id,
+                ReadingAttemptHistory.session_id == session_id,
+            )
+            .first()
+        )
+    else:
+        attempt = (
+            db.query(ReadingAttemptHistory)
+            .filter(ReadingAttemptHistory.session_id == session_id)
+            .order_by(ReadingAttemptHistory.attempt_no.desc())
+            .first()
+        )
+
+    if attempt is None:
+        logger.warning(
+            "save-audio: no ReadingAttemptHistory for session_id=%d attempt_id=%s user=%d",
+            session_id,
+            attempt_id,
+            current_user.id,
+        )
+        return SaveAudioResponse(ok=False, reason="attempt_not_found")
+
+    # ── 4. Upload to GCS ─────────────────────────────────────────────────────
+    base_mime = _normalise_mime(raw_mime)
+    ext = _MIME_TO_EXT.get(base_mime, ".audio")
+    blob_path = f"reading-audio/attempts/{attempt.id}{ext}"
+
+    stored_path = upload_reading_audio_to_gcs_sync(
+        audio_bytes=audio_bytes,
+        mime_type=raw_mime,
+        blob_path=blob_path,
+    )
+
+    if stored_path is None:
+        # GCS unavailable or upload failed — fail-safe: log, return ok=False.
+        logger.warning(
+            "save-audio: GCS upload failed for attempt=%d session=%d user=%d",
+            attempt.id,
+            session_id,
+            current_user.id,
+        )
+        return SaveAudioResponse(ok=False, reason="gcs_upload_failed")
+
+    # ── 5. Persist path to DB ────────────────────────────────────────────────
+    try:
+        attempt.audio_gcs_path = stored_path
+        db.commit()
+        logger.info(
+            "save-audio: OK attempt=%d session=%d user=%d path=%s",
+            attempt.id,
+            session_id,
+            current_user.id,
+            stored_path,
+        )
+        return SaveAudioResponse(ok=True, audio_gcs_path=stored_path)
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "save-audio: DB commit failed for attempt=%d session=%d: %s",
+            attempt.id,
+            session_id,
+            exc,
+        )
+        return SaveAudioResponse(ok=False, reason="db_commit_failed")

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -7,7 +7,7 @@ import { scopedStepStorageKey, isToolboxMode } from '../../../services/learningS
 import { useLiveTutorSpeech } from '../../../hooks/useLiveTutorSpeech';
 import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 import { useAudioRecorder } from '../../../hooks/useAudioRecorder';
-import { transcribeReading } from '../../../services/learning/session';
+import { transcribeReading, saveReadingAudio } from '../../../services/learning/session';
 import { useAuth } from '../../../contexts/AuthContext';
 import { splitIntoSentences } from '../../../utils/localEval';
 import { normalizePunctuationToChinese } from '../../../utils/textDiff';
@@ -74,6 +74,9 @@ interface LiveTutorProps {
   initialProgress?: TutorStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: TutorStepData, immediate?: boolean) => void;
+  /** DB LearningSession integer id — used to bind accepted audio to the attempt row
+   *  via POST /reading/save-audio (Issue #2297). Optional: upload is skipped if absent. */
+  dbSessionId?: number | null;
 }
 
 const LiveTutor: React.FC<LiveTutorProps> = ({
@@ -86,6 +89,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   initialCompletedParagraphs,
   initialProgress,
   onProgressChange,
+  dbSessionId,
 }) => {
   const { px: fontSizePx } = useFontSize();
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
@@ -442,6 +446,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             currentLineIndex,
             transcriptSource,
           );
+          // Issue #2297: upload audio AFTER evaluation (score) is sent to the UI.
+          // Only upload when transcription succeeded (Gemini confirmed the take).
+          // Fail-safe: .catch() ensures upload failure never blocks the student.
+          if (audioBlob && token && dbSessionId != null && transcriptSource === 'gemini') {
+            saveReadingAudio(audioBlob, dbSessionId, undefined, token)
+              .catch((err) => console.warn('[LiveTutor] saveReadingAudio error:', err));
+          }
         }
       }
     } finally {
@@ -452,6 +463,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     sentenceRetry.retrySentenceInfoRef,
     currentLineIndex,
     token,
+    dbSessionId,
     story.content,
     clearParagraphFallback,
     setParagraphFallbackReason,

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -19,7 +19,7 @@ import { DiffToken } from '../types';
 import { useAudioRecorder } from './useAudioRecorder';
 import { cancelTts } from '../services/ttsApi';
 import { saveReadingHistory } from '../services/readingHistoryApi';
-import { transcribeReading } from '../services/learning/session';
+import { transcribeReading, saveReadingAudio } from '../services/learning/session';
 
 export interface SavedResult {
   matchRate: number;
@@ -146,7 +146,7 @@ export function useFullReadingSession({
      * NOTE: Real audio E2E requires a microphone — cannot be tested headless.
      *       The transcribeReading() wrapper is unit-tested with mocks (vitest). */
 
-    const _evaluate = (finalTranscript: string) => {
+    const _evaluate = (finalTranscript: string, capturedAudioBlob: Blob) => {
       const fluency = analyzeFluency({
         spoken: cleanChineseText(finalTranscript),
         target: fullText,
@@ -161,6 +161,14 @@ export function useFullReadingSession({
         errorBreakdown: fluency.errorBreakdown,
       };
       onResultReady(newResult, cleanChineseText(finalTranscript));
+
+      // Issue #2297: upload audio AFTER score is returned to UI (deferred upload).
+      // Fail-safe: .catch() ensures upload failure never affects score display.
+      if (token && dbSessionId != null) {
+        saveReadingAudio(capturedAudioBlob, dbSessionId, undefined, token)
+          .catch((err) => console.warn('[FullReading] saveReadingAudio error:', err));
+      }
+
       const durationSec = fluency.durationMs / 1000;
       if (token && durationSec > 0) {
         saveReadingHistory(
@@ -179,12 +187,14 @@ export function useFullReadingSession({
     if (token) {
       // I1: audio blob available → try Gemini.
       setIsTranscribing(true);
-      transcribeReading(audioBlob, fullText, durationMs, token, dbSessionId ?? undefined)
+      // Issue #2297: no longer pass session_id to transcribeReading — upload is
+      // deferred to saveReadingAudio called inside _evaluate after score is ready.
+      transcribeReading(audioBlob, fullText, durationMs, token)
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {
             // Gemini success (I1): Gemini transcript is the sole scoring source.
-            _evaluate(result.transcript);
+            _evaluate(result.transcript, audioBlob);
           } else {
             // Gemini failed — cannot fall back to Web Speech (removed, Issue #2266).
             setMicError('辨識失敗，請重錄一次');
@@ -198,7 +208,7 @@ export function useFullReadingSession({
       // No token — cannot reach Gemini.
       setMicError('未偵測到語音，請重試。');
     }
-  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.stopAndGetBlob]);
+  }, [fullText, stopSession, token, storyId, dbSessionId, onResultReady, audioRecorder.stopAndGetBlob]);
 
   return {
     isSessionActive,

--- a/frontend/src/pages/learning/TutorPage.tsx
+++ b/frontend/src/pages/learning/TutorPage.tsx
@@ -14,6 +14,7 @@ const TutorPage: React.FC = () => {
     handleParagraphComplete,
     stepProgressData,
     saveStepProgressPatch,
+    dbSessionId,
   } = useLearningContext();
   const navigate = useNavigate();
 
@@ -42,6 +43,7 @@ const TutorPage: React.FC = () => {
       initialCompletedParagraphs={completedParagraphsSet}
       initialProgress={stepProgressData.step_data?.tutor as TutorStepData | undefined}
       onProgressChange={handleProgressChange}
+      dbSessionId={dbSessionId}
     />
   );
 };

--- a/frontend/src/services/learning/session.ts
+++ b/frontend/src/services/learning/session.ts
@@ -44,9 +44,8 @@ export async function transcribeReading(
   targetText: string,
   durationMs: number,
   token: string,
-  /** Optional DB LearningSession id — when provided the backend binds the uploaded
-   *  audio blob to the latest ReadingAttemptHistory row so the student can replay
-   *  their recording later (Issue #2266). */
+  /** @deprecated Issue #2297: GCS upload is deferred to saveReadingAudio().
+   *  Kept for API compat; backend ignores this parameter. */
   dbSessionId?: number,
 ): Promise<TranscribeReadingResult> {
   const FALLBACK: TranscribeReadingResult = { transcript: null, method: 'fallback', reasoning: '', reason: 'error' };
@@ -56,7 +55,7 @@ export async function transcribeReading(
     form.append('audio', audioBlob, 'recording.webm');
     form.append('target_text', targetText);
     form.append('duration_ms', String(durationMs));
-    // Issue #2266: pass session_id so backend can bind audio to DB attempt row.
+    // Issue #2297: session_id is kept for API compat but no longer triggers upload.
     if (dbSessionId != null) {
       form.append('session_id', String(dbSessionId));
     }
@@ -120,6 +119,63 @@ export async function getReadingAudioSignedUrl(
     return typeof data.signed_url === 'string' ? data.signed_url : null;
   } catch {
     return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deferred GCS audio upload (Issue #2297)
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload the accepted reading take audio to GCS via the backend.
+ *
+ * Called AFTER the student accepts the score (not at transcription time) so
+ * only accepted takes are persisted.  Discarded / re-recorded takes are never
+ * uploaded.
+ *
+ * Fail-safe: any network or server error is caught and returns {ok: false}.
+ * This must NEVER throw or block the score display in the UI.
+ *
+ * @param audioBlob  The audio blob captured by the MediaRecorder.
+ * @param sessionId  DB LearningSession id.
+ * @param attemptId  Optional DB ReadingAttemptHistory id.  When omitted the
+ *                   backend uses the latest attempt row for this session.
+ * @param token      JWT bearer token.
+ */
+export async function saveReadingAudio(
+  audioBlob: Blob,
+  sessionId: number,
+  attemptId?: number,
+  token?: string,
+): Promise<{ ok: boolean; audio_gcs_path?: string }> {
+  if (!token) {
+    console.warn('[saveReadingAudio] no token — skipping upload');
+    return { ok: false };
+  }
+  try {
+    const form = new FormData();
+    form.append('audio', audioBlob, 'recording.webm');
+    form.append('session_id', String(sessionId));
+    if (attemptId != null) {
+      form.append('attempt_id', String(attemptId));
+    }
+    const res = await fetch(`${API_BASE}/api/reading/save-audio`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+    if (!res.ok) {
+      console.warn('[saveReadingAudio] non-OK response:', res.status);
+      return { ok: false };
+    }
+    const data = await res.json();
+    return {
+      ok: data?.ok === true,
+      audio_gcs_path: typeof data?.audio_gcs_path === 'string' ? data.audio_gcs_path : undefined,
+    };
+  } catch (err) {
+    console.warn('[saveReadingAudio] error:', err);
+    return { ok: false };
   }
 }
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2297

## Summary

把音檔 GCS 上傳從 STT 時（`/reading/transcribe`）移到評分確認後（新 `/reading/save-audio`）：

- 學生重錄/放棄/STT 失敗時，音檔**不上傳**（避免 orphan blob 堆積）
- 只有「Gemini 辨識成功且評分回傳前端」後才送音檔
- 儲存失敗只 WARNING，絕不阻擋分數顯示

## 改動檔案

**後端**
- `learning_reading.py` — 移除 step 4.5 GCS 上傳邏輯（`session_id` 參數保留但 deprecated）
- `learning_save_audio.py`（新增）— `POST /reading/save-audio`，含 IDOR check、rate-limit、fail-closed
- `__init__.py` — include 新 router

**前端**
- `session.ts` — 新增 `saveReadingAudio()` function
- `useFullReadingSession.ts` — `onResultReady()` 後才呼叫 `saveReadingAudio`
- `LiveTutor.tsx` — `evaluateAndRespond` 後才呼叫（只在 `transcriptSource === 'gemini'`）
- `TutorPage.tsx` — 傳 `dbSessionId` prop 給 LiveTutor

## 更新後資訊流

```
錄音
 ↓
POST /reading/transcribe  ← STT only，不做 GCS 上傳
 ↓
前端評分 (local eval → Gemini evaluate)
 ↓
onResultReady → UI 顯示分數
 ↓
saveReadingAudio(audioBlob, dbSessionId)  ← 分數已給 UI，才上傳
 ↓
POST /reading/save-audio
  ├─ IDOR check (session.student_id == current_user.id)
  ├─ rate-limit (10/min)
  ├─ 找最新 ReadingAttemptHistory
  ├─ GCS upload
  └─ 寫 audio_gcs_path to DB
```

## Test plan

- [ ] 全文朗讀：錄音→STT→評分顯示→確認 audio_gcs_path 寫入 DB
- [ ] 逐段朗讀：段落評分後 save-audio 被呼叫（Gemini success path）
- [ ] 重錄：第一次錄音 STT 後重錄，第一次音檔不上傳
- [ ] STT 失敗：音檔不上傳
- [ ] save-audio 失敗：分數仍正常顯示（console warn 但 UI 不受影響）
- [ ] 學生回放（#2283）、老師回放（#2286）：audio_gcs_path 仍正常寫入

## 驗證證據

- specs/run-ci.sh: 639 passed, 4 xfailed
- npm run lint: 0 errors
- npm run test src/__smoke__/: 13 passed