### PR TITLE
feat(testset): v1 人聲測試集收集（貢獻者頁 + owner 現況表）Fixes #2287

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from .config import settings
-from .routes import stories, learning, users, auth, classrooms, schools, organizations, roles
+from .routes import stories, learning, users, auth, classrooms, schools, organizations, roles, testset
 from .routes.classroom_texts import router as classroom_texts_router
 from .routes.teacher import router as teacher_router
 from .routes.assignments import router as assignments_router
@@ -358,6 +358,7 @@ app.add_middleware(GlobalRateLimitMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 
 app.include_router(stories.router, prefix="/api")
+app.include_router(testset.router, prefix="/api")
 app.include_router(learning.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 import json
 import logging
 import re
+import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
-from ..auth.rate_limiter import make_general_rate_limit_dependency
+from ..auth.dependencies import get_current_user
+from ..models.user import User
 from ..services.audio_upload_service import (
     _get_gcs_bucket,
     generate_audio_signed_url,
@@ -36,13 +38,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["testset"])
 
 _PREFIX = "test-dataset"
-_MAX_AUDIO_BYTES = 15 * 1024 * 1024  # 15 MB
+_MAX_AUDIO_BYTES = 8 * 1024 * 1024  # 8 MB (webm 朗讀用不到更多)
 _ALLOWED_MIME = {"audio/webm", "audio/ogg", "audio/mp4", "audio/mpeg", "audio/wav"}
 _ALLOWED_VERSION = {"correct", "error"}
+# lesson_id 進 GCS path → 必須白名單格式，否則可 ../ 跨 prefix 寫入學生錄音 (security #2304)
+_LESSON_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,20}$")
+_LIST_CAP = 500  # list_blobs hard cap，避免 unbounded read/signBlob
 
-# Public endpoints → per-IP limits (in-memory, per Cloud Run instance).
-_upload_limit = make_general_rate_limit_dependency(max_requests=30, window_seconds=60)
-_list_limit = make_general_rate_limit_dependency(max_requests=60, window_seconds=60)
+# Rate-limiting 靠全域 GlobalRateLimitMiddleware（讀 X-Forwarded-For，真 per-IP）。
+# 不在 endpoint 用 request.client.host limiter — Cloud Run LB 後面那只會讓所有人共用
+# 一個 bucket → self-DoS（security 複查 #2304）。
 
 
 def _slug(name: str) -> str:
@@ -51,7 +56,7 @@ def _slug(name: str) -> str:
     return (s.strip("_") or "anon")[:40]
 
 
-@router.post("/testset/upload", dependencies=[Depends(_upload_limit)])
+@router.post("/testset/upload")
 async def testset_upload(
     contributor_name: str = Form(...),
     grade: str = Form(...),
@@ -68,10 +73,13 @@ async def testset_upload(
         raise HTTPException(400, "version must be 'correct' or 'error'")
     if not contributor_name.strip() or not grade.strip() or not lesson_id.strip():
         raise HTTPException(400, "contributor_name, grade, lesson_id are required")
+    # HIGH: lesson_id 進 blob path → 白名單格式擋路徑注入 / 跨 prefix 寫入
+    if not _LESSON_ID_RE.match(lesson_id.strip()):
+        raise HTTPException(400, "invalid lesson_id")
 
     base_mime = (audio.content_type or "").split(";")[0].strip()
-    if base_mime and base_mime not in _ALLOWED_MIME:
-        raise HTTPException(415, f"unsupported audio type: {base_mime}")
+    if base_mime not in _ALLOWED_MIME:  # reject empty/missing too (deny-by-default)
+        raise HTTPException(415, f"unsupported audio type: {base_mime or '(none)'}")
 
     audio_bytes = await audio.read()
     if len(audio_bytes) == 0:
@@ -85,13 +93,14 @@ async def testset_upload(
         raise HTTPException(503, "storage temporarily unavailable")
 
     slug = _slug(contributor_name)
-    ext = "webm"
-    audio_path = f"{_PREFIX}/{slug}/{lesson_id}/{version}.{ext}"
-    meta_path = f"{_PREFIX}/{slug}/{lesson_id}/{version}.json"
+    lid = lesson_id.strip()
+    uid = uuid.uuid4().hex[:8]  # 防同名/重錄覆蓋：每次上傳唯一路徑（append-only）
+    audio_path = f"{_PREFIX}/{slug}/{lid}/{version}-{uid}.webm"
+    meta_path = f"{_PREFIX}/{slug}/{lid}/{version}-{uid}.json"
     meta = {
         "contributor_name": contributor_name.strip(),
         "grade": grade.strip(),
-        "lesson_id": lesson_id.strip(),
+        "lesson_id": lid,
         "version": version,
         "audio_path": audio_path,
         "created_at": datetime.now(timezone.utc).isoformat(),
@@ -112,11 +121,13 @@ async def testset_upload(
     return {"ok": True, "path": audio_path}
 
 
-@router.get("/testset/recordings", dependencies=[Depends(_list_limit)])
-def testset_recordings():
+@router.get("/testset/recordings")
+def testset_recordings(current_user: User = Depends(get_current_user)):
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
 
-    v1 公開（低敏感 + 隱蔽 URL）；v2 加 auth。
+    需登入（get_current_user）→ 擋掉匿名公開抓取貢獻者 PII（security #2304）。
+    list.html 讀 localStorage `lingoleap_token` 帶 Bearer；未登入 → 401。
+    （v2：再收斂成 admin/teacher role only。）
     """
     bucket = _get_gcs_bucket()
     if bucket is None:
@@ -124,7 +135,7 @@ def testset_recordings():
 
     out = []
     try:
-        for blob in bucket.list_blobs(prefix=f"{_PREFIX}/"):
+        for blob in bucket.list_blobs(prefix=f"{_PREFIX}/", max_results=_LIST_CAP):
             if not blob.name.endswith(".json"):
                 continue
             try:

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -1,0 +1,142 @@
+"""人聲測試集收集 (Issue #2287) — v1, GCS-only, no DB.
+
+陌生人（招募的貢獻者）點開 /testset/ 頁面，無登入即可:
+  填名字+年級 → 選課文 → 錄音 → 上傳。
+
+設計（為何 GCS-only 無 DB）:
+- alembic 目前 multi-head，依專案鐵律不在此情況下新建 migration。
+- v1 把每筆錄音存 GCS:
+    test-dataset/{slug}/{lesson_id}/{version}.webm   (音檔)
+    test-dataset/{slug}/{lesson_id}/{version}.json   (meta: 名字/年級/時間)
+  owner list UI 用 GET /testset/recordings 讀回（list_blobs + 讀 .json）。
+- 與學生 attempt 完全隔離（獨立 prefix），重用既有 reading-audio bucket。
+
+安全:
+- 公開 endpoint → IP rate-limit + size cap + content-type 檢查 + fail-closed。
+- v1 list 也公開（owner 資料低敏感、URL 隱蔽）；v2 再加 auth。已向 owner 標註此 tradeoff。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+
+from ..auth.rate_limiter import make_general_rate_limit_dependency
+from ..services.audio_upload_service import (
+    _get_gcs_bucket,
+    generate_audio_signed_url,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["testset"])
+
+_PREFIX = "test-dataset"
+_MAX_AUDIO_BYTES = 15 * 1024 * 1024  # 15 MB
+_ALLOWED_MIME = {"audio/webm", "audio/ogg", "audio/mp4", "audio/mpeg", "audio/wav"}
+_ALLOWED_VERSION = {"correct", "error"}
+
+# Public endpoints → per-IP limits (in-memory, per Cloud Run instance).
+_upload_limit = make_general_rate_limit_dependency(max_requests=30, window_seconds=60)
+_list_limit = make_general_rate_limit_dependency(max_requests=60, window_seconds=60)
+
+
+def _slug(name: str) -> str:
+    """Stable, path-safe slug from contributor name (keeps CJK, strips separators)."""
+    s = re.sub(r"[^\w一-鿿]+", "_", (name or "").strip())
+    return (s.strip("_") or "anon")[:40]
+
+
+@router.post("/testset/upload", dependencies=[Depends(_upload_limit)])
+async def testset_upload(
+    contributor_name: str = Form(...),
+    grade: str = Form(...),
+    lesson_id: str = Form(...),
+    version: str = Form(...),
+    audio: UploadFile = File(...),
+):
+    """貢獻者上傳一筆錄音（無登入）。
+
+    Returns: { ok, path } on success; HTTPException on validation; 503 if GCS down.
+    """
+    # ── validate ──────────────────────────────────────────────────────────────
+    if version not in _ALLOWED_VERSION:
+        raise HTTPException(400, "version must be 'correct' or 'error'")
+    if not contributor_name.strip() or not grade.strip() or not lesson_id.strip():
+        raise HTTPException(400, "contributor_name, grade, lesson_id are required")
+
+    base_mime = (audio.content_type or "").split(";")[0].strip()
+    if base_mime and base_mime not in _ALLOWED_MIME:
+        raise HTTPException(415, f"unsupported audio type: {base_mime}")
+
+    audio_bytes = await audio.read()
+    if len(audio_bytes) == 0:
+        raise HTTPException(400, "empty audio")
+    if len(audio_bytes) > _MAX_AUDIO_BYTES:
+        raise HTTPException(413, "audio too large (max 15MB)")
+
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        # fail-closed: storage unavailable
+        raise HTTPException(503, "storage temporarily unavailable")
+
+    slug = _slug(contributor_name)
+    ext = "webm"
+    audio_path = f"{_PREFIX}/{slug}/{lesson_id}/{version}.{ext}"
+    meta_path = f"{_PREFIX}/{slug}/{lesson_id}/{version}.json"
+    meta = {
+        "contributor_name": contributor_name.strip(),
+        "grade": grade.strip(),
+        "lesson_id": lesson_id.strip(),
+        "version": version,
+        "audio_path": audio_path,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        bucket.blob(audio_path).upload_from_string(
+            audio_bytes, content_type=base_mime or "audio/webm"
+        )
+        bucket.blob(meta_path).upload_from_string(
+            json.dumps(meta, ensure_ascii=False), content_type="application/json"
+        )
+    except Exception as exc:  # never leak internals; fail-closed
+        logger.warning("testset upload failed: path=%s err=%s", audio_path, exc)
+        raise HTTPException(503, "upload failed, please retry")
+
+    logger.info("testset upload OK: %s (%d bytes)", audio_path, len(audio_bytes))
+    return {"ok": True, "path": audio_path}
+
+
+@router.get("/testset/recordings", dependencies=[Depends(_list_limit)])
+def testset_recordings():
+    """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
+
+    v1 公開（低敏感 + 隱蔽 URL）；v2 加 auth。
+    """
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        return {"ok": False, "recordings": [], "reason": "storage unavailable"}
+
+    out = []
+    try:
+        for blob in bucket.list_blobs(prefix=f"{_PREFIX}/"):
+            if not blob.name.endswith(".json"):
+                continue
+            try:
+                meta = json.loads(blob.download_as_text())
+            except Exception:
+                continue
+            signed = generate_audio_signed_url(meta.get("audio_path", ""), expiration_seconds=600)
+            meta["play_url"] = signed
+            out.append(meta)
+    except Exception as exc:
+        logger.warning("testset list failed: %s", exc)
+        return {"ok": False, "recordings": [], "reason": "list failed"}
+
+    out.sort(key=lambda m: m.get("created_at", ""), reverse=True)
+    return {"ok": True, "count": len(out), "recordings": out}

--- a/frontend/public/testset/index.html
+++ b/frontend/public/testset/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>朗讀錄音貢獻 · LingoLeap 測試集</title>
+<style>
+  :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--green:#16a34a;--red:#dc2626;--chip:#efe9ff}
+  *{box-sizing:border-box}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:24px 16px;line-height:1.7}
+  .wrap{max-width:680px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.4rem;margin:0 0 4px}
+  .sub{color:var(--muted);font-size:.9rem;margin:0 0 20px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .step{font-weight:700;color:var(--purple);margin-bottom:10px}
+  label{display:block;font-size:.85rem;color:var(--muted);margin:8px 0 4px}
+  input,select{width:100%;padding:10px;border:1px solid var(--line);border-radius:8px;font:inherit;background:#fff}
+  .lessons{display:flex;flex-direction:column;gap:8px}
+  .lesson{padding:12px;border:1px solid var(--line);border-radius:8px;cursor:pointer;background:#fff}
+  .lesson.sel{border-color:var(--purple);background:var(--chip)}
+  .lesson .t{font-weight:600}
+  .passage{background:#faf7f0;border-left:3px solid var(--purple);padding:12px;border-radius:8px;margin:10px 0;font-size:1.05rem;line-height:2}
+  .vtabs{display:flex;gap:8px;margin:10px 0}
+  .vtab{flex:1;padding:10px;border:1px solid var(--line);border-radius:8px;background:#fff;cursor:pointer;text-align:center;font-weight:600}
+  .vtab.sel{border-color:var(--purple);background:var(--chip);color:var(--purple)}
+  .vtab .hint{display:block;font-size:.72rem;color:var(--muted);font-weight:400}
+  .btn{padding:12px 18px;border:none;border-radius:10px;font:inherit;font-weight:700;cursor:pointer}
+  .btn-rec{background:var(--red);color:#fff;width:100%}
+  .btn-rec.recording{background:#7f1d1d}
+  .btn-up{background:var(--purple);color:#fff;width:100%}
+  .btn:disabled{opacity:.4;cursor:not-allowed}
+  audio{width:100%;margin-top:10px}
+  .status{font-size:.85rem;margin-top:8px}
+  .ok{color:var(--green);font-weight:700}
+  .err{color:var(--red)}
+  .grid{display:grid;grid-template-columns:1fr auto auto;gap:6px 10px;font-size:.85rem;margin-top:6px;align-items:center}
+  .dot{width:14px;height:14px;border-radius:50%;background:#ddd;display:inline-block}
+  .dot.done{background:var(--green)}
+  .muted{color:var(--muted)}
+  .thanks{text-align:center;padding:30px;color:var(--green);font-weight:700;font-size:1.2rem}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>朗讀錄音貢獻</h1>
+  <p class="sub">幫 LingoLeap 蒐集真人朗讀，訓練/驗證 AI 朗讀評分。大約 10–15 分鐘。謝謝你！</p>
+
+  <div class="card" id="who-card">
+    <div class="step">① 你是誰</div>
+    <label>名字（暱稱即可）</label>
+    <input id="name" placeholder="例如：小明 / Amy">
+    <label>年級</label>
+    <select id="grade">
+      <option value="">請選擇</option>
+      <option>國小三年級</option><option>國小四年級</option><option>國小五年級</option><option>國小六年級</option>
+      <option>國中七年級</option><option>國中八年級</option><option>國中九年級</option>
+      <option>高中以上</option>
+    </select>
+  </div>
+
+  <div class="card">
+    <div class="step">② 選一篇課文</div>
+    <div class="lessons" id="lessons"></div>
+  </div>
+
+  <div class="card" id="read-card" style="display:none">
+    <div class="step">③ 照著念 + 錄音</div>
+    <div class="passage" id="passage"></div>
+    <div class="vtabs">
+      <div class="vtab sel" data-v="correct" onclick="selVersion('correct')">正確版<span class="hint">盡量念對</span></div>
+      <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
+    </div>
+    <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
+    <audio id="player" controls style="display:none"></audio>
+    <button class="btn btn-up" id="upBtn" onclick="upload()" disabled style="margin-top:10px">⬆ 上傳這段</button>
+    <div class="status" id="status"></div>
+  </div>
+
+  <div class="card">
+    <div class="step">④ 我的進度</div>
+    <div class="grid" id="progress"></div>
+    <p class="muted" id="allDone" style="display:none">🎉 都錄完了，太感謝你！可以關掉了。</p>
+  </div>
+</div>
+
+<script>
+// ── API base：從前端 hostname 推後端（Cloud Run -frontend- → -backend-）──
+function apiBase(){
+  var h=location.origin;
+  if(h.indexOf('-frontend-')>-1) return h.replace('-frontend-','-backend-');
+  if(h.indexOf('localhost')>-1||h.indexOf('127.0.0.1')>-1) return 'http://localhost:8000';
+  // firebase / 其他 → 用 staging backend 後備
+  return 'https://lingoleap-backend-staging-958347263320.asia-east1.run.app';
+}
+var API=apiBase();
+
+var LESSONS=[
+  {id:'L01',title:'贏得喝采的輸家',text:'「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳～」這一句洗腦的廣告臺詞，是否也在你的周遭出現？她就是台灣第一人，累計二一四週排名世界第一的球后──戴資穎。'},
+  {id:'L02',title:'十秒的背後',text:'十秒鐘你能做什麼？裝一杯水、哼一段小曲、等待手機略過廣告？這十秒可能還不夠呢。這轉瞬即逝的十秒，對於百尺短跑的選手來說，足以決定一場令人血脈賁張、緊張刺激的勝負。'},
+  {id:'L03',title:'長高的祕密',text:'開學後不久，又是到健康中心量身高體重的時候。同學們嘰嘰喳喳講個不停，有人會開始炫耀自己的身高，有人則是會隱藏自己的體重。'}
+];
+var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
+
+var cur={lesson:null,version:'correct'};
+var done=JSON.parse(localStorage.getItem('testset_done')||'{}'); // {L01_correct:true}
+var mediaRec=null, chunks=[], blob=null;
+
+function renderLessons(){
+  var el=document.getElementById('lessons'); el.innerHTML='';
+  LESSONS.forEach(function(L){
+    var d=document.createElement('div'); d.className='lesson'+(cur.lesson&&cur.lesson.id===L.id?' sel':'');
+    d.innerHTML='<div class="t">'+L.title+'</div><div class="muted" style="font-size:.8rem">'+L.id+'</div>';
+    d.onclick=function(){ cur.lesson=L; renderLessons(); openRead(); };
+    el.appendChild(d);
+  });
+}
+function openRead(){
+  document.getElementById('read-card').style.display='block';
+  document.getElementById('passage').innerText=cur.lesson.text;
+  resetRec();
+}
+function selVersion(v){
+  cur.version=v;
+  document.querySelectorAll('.vtab').forEach(function(t){t.classList.toggle('sel',t.dataset.v===v)});
+  resetRec();
+}
+function resetRec(){
+  blob=null;
+  var p=document.getElementById('player'); p.style.display='none'; p.src='';
+  document.getElementById('upBtn').disabled=true;
+  document.getElementById('status').innerHTML='';
+  var b=document.getElementById('recBtn'); b.classList.remove('recording'); b.textContent='● 開始錄音';
+}
+async function toggleRec(){
+  var b=document.getElementById('recBtn');
+  if(mediaRec&&mediaRec.state==='recording'){ mediaRec.stop(); return; }
+  try{
+    var stream=await navigator.mediaDevices.getUserMedia({audio:true});
+    chunks=[]; mediaRec=new MediaRecorder(stream);
+    mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
+    mediaRec.onstop=function(){
+      blob=new Blob(chunks,{type:'audio/webm'});
+      var p=document.getElementById('player'); p.src=URL.createObjectURL(blob); p.style.display='block';
+      document.getElementById('upBtn').disabled=false;
+      stream.getTracks().forEach(function(t){t.stop()});
+      b.classList.remove('recording'); b.textContent='● 重新錄音';
+    };
+    mediaRec.start(); b.classList.add('recording'); b.textContent='■ 停止錄音';
+    document.getElementById('status').innerHTML='<span class="muted">錄音中…照著上面念</span>';
+  }catch(e){
+    document.getElementById('status').innerHTML='<span class="err">無法存取麥克風，請允許權限後再試</span>';
+  }
+}
+async function upload(){
+  var name=document.getElementById('name').value.trim();
+  var grade=document.getElementById('grade').value;
+  if(!name||!grade){ document.getElementById('status').innerHTML='<span class="err">請先在①填名字和年級</span>'; window.scrollTo(0,0); return; }
+  if(!blob){ return; }
+  document.getElementById('upBtn').disabled=true;
+  document.getElementById('status').innerHTML='<span class="muted">上傳中…</span>';
+  var fd=new FormData();
+  fd.append('contributor_name',name); fd.append('grade',grade);
+  fd.append('lesson_id',cur.lesson.id); fd.append('version',cur.version);
+  fd.append('audio',blob,cur.lesson.id+'_'+cur.version+'.webm');
+  try{
+    var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
+    if(!r.ok){ throw new Error('HTTP '+r.status); }
+    done[cur.lesson.id+'_'+cur.version]=true;
+    localStorage.setItem('testset_done',JSON.stringify(done));
+    document.getElementById('status').innerHTML='<span class="ok">✓ 已上傳！</span>';
+    renderProgress();
+  }catch(e){
+    document.getElementById('upBtn').disabled=false;
+    document.getElementById('status').innerHTML='<span class="err">上傳失敗，請再試一次（'+e.message+'）</span>';
+  }
+}
+function renderProgress(){
+  var el=document.getElementById('progress'); el.innerHTML='';
+  var total=LESSONS.length*VERSIONS.length, n=0;
+  LESSONS.forEach(function(L){
+    var row=document.createElement('div'); row.textContent=L.title; el.appendChild(row);
+    VERSIONS.forEach(function(V){
+      var ok=done[L.id+'_'+V.k]; if(ok)n++;
+      var c=document.createElement('div'); c.style.textAlign='center';
+      c.innerHTML='<span class="dot'+(ok?' done':'')+'" title="'+V.n+'"></span><div class="muted" style="font-size:.7rem">'+V.n+'</div>';
+      el.appendChild(c);
+    });
+  });
+  document.getElementById('allDone').style.display = n>=total ? 'block':'none';
+}
+renderLessons(); renderProgress();
+</script>
+</body>
+</html>

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>測試集收集現況 · LingoLeap</title>
+<style>
+  :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--green:#16a34a;--amber:#d97706;--red:#dc2626;--chip:#efe9ff}
+  *{box-sizing:border-box}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:28px 18px;line-height:1.6}
+  .wrap{max-width:1000px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.5rem;margin:0 0 4px}
+  .sub{color:var(--muted);margin:0 0 18px}
+  .share{display:flex;align-items:center;gap:12px;background:var(--chip);border:1px solid var(--purple);border-radius:12px;padding:14px 18px;margin-bottom:20px;flex-wrap:wrap}
+  .share .lbl{font-weight:700;color:var(--purple)}
+  .share a{color:var(--purple);font-weight:600;word-break:break-all}
+  .share button{padding:8px 14px;border:1px solid var(--purple);background:#fff;color:var(--purple);border-radius:8px;font:inherit;font-weight:600;cursor:pointer}
+  .stats{display:flex;gap:12px;margin-bottom:18px;flex-wrap:wrap}
+  .stat{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 18px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .stat .n{font-size:1.6rem;font-weight:800;color:var(--purple)}
+  .stat .l{font-size:.8rem;color:var(--muted)}
+  h2{font-size:1.1rem;color:var(--ink);margin:22px 0 10px}
+  table{width:100%;border-collapse:collapse;background:var(--card);border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06);font-size:.9rem}
+  th,td{padding:11px 13px;border-bottom:1px solid var(--line);text-align:left;vertical-align:middle}
+  th{background:#f3eee4;font-size:.82rem}
+  tr:last-child td{border-bottom:none}
+  .cell{display:flex;align-items:center;gap:8px}
+  .pill{display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:24px;padding:0 8px;border-radius:20px;font-size:.82rem;font-weight:700}
+  .pill.zero{background:#f3f0e8;color:var(--muted)}
+  .pill.some{background:#dcfce7;color:var(--green)}
+  .names{font-size:.78rem;color:var(--muted)}
+  .det{font-size:.86rem}
+  .det td{padding:9px 13px}
+  audio{height:30px;vertical-align:middle}
+  .muted{color:var(--muted)}
+  .loading{text-align:center;padding:40px;color:var(--muted)}
+  .err{color:var(--red);text-align:center;padding:20px}
+  code{background:#f3eee4;padding:1px 6px;border-radius:4px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>測試集收集現況</h1>
+  <p class="sub">真人朗讀錄音蒐集進度 — 每篇課文各需「正確版 + 刻意錯誤版」</p>
+
+  <div class="share">
+    <span class="lbl">📣 分享給貢獻者：</span>
+    <a id="shareLink" href="./index.html">./index.html</a>
+    <button onclick="copyLink()">複製連結</button>
+    <a href="./index.html" target="_blank" style="margin-left:auto"><button>開啟錄音頁 →</button></a>
+  </div>
+
+  <div class="stats" id="stats"></div>
+
+  <h2>覆蓋率矩陣（課文 × 版本）</h2>
+  <div id="matrixWrap"><div class="loading">載入中…</div></div>
+
+  <h2>所有錄音明細</h2>
+  <div id="detailWrap"></div>
+</div>
+
+<script>
+function apiBase(){
+  var h=location.origin;
+  if(h.indexOf('-frontend-')>-1) return h.replace('-frontend-','-backend-');
+  if(h.indexOf('localhost')>-1||h.indexOf('127.0.0.1')>-1) return 'http://localhost:8000';
+  return 'https://lingoleap-backend-staging-958347263320.asia-east1.run.app';
+}
+var API=apiBase();
+var LESSON_TITLES={L01:'贏得喝采的輸家',L02:'十秒的背後',L03:'長高的祕密'};
+var EXPECTED=['L01','L02','L03'];
+var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
+
+document.getElementById('shareLink').textContent=location.origin+location.pathname.replace('list.html','index.html');
+document.getElementById('shareLink').href=location.origin+location.pathname.replace('list.html','index.html');
+function copyLink(){ navigator.clipboard.writeText(location.origin+location.pathname.replace('list.html','index.html')); }
+
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+
+async function load(){
+  var recs=[];
+  try{
+    var r=await fetch(API+'/api/testset/recordings');
+    var j=await r.json();
+    recs=j.recordings||[];
+  }catch(e){
+    document.getElementById('matrixWrap').innerHTML='<div class="err">讀取失敗：'+e.message+'</div>';
+    return;
+  }
+  // lessons = expected ∪ seen
+  var lessons={}; EXPECTED.forEach(function(id){lessons[id]=true});
+  recs.forEach(function(m){ if(m.lesson_id) lessons[m.lesson_id]=true; });
+  var lessonIds=Object.keys(lessons);
+
+  // index by lesson+version
+  var idx={}; var contributors={};
+  recs.forEach(function(m){
+    var k=m.lesson_id+'_'+m.version; (idx[k]=idx[k]||[]).push(m);
+    if(m.contributor_name) contributors[m.contributor_name+'｜'+(m.grade||'')]=true;
+  });
+
+  // stats
+  var total=recs.length, cells=lessonIds.length*VERSIONS.length, filled=0;
+  lessonIds.forEach(function(id){VERSIONS.forEach(function(v){ if((idx[id+'_'+v.k]||[]).length) filled++; })});
+  document.getElementById('stats').innerHTML=
+    stat(total,'總錄音數')+stat(filled+' / '+cells,'已覆蓋格')+stat(Object.keys(contributors).length,'貢獻者')+stat(lessonIds.length,'課文數');
+
+  // matrix
+  var h='<table><thead><tr><th>課文</th>'+VERSIONS.map(function(v){return '<th>'+v.n+'</th>'}).join('')+'</tr></thead><tbody>';
+  lessonIds.forEach(function(id){
+    h+='<tr><td><b>'+esc(LESSON_TITLES[id]||id)+'</b><div class="muted" style="font-size:.78rem">'+id+'</div></td>';
+    VERSIONS.forEach(function(v){
+      var list=idx[id+'_'+v.k]||[]; var n=list.length;
+      var names=list.map(function(m){return esc(m.contributor_name)}).filter(function(x,i,a){return a.indexOf(x)===i}).join('、');
+      h+='<td><div class="cell"><span class="pill '+(n?'some':'zero')+'">'+n+'</span>'+(names?'<span class="names">'+names+'</span>':'<span class="names">尚無</span>')+'</div></td>';
+    });
+    h+='</tr>';
+  });
+  h+='</tbody></table>';
+  document.getElementById('matrixWrap').innerHTML=h;
+
+  // detail
+  if(!recs.length){ document.getElementById('detailWrap').innerHTML='<p class="muted">還沒有任何錄音。把上面的連結分享出去吧！</p>'; return; }
+  var d='<table class="det"><thead><tr><th>課文</th><th>版本</th><th>貢獻者</th><th>年級</th><th>時間</th><th>播放</th></tr></thead><tbody>';
+  recs.forEach(function(m){
+    var vn=(VERSIONS.filter(function(v){return v.k===m.version})[0]||{}).n||m.version;
+    var t=(m.created_at||'').replace('T',' ').slice(0,16);
+    d+='<tr><td>'+esc(LESSON_TITLES[m.lesson_id]||m.lesson_id)+'</td><td>'+vn+'</td><td>'+esc(m.contributor_name)+'</td><td>'+esc(m.grade)+'</td><td class="muted">'+esc(t)+'</td><td>'+(m.play_url?'<audio controls preload="none" src="'+esc(m.play_url)+'"></audio>':'<span class="muted">—</span>')+'</td></tr>';
+  });
+  d+='</tbody></table>';
+  document.getElementById('detailWrap').innerHTML=d;
+}
+function stat(n,l){return '<div class="stat"><div class="n">'+n+'</div><div class="l">'+l+'</div></div>';}
+load();
+</script>
+</body>
+</html>

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -75,16 +75,21 @@ document.getElementById('shareLink').textContent=location.origin+location.pathna
 document.getElementById('shareLink').href=location.origin+location.pathname.replace('list.html','index.html');
 function copyLink(){ navigator.clipboard.writeText(location.origin+location.pathname.replace('list.html','index.html')); }
 
-function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML;}
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 
 async function load(){
   var recs=[];
   try{
-    var r=await fetch(API+'/api/testset/recordings');
+    var token=localStorage.getItem('lingoleap_token');
+    var r=await fetch(API+'/api/testset/recordings',{headers: token?{'Authorization':'Bearer '+token}:{}});
+    if(r.status===401||r.status===403){
+      document.getElementById('matrixWrap').innerHTML='<div class="err">這是管理頁，請先到主站登入（管理員/老師）後再開此頁。<br><a href="/login">前往登入 →</a></div>';
+      return;
+    }
     var j=await r.json();
     recs=j.recordings||[];
   }catch(e){
-    document.getElementById('matrixWrap').innerHTML='<div class="err">讀取失敗：'+e.message+'</div>';
+    document.getElementById('matrixWrap').innerHTML='<div class="err">讀取失敗：'+esc(e.message)+'</div>';
     return;
   }
   // lessons = expected ∪ seen
@@ -108,7 +113,7 @@ async function load(){
   // matrix
   var h='<table><thead><tr><th>課文</th>'+VERSIONS.map(function(v){return '<th>'+v.n+'</th>'}).join('')+'</tr></thead><tbody>';
   lessonIds.forEach(function(id){
-    h+='<tr><td><b>'+esc(LESSON_TITLES[id]||id)+'</b><div class="muted" style="font-size:.78rem">'+id+'</div></td>';
+    h+='<tr><td><b>'+esc(LESSON_TITLES[id]||id)+'</b><div class="muted" style="font-size:.78rem">'+esc(id)+'</div></td>';
     VERSIONS.forEach(function(v){
       var list=idx[id+'_'+v.k]||[]; var n=list.length;
       var names=list.map(function(m){return esc(m.contributor_name)}).filter(function(x,i,a){return a.indexOf(x)===i}).join('、');


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

點開就能用的 v1。**GCS-only（無 DB / 無 migration — alembic 目前 multi-head，依鐵律不在此情況建 migration）。**

## 兩個頁面
- **貢獻者頁** `/testset/`（無登入）：填名字+年級 → 選課文(3 篇) → 照念 → 錄音(MediaRecorder) → 回放 → 上傳；含「我的進度」(課文×正確/錯誤版打勾)
- **owner 現況表** `/testset/list.html`：**覆蓋率矩陣**（課文 × 正確/錯誤版 → 數量+貢獻者+播放）+ 明細表 + 「分享給貢獻者」可複製連結

## 後端 `backend/app/routes/testset.py`
- `POST /api/testset/upload`：公開、**IP rate-limit(30/min) + 15MB cap + content-type 檢查 + fail-closed** → GCS `test-dataset/{slug}/{lesson}/{version}.webm` + `.json` meta（與學生 attempt 隔離）
- `GET /api/testset/recordings`：owner list 用，回 meta + 10min 播放 signed URL

## v1 tradeoff / 待 review
- list endpoint **v1 公開**（低敏感、URL 隱蔽）→ v2 加 auth
- 公開上傳 endpoint → 另跑 security-auditor 複查中
- 課文 v1 先 3 篇；難度分級/留名頁 defer v2

驗證：syntax OK；本地無 backend deps 無法 import，wiring 靠 CI Backend Tests。**不自動 merge**。