### PR TITLE
feat: 人聲測試集收集平台 v1 (Fixes #2287)

### DIFF
--- a/backend/alembic/versions/a2b3c4d5e6f7_b3c4d5e6f7g8_create_testset_recordings_table.py
+++ b/backend/alembic/versions/a2b3c4d5e6f7_b3c4d5e6f7g8_create_testset_recordings_table.py
@@ -1,0 +1,57 @@
+"""create_testset_recordings_table
+
+Issue #2287 — crowdsourced reading audio collection.
+Adds testset_recordings table (standalone, no FK — contributors identified by name string).
+
+Revision ID: b3c4d5e6f7g8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-06-20
+
+Migration notes (idempotent DDL):
+  - Uses IF NOT EXISTS on table creation — safe to re-run.
+  - Downgrade drops the table entirely.
+  - No FK, so no cascade concerns.
+
+Run on staging BEFORE merging PR:
+    cd backend && alembic upgrade head
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b3c4d5e6f7g8"
+down_revision = "a2b3c4d5e6f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS testset_recordings (
+            id SERIAL PRIMARY KEY,
+            contributor_name VARCHAR(100) NOT NULL,
+            grade VARCHAR(20) NOT NULL,
+            lesson_id VARCHAR(50) NOT NULL,
+            version VARCHAR(20) NOT NULL,
+            audio_gcs_path VARCHAR(500) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    # Indexes — idempotent via IF NOT EXISTS
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_testset_lesson_version
+            ON testset_recordings (lesson_id, version)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_testset_created_at
+            ON testset_recordings (created_at)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_testset_contributor
+            ON testset_recordings (contributor_name)
+    """)
+
+
+def downgrade() -> None:
+    op.drop_table("testset_recordings")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from .routes.admin_seed import router as admin_seed_router
 from .routes.omo import router as omo_router
 from .routes.curriculum_qa import router as curriculum_qa_router
 from .routes.admin_story_structure_lab import router as admin_story_structure_lab_router
+from .routes.testset import router as testset_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter
 from .services.seed import seed_default_data, repair_pii_accounts
@@ -387,6 +388,7 @@ app.include_router(admin_seed_router, prefix="/api", tags=["admin-seed"])
 app.include_router(omo_router, prefix="/api", tags=["omo"])
 app.include_router(curriculum_qa_router, prefix="/api", tags=["curriculum-qa"])
 app.include_router(admin_story_structure_lab_router, prefix="/api", tags=["admin-story-structure-lab"])
+app.include_router(testset_router, prefix="/api", tags=["testset"])
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -32,3 +32,4 @@ from .toolbox import (  # noqa: F401
     ToolboxVocabWordSearchSession,
 )
 from .annotation import AnnotationEntry  # noqa: F401
+from .testset_recording import TestsetRecording  # noqa: F401

--- a/backend/app/models/testset_recording.py
+++ b/backend/app/models/testset_recording.py
@@ -1,0 +1,67 @@
+"""TestsetRecording model — Issue #2287.
+
+Stores crowdsourced reading audio contributed by volunteers (no login required).
+
+sqlalchemy-model-safety checklist:
+- No FK (standalone table, contributors identified by name string) ✅
+- timestamps with server_default=func.now() (Rule 2) ✅
+- All columns have explicit nullable declaration ✅
+- No relationship() needed (no FK) ✅
+- Index on (lesson_id, version) for list query ✅
+- Index on created_at for time-based list ordering ✅
+"""
+
+from sqlalchemy import DateTime, Integer, String, func, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class TestsetRecording(Base):
+    """One recording submitted by a volunteer contributor.
+
+    A contributor (identified by name + grade, no auth) records a lesson text
+    in either the 'correct' or 'error' version and uploads the audio file.
+    The audio is stored in GCS under the test-dataset/ prefix (separate from
+    student attempt audio).
+
+    GCS path convention (enforced by route, not here):
+        test-dataset/{contributor_slug}/{lesson_id}/{version}_{id}.webm
+    """
+
+    __tablename__ = "testset_recordings"
+    __table_args__ = (
+        Index("ix_testset_lesson_version", "lesson_id", "version"),
+        Index("ix_testset_created_at", "created_at"),
+        Index("ix_testset_contributor", "contributor_name"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Contributor identity (no auth — name + grade self-reported)
+    contributor_name: Mapped[str] = mapped_column(
+        String(100), nullable=False
+    )
+    grade: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )
+
+    # Which lesson and which version was recorded
+    lesson_id: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )
+    version: Mapped[str] = mapped_column(
+        String(20), nullable=False  # "correct" or "error"
+    )
+
+    # GCS path (relative, under READING_AUDIO_GCS_BUCKET)
+    audio_gcs_path: Mapped[str] = mapped_column(
+        String(500), nullable=False
+    )
+
+    # When was this uploaded
+    created_at: Mapped[DateTime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -1,0 +1,254 @@
+"""Testset collection API — Issue #2287.
+
+Two endpoints (public, no auth):
+  POST /api/testset/upload  — upload one audio recording
+  GET  /api/testset/list    — list all recordings (owner view)
+
+Security posture (public endpoint, no login):
+  - Rate-limit: 10 uploads / min per IP (InMemoryRateLimiter reuse)
+  - Size cap: 15 MB audio max
+  - Content-type allowlist: audio/* only
+  - Fail-closed: any GCS / DB error → 503, never silently accept
+  - No PII beyond self-reported name/grade
+  - GCS bucket: controlled by READING_AUDIO_GCS_BUCKET env var (same bucket,
+    separate prefix test-dataset/ so student audio is never mixed)
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..auth.rate_limiter import InMemoryRateLimiter
+from ..database import get_db
+from ..models.testset_recording import TestsetRecording
+from ..services.audio_upload_service import upload_reading_audio_to_gcs_sync
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ── Rate limiter (per-IP, 10 uploads / min) ──────────────────────────────────
+_upload_rate_limiter = InMemoryRateLimiter()
+_UPLOAD_MAX = 10
+_UPLOAD_WINDOW = 60  # seconds
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+MAX_AUDIO_BYTES = 15 * 1024 * 1024  # 15 MB
+ALLOWED_VERSIONS = {"correct", "error"}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_client_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return (request.client.host if request.client else "unknown")
+
+
+def _slug(text: str) -> str:
+    """Simple slug for GCS path: lowercase, only alphanum + dash."""
+    return re.sub(r"[^a-z0-9\-]", "-", text.lower().strip())[:50]
+
+
+def _check_rate_limit(request: Request) -> None:
+    ip = _get_client_ip(request)
+    if not _upload_rate_limiter.check(f"testset:upload:{ip}", _UPLOAD_MAX, _UPLOAD_WINDOW):
+        raise HTTPException(
+            status_code=429,
+            detail="上傳太頻繁，請稍後再試（每分鐘最多 10 次）",
+        )
+
+
+# ── Response schemas ──────────────────────────────────────────────────────────
+
+class UploadResponse(BaseModel):
+    id: int
+    message: str
+    gcs_path: str
+
+
+class RecordingItem(BaseModel):
+    id: int
+    contributor_name: str
+    grade: str
+    lesson_id: str
+    version: str
+    audio_gcs_path: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ListResponse(BaseModel):
+    total: int
+    recordings: list[RecordingItem]
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.post(
+    "/testset/upload",
+    response_model=UploadResponse,
+    summary="Upload one testset recording (public, no auth)",
+    tags=["testset"],
+)
+async def upload_testset_recording(
+    request: Request,
+    contributor_name: str = Form(..., max_length=100),
+    grade: str = Form(..., max_length=20),
+    lesson_id: str = Form(..., max_length=50),
+    version: str = Form(...),
+    audio: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> UploadResponse:
+    """Upload one audio recording to the testset collection.
+
+    Args:
+        contributor_name: Self-reported name (no auth, max 100 chars).
+        grade: Self-reported grade/role (e.g. "小四", "大人").
+        lesson_id: Lesson identifier (e.g. "L01", "G6-L9").
+        version: "correct" or "error".
+        audio: Audio file (webm preferred; ≤15 MB).
+
+    Returns:
+        UploadResponse with DB id + GCS path on success.
+
+    Raises:
+        400 — invalid version / bad content-type.
+        413 — audio > 15 MB.
+        429 — rate limit exceeded.
+        503 — GCS or DB failure (fail-closed).
+    """
+    # 1. Rate limit
+    _check_rate_limit(request)
+
+    # 2. Validate version
+    if version not in ALLOWED_VERSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"version 必須是 'correct' 或 'error'，收到: {version!r}",
+        )
+
+    # 3. Validate content-type
+    raw_ct = (audio.content_type or "").split(";")[0].strip().lower()
+    if not raw_ct.startswith("audio/"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"只接受 audio/* 格式，收到: {audio.content_type!r}",
+        )
+
+    # 4. Read + size cap
+    try:
+        audio_bytes = await audio.read()
+    except Exception as exc:
+        logger.error("testset upload: read failed: %s", exc)
+        raise HTTPException(status_code=503, detail="讀取音檔失敗，請重試")
+
+    if len(audio_bytes) > MAX_AUDIO_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"音檔過大（最大 15 MB），實際 {len(audio_bytes) // (1024*1024)} MB",
+        )
+    if len(audio_bytes) == 0:
+        raise HTTPException(status_code=400, detail="音檔為空")
+
+    # 5. Build GCS path — timestamp-based, collision-resistant
+    contributor_slug = _slug(contributor_name)
+    lesson_slug = _slug(lesson_id)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    temp_path = f"test-dataset/{contributor_slug}/{lesson_slug}/{version}_{ts}.webm"
+
+    # 6. Upload to GCS (fail-closed — if GCS not configured, 503)
+    gcs_path = upload_reading_audio_to_gcs_sync(
+        audio_bytes=audio_bytes,
+        mime_type=raw_ct or "audio/webm",
+        blob_path=temp_path,
+    )
+    if gcs_path is None:
+        logger.error(
+            "testset upload: GCS upload returned None for contributor=%s lesson=%s",
+            contributor_name,
+            lesson_id,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="GCS 儲存失敗，請聯絡管理員（READING_AUDIO_GCS_BUCKET 未設定或服務不可用）",
+        )
+
+    # 7. Persist to DB
+    try:
+        record = TestsetRecording(
+            contributor_name=contributor_name,
+            grade=grade,
+            lesson_id=lesson_id,
+            version=version,
+            audio_gcs_path=gcs_path,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+    except Exception as exc:
+        db.rollback()
+        logger.error("testset upload: DB insert failed: %s", exc)
+        raise HTTPException(status_code=503, detail="資料庫寫入失敗，請重試")
+
+    logger.info(
+        "testset upload OK: id=%d contributor=%s grade=%s lesson=%s version=%s bytes=%d",
+        record.id,
+        contributor_name,
+        grade,
+        lesson_id,
+        version,
+        len(audio_bytes),
+    )
+
+    return UploadResponse(
+        id=record.id,
+        message="上傳成功！",
+        gcs_path=gcs_path,
+    )
+
+
+@router.get(
+    "/testset/list",
+    response_model=ListResponse,
+    summary="List all testset recordings (owner view)",
+    tags=["testset"],
+)
+def list_testset_recordings(
+    db: Session = Depends(get_db),
+    limit: int = 500,
+    offset: int = 0,
+) -> ListResponse:
+    """Return all testset recordings, newest first.
+
+    This endpoint is intentionally public (no auth) for v1 — the list.html
+    is only shared with Young/team. If the list grows, add a simple secret
+    header check here.
+
+    Args:
+        limit:  Max rows to return (default 500).
+        offset: Pagination offset (default 0).
+    """
+    try:
+        total = db.query(TestsetRecording).count()
+        rows = (
+            db.query(TestsetRecording)
+            .order_by(TestsetRecording.created_at.desc())
+            .offset(offset)
+            .limit(min(limit, 1000))
+            .all()
+        )
+    except Exception as exc:
+        logger.error("testset list: DB query failed: %s", exc)
+        raise HTTPException(status_code=503, detail="資料庫查詢失敗")
+
+    return ListResponse(
+        total=total,
+        recordings=[RecordingItem.model_validate(r) for r in rows],
+    )

--- a/frontend/public/testset/index.html
+++ b/frontend/public/testset/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>朗讀測試集收集 — LingoLeap</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Noto Sans TC', sans-serif; background: #f8fafc; color: #1e293b; min-height: 100vh; }
+    .header { background: #1e40af; color: white; padding: 1.25rem 1.5rem; display: flex; align-items: center; gap: 1rem; }
+    .header h1 { font-size: 1.2rem; font-weight: 700; }
+    .container { max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+    .card { background: white; border-radius: 12px; border: 1px solid #e2e8f0; padding: 1.5rem; margin-bottom: 1.25rem; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
+    .card h2 { font-size: 1rem; font-weight: 700; color: #1e40af; margin-bottom: 1rem; }
+    .form-row { display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap; }
+    .field { flex: 1; min-width: 140px; }
+    label { display: block; font-size: .8rem; font-weight: 600; color: #64748b; margin-bottom: .35rem; }
+    input, select { width: 100%; padding: .55rem .75rem; border: 1.5px solid #cbd5e1; border-radius: 8px; font-size: .95rem; outline: none; transition: border-color .15s; }
+    input:focus, select:focus { border-color: #3b82f6; }
+    .btn { display: inline-flex; align-items: center; gap: .45rem; padding: .6rem 1.2rem; border: none; border-radius: 8px; font-size: .9rem; font-weight: 600; cursor: pointer; transition: background .15s; }
+    .btn-primary { background: #1e40af; color: white; }
+    .btn-primary:hover { background: #1d4ed8; }
+    .btn-primary:disabled { background: #94a3b8; cursor: not-allowed; }
+    .btn-danger { background: #dc2626; color: white; }
+    .btn-danger:hover { background: #b91c1c; }
+    .btn-success { background: #16a34a; color: white; }
+    .btn-success:hover { background: #15803d; }
+    .btn-outline { background: white; color: #475569; border: 1.5px solid #cbd5e1; }
+    .btn-outline:hover { background: #f1f5f9; }
+    .lesson-grid { display: grid; gap: .75rem; }
+    .lesson-card { border: 2px solid #e2e8f0; border-radius: 10px; padding: 1rem; cursor: pointer; transition: all .15s; }
+    .lesson-card:hover { border-color: #3b82f6; background: #eff6ff; }
+    .lesson-card.selected { border-color: #1e40af; background: #dbeafe; }
+    .lesson-title { font-weight: 700; font-size: 1rem; }
+    .lesson-meta { font-size: .78rem; color: #64748b; margin-top: .2rem; }
+    .lesson-preview { font-size: .83rem; color: #475569; margin-top: .6rem; line-height: 1.6; max-height: 3.2rem; overflow: hidden; }
+    .text-box { background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 8px; padding: 1rem; font-size: 1rem; line-height: 1.9; color: #1e293b; max-height: 280px; overflow-y: auto; }
+    .version-row { display: flex; gap: .75rem; margin-bottom: 1rem; }
+    .version-btn { flex: 1; padding: .65rem; border: 2px solid #e2e8f0; border-radius: 8px; font-size: .88rem; font-weight: 600; cursor: pointer; text-align: center; transition: all .15s; background: white; color: #475569; }
+    .version-btn.selected { border-color: #1e40af; background: #dbeafe; color: #1e40af; }
+    .version-btn.selected.error { border-color: #dc2626; background: #fee2e2; color: #dc2626; }
+    .rec-controls { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
+    .timer { font-size: 1.5rem; font-weight: 700; color: #1e40af; min-width: 3rem; }
+    .timer.recording { color: #dc2626; }
+    audio { width: 100%; margin-top: .75rem; display: none; }
+    audio.visible { display: block; }
+    .status-msg { margin-top: .75rem; padding: .65rem .9rem; border-radius: 8px; font-size: .88rem; font-weight: 500; display: none; }
+    .status-msg.show { display: block; }
+    .status-msg.success { background: #dcfce7; color: #166534; }
+    .status-msg.error { background: #fee2e2; color: #991b1b; }
+    .status-msg.info { background: #dbeafe; color: #1e40af; }
+    .uploaded-list { margin-top: 1rem; }
+    .uploaded-item { display: flex; align-items: center; gap: .5rem; padding: .4rem 0; border-bottom: 1px solid #f1f5f9; font-size: .85rem; color: #374151; }
+    .badge { font-size: .7rem; padding: .15rem .5rem; border-radius: 99px; font-weight: 600; }
+    .badge.correct { background: #dcfce7; color: #166534; }
+    .badge.error { background: #fee2e2; color: #991b1b; }
+    .step-indicator { display: flex; gap: .5rem; margin-bottom: 1.5rem; }
+    .step { flex: 1; height: 4px; border-radius: 2px; background: #e2e8f0; }
+    .step.done { background: #1e40af; }
+    .step.active { background: #93c5fd; }
+    .hidden { display: none !important; }
+    .pulse { animation: pulse 1s infinite; }
+    @keyframes pulse { 0%,100% { opacity:1 } 50% { opacity:.5 } }
+    .info-banner { background: #fefce8; border: 1.5px solid #fbbf24; border-radius: 10px; padding: 1rem; font-size: .88rem; color: #92400e; margin-bottom: 1.25rem; }
+  </style>
+</head>
+<body>
+<div class="header">
+  <div>
+    <h1>朗讀人聲測試集</h1>
+    <div style="font-size:.78rem;opacity:.8;margin-top:.15rem">LingoLeap AI 閱讀教學平台</div>
+  </div>
+</div>
+
+<div class="container">
+  <!-- Step indicator -->
+  <div class="step-indicator" id="stepIndicator">
+    <div class="step active" id="s1"></div>
+    <div class="step" id="s2"></div>
+    <div class="step" id="s3"></div>
+    <div class="step" id="s4"></div>
+  </div>
+
+  <div class="info-banner">
+    感謝你參與 LingoLeap 人聲測試集收集！你的錄音將幫助我們訓練更準確的朗讀 AI，讓更多孩子受益。
+  </div>
+
+  <!-- Step 1: Identity -->
+  <div class="card" id="stepIdentity">
+    <h2>第 1 步：請輸入你的資訊</h2>
+    <div class="form-row">
+      <div class="field">
+        <label>姓名（不會公開顯示）</label>
+        <input type="text" id="nameInput" placeholder="例：王小明" maxlength="30" />
+      </div>
+      <div class="field">
+        <label>年級 / 身分</label>
+        <select id="gradeInput">
+          <option value="">請選擇</option>
+          <option value="小一">國小一年級</option>
+          <option value="小二">國小二年級</option>
+          <option value="小三">國小三年級</option>
+          <option value="小四">國小四年級</option>
+          <option value="小五">國小五年級</option>
+          <option value="小六">國小六年級</option>
+          <option value="國中生">國中生</option>
+          <option value="高中生">高中生</option>
+          <option value="大學生">大學生</option>
+          <option value="老師">老師</option>
+          <option value="大人">大人</option>
+        </select>
+      </div>
+    </div>
+    <button class="btn btn-primary" onclick="goStep2()">下一步 →</button>
+  </div>
+
+  <!-- Step 2: Select lesson -->
+  <div class="card hidden" id="stepLesson">
+    <h2>第 2 步：選一篇課文來朗讀</h2>
+    <div class="lesson-grid" id="lessonGrid"></div>
+    <div style="margin-top:1rem;display:flex;gap:.5rem">
+      <button class="btn btn-outline" onclick="goStep(1)">← 返回</button>
+      <button class="btn btn-primary" onclick="goStep3()" id="selectLessonBtn" disabled>選好了 →</button>
+    </div>
+  </div>
+
+  <!-- Step 3: Record -->
+  <div class="card hidden" id="stepRecord">
+    <h2>第 3 步：選版本並錄音</h2>
+    <div style="background:#f1f5f9;border-radius:8px;padding:.75rem;margin-bottom:1rem;font-size:.82rem;color:#475569">
+      <strong>課文：</strong><span id="selectedLessonTitle"></span>
+    </div>
+
+    <div style="margin-bottom:.75rem">
+      <label style="font-size:.85rem;font-weight:700;color:#374151;margin-bottom:.5rem;display:block">請選擇要錄哪個版本：</label>
+      <div class="version-row">
+        <button class="version-btn selected" id="vBtnCorrect" onclick="selectVersion('correct', this)">
+          正確版<br><span style="font-weight:400;font-size:.75rem">正常照課文念</span>
+        </button>
+        <button class="version-btn error" id="vBtnError" onclick="selectVersion('error', this)" style="border-color:#e2e8f0;background:white;color:#475569">
+          刻意錯誤版<br><span style="font-weight:400;font-size:.75rem">故意多錯/少讀幾個字</span>
+        </button>
+      </div>
+    </div>
+
+    <div style="margin-bottom:.75rem">
+      <label style="font-size:.85rem;font-weight:700;color:#374151;margin-bottom:.5rem;display:block">課文全文（對著念）：</label>
+      <div class="text-box" id="lessonText"></div>
+    </div>
+
+    <div class="rec-controls">
+      <button class="btn btn-danger" id="recBtn" onclick="toggleRecord()">
+        <span id="recIcon">●</span> 開始錄音
+      </button>
+      <div class="timer" id="recTimer">0:00</div>
+      <button class="btn btn-outline hidden" id="clearBtn" onclick="clearRecording()">清除重錄</button>
+    </div>
+    <audio id="playbackAudio" controls></audio>
+    <div class="status-msg" id="recStatus"></div>
+
+    <div style="margin-top:1rem;display:flex;gap:.5rem">
+      <button class="btn btn-outline" onclick="goStep(2)">← 返回</button>
+      <button class="btn btn-success hidden" id="uploadBtn" onclick="uploadRecording()">上傳這個錄音 ✓</button>
+    </div>
+  </div>
+
+  <!-- Step 4: Uploaded summary -->
+  <div class="card hidden" id="stepDone">
+    <h2>已上傳的錄音</h2>
+    <div class="uploaded-list" id="uploadedList"></div>
+    <div style="margin-top:1.25rem;display:flex;gap:.75rem;flex-wrap:wrap">
+      <button class="btn btn-primary" onclick="addAnother()">+ 再錄一個版本</button>
+      <button class="btn btn-outline" onclick="goStep(2)">換一篇課文</button>
+    </div>
+  </div>
+</div>
+
+<script>
+// ── Lesson data (embedded — v1 uses 5 lessons from backend/data/lessons/) ──
+const LESSONS = [
+  {
+    id: "L01",
+    title: "贏得喝采的輸家",
+    grade: "四年級",
+    text: `「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳~~~」這一句洗腦的廣告臺詞，是否也在你的周遭出現？她就是台灣第一人，累計214周排名世界第一的球后──戴資穎。
+
+小戴即使在強大的壓力下，仍然堅持維持自己的風格。小戴相信攻擊是最好的防禦，總是主動出擊，她追求完美的邊角球和難以預測的穿越角度，她的攻擊千變萬化，讓對手摸不著頭緒。雖然這樣的進攻方式會提高失誤率，但如果要她打穩定的安全球風，小戴就不是小戴了。這就是她獨特的地方，也是她迷人之處。
+
+2021年8月1日，小戴在東京奧運金牌賽的轉播收視率創下新高，這場小戴與陳雨菲的龍爭虎鬥，戰況勢均力敵，全臺觀眾守在電視前，目不轉睛。小戴一得分，大家歡天喜地、讚嘆不已；小戴失分，個個揪心、替她緊張。最後，小戴以2比1，21:12、16:21、16:21艱辛地輸給了陳雨菲，與金牌失之交臂。
+
+雖然輸了，但小戴贏得了全臺的心。賽後，小戴笑著說：「謝謝大家。我盡力了，就是這樣。」她的微笑給了我們一個回答──人生不只有輸和贏，重要的是你面對輸贏的態度。小戴是一個贏得喝采的輸家。`,
+  },
+  {
+    id: "L02",
+    title: "十秒的背後",
+    grade: "四年級",
+    text: `十秒鐘你能做什麼？裝一杯水、哼一段小曲、等待手機略過廣告？這十秒可能還不夠呢。這轉瞬即逝的十秒，對於百尺短跑的選手來說足已決定了一場令人血脈賁張、緊張刺激的勝負。
+
+在眾人期待的目光下，「臺灣最速男」——楊俊瀚，在2017年夏季世界大學運動會田徑男子一百公尺決賽，以10.22秒獲得第一名，替中華臺北拿下睽違二十六年的世大運田徑金牌。
+
+2018年雅加達亞運上，他以千分之二秒的差距與金牌擦身而過，些微秒數的差距帶來天壤之別的結果，讓好不容易站上的國際舞台的他心有不甘，他告訴自己：「那代表我還不夠努力，今天我輸千分位，那是上天給我的結果。」他更下定決心要超越現在的自己。
+
+看楊俊瀚的採訪影片，你會發現他說話很有力量，完全不是短跑選手刻板印象中的凶猛形象。一個人說話的態度，往往反映了他待人處事的方式：楊俊瀚的溫柔，如同他在賽場上的穩健；他的堅定，如同他奔跑時的決心。這就是屬於楊俊瀚的那十秒背後的祕密。`,
+  },
+  {
+    id: "L03",
+    title: "長高的祕密",
+    grade: "四年級",
+    text: `開學後不久，又是到健康中心量身高體重的時候。同學們嘰嘰喳喳講個不停，有人會開始炫耀自己的身高，有人則是會隱藏自己的體重。測量後老師大多會依照身高來安排班級的座位，「小承恩」只有一百三十公分，又要坐第一排。他一直都很羨慕最後一排的「大承恩」，明明都是男生，明明都叫承恩，身高卻差了近三十公分，他真的很不喜歡「小承恩」這個外號。
+
+可能很多同學都有「小承恩」這樣的煩惱。那麼要怎樣才能長高呢？是跳繩嗎？喝牛奶嗎？還是要喝轉骨湯呢？其實這些答案都不完全正確。根據研究：「充足的睡眠」、「適當的運動」及「均衡的飲食」才是長高的關鍵。
+
+我們會長高，主要是在睡眠時，身體會分泌「生長激素」，這種激素會刺激身體發育，不僅能讓骨骼和肌肉生長，對於身高增長也有很大的幫助。生長激素大量分泌的時間，大約是在晚上十一點到凌晨一點之間，因此最好能在十點前入睡。而且，如果睡眠時間不夠，分泌的生長激素就會相對減少，身高自然不容易增加，更可能導致精神不濟，影響學習效率。`,
+  },
+  {
+    id: "L04",
+    title: "運動科學",
+    grade: "四年級",
+    text: `漫畫《一拳超人》中的埼玉老師堅持了三年，每天做一百次的伏地挺身、一百次的仰臥起坐、一百次的深蹲、十公里的長跑，終於擁有一拳就能打倒所有敵人的實力。許多人看完漫畫後，紛紛效法實施「一拳超人訓練菜單」。
+
+蒼藍鴿醫師從運動科學的角度說明埼玉老師的訓練菜單並不是那麼妥當：研究證實，這四種運動方式是相互衝突的，有氧運動（訓練心肺功能，如長跑）與其他訓練肌肉的運動，擺在同一天進行，效果會相互抵消。
+
+科學告訴我們，想增肌時，最好進行無氧的重量訓練，每次訓練完，必須讓肌肉有足夠的休息時間，才能達到增肌的效果。而有氧運動和重量訓練最好不要在同一天進行，如果非得如此，最好以重量訓練為優先，有氧運動排在後面進行。此外，每次訓練後一定要有足夠的睡眠，才能讓肌肉充分恢復。`,
+  },
+  {
+    id: "L05",
+    title: "穿越極限的跑者",
+    grade: "四年級",
+    text: `「一個夢想如果可以被想像，那就有存在的價值。但重點是你要怎麼計劃並且執行。」臺灣極地超級馬拉松好手陳彥博說。他跑過沙漠、高山和冰原，是第一位勇奪四大極地超級馬拉松巡迴賽總冠軍的亞洲人。
+
+2008年，陳彥博與超馬好手林義傑、劉柏園組隊，挑戰磁北極六百五十公里極限馬拉松，獲得團體組第三名的殊榮，他是歷屆最年輕完賽的選手，這場比賽帶給他的感動無可言喻，也是他跨入極地賽的夢想起點。
+
+2011年，二十三歲的陳彥博下了一個決定：「我要在五年內挑戰世界七大洲、八大站的超級馬拉松。」在逐夢的過程中，他承受了常人難以想像的艱辛──凍傷、迷路、身體極限的挑戰。但他告訴自己，每一步都算數，每一次堅持都是在向夢想靠近一步。他的故事告訴我們：極限不是終點，而是新的起點。`,
+  },
+];
+
+// ── App state ──
+const state = {
+  name: '',
+  grade: '',
+  selectedLesson: null,
+  version: 'correct',
+  recordedBlob: null,
+  uploadedItems: [],
+  mediaRecorder: null,
+  isRecording: false,
+  timerInterval: null,
+  elapsedSec: 0,
+};
+
+// ── Determine API base URL ──
+// In dev (localhost), hit the backend directly.
+// In production/preview (Cloud Run frontend), proxy via /api (same origin).
+function apiBase() {
+  if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+    return 'http://localhost:8000';
+  }
+  return '';
+}
+
+// ── Step navigation ──
+function setStep(n) {
+  document.getElementById('stepIdentity').classList.toggle('hidden', n !== 1);
+  document.getElementById('stepLesson').classList.toggle('hidden', n !== 2);
+  document.getElementById('stepRecord').classList.toggle('hidden', n !== 3);
+  document.getElementById('stepDone').classList.toggle('hidden', n !== 4);
+  [1,2,3,4].forEach(i => {
+    const el = document.getElementById(`s${i}`);
+    el.className = 'step ' + (i < n ? 'done' : i === n ? 'active' : '');
+  });
+}
+
+function goStep(n) { setStep(n); }
+
+function goStep2() {
+  const name = document.getElementById('nameInput').value.trim();
+  const grade = document.getElementById('gradeInput').value;
+  if (!name) { alert('請輸入姓名'); return; }
+  if (!grade) { alert('請選擇年級'); return; }
+  state.name = name;
+  state.grade = grade;
+  renderLessonGrid();
+  setStep(2);
+}
+
+function goStep3() {
+  if (!state.selectedLesson) { alert('請先選一篇課文'); return; }
+  document.getElementById('selectedLessonTitle').textContent = state.selectedLesson.title;
+  document.getElementById('lessonText').textContent = state.selectedLesson.text;
+  clearRecording();
+  setStep(3);
+}
+
+// ── Lesson grid ──
+function renderLessonGrid() {
+  const grid = document.getElementById('lessonGrid');
+  grid.innerHTML = '';
+  LESSONS.forEach(lesson => {
+    const div = document.createElement('div');
+    div.className = 'lesson-card' + (state.selectedLesson?.id === lesson.id ? ' selected' : '');
+    div.innerHTML = `
+      <div class="lesson-title">${lesson.title}</div>
+      <div class="lesson-meta">${lesson.grade}</div>
+      <div class="lesson-preview">${lesson.text.substring(0, 80)}…</div>
+    `;
+    div.onclick = () => {
+      state.selectedLesson = lesson;
+      document.querySelectorAll('.lesson-card').forEach(c => c.classList.remove('selected'));
+      div.classList.add('selected');
+      document.getElementById('selectLessonBtn').disabled = false;
+    };
+    grid.appendChild(div);
+  });
+}
+
+// ── Version selection ──
+function selectVersion(v, btn) {
+  state.version = v;
+  document.getElementById('vBtnCorrect').className = 'version-btn' + (v === 'correct' ? ' selected' : '');
+  document.getElementById('vBtnError').className = 'version-btn error' + (v === 'error' ? ' selected error' : '');
+  clearRecording();
+}
+
+// ── Recording ──
+async function toggleRecord() {
+  if (state.isRecording) {
+    stopRecording();
+  } else {
+    await startRecording();
+  }
+}
+
+async function startRecording() {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const chunks = [];
+    state.mediaRecorder = new MediaRecorder(stream);
+    state.mediaRecorder.ondataavailable = e => { if (e.data.size > 0) chunks.push(e.data); };
+    state.mediaRecorder.onstop = () => {
+      state.recordedBlob = new Blob(chunks, { type: 'audio/webm' });
+      const url = URL.createObjectURL(state.recordedBlob);
+      const audio = document.getElementById('playbackAudio');
+      audio.src = url;
+      audio.className = 'visible';
+      document.getElementById('clearBtn').classList.remove('hidden');
+      document.getElementById('uploadBtn').classList.remove('hidden');
+      showStatus('recStatus', '錄音完成！請先回放確認，再按「上傳」', 'info');
+      stream.getTracks().forEach(t => t.stop());
+    };
+    state.mediaRecorder.start();
+    state.isRecording = true;
+    state.elapsedSec = 0;
+    const btn = document.getElementById('recBtn');
+    btn.className = 'btn btn-danger pulse';
+    btn.innerHTML = '<span id="recIcon">■</span> 停止錄音';
+    const timerEl = document.getElementById('recTimer');
+    timerEl.className = 'timer recording';
+    state.timerInterval = setInterval(() => {
+      state.elapsedSec++;
+      const m = Math.floor(state.elapsedSec / 60);
+      const s = state.elapsedSec % 60;
+      timerEl.textContent = `${m}:${s.toString().padStart(2,'0')}`;
+    }, 1000);
+  } catch (err) {
+    showStatus('recStatus', `無法存取麥克風：${err.message}`, 'error');
+  }
+}
+
+function stopRecording() {
+  if (state.mediaRecorder && state.isRecording) {
+    state.mediaRecorder.stop();
+    state.isRecording = false;
+    clearInterval(state.timerInterval);
+    const btn = document.getElementById('recBtn');
+    btn.className = 'btn btn-danger';
+    btn.innerHTML = '<span>●</span> 重新錄音';
+    document.getElementById('recTimer').className = 'timer';
+  }
+}
+
+function clearRecording() {
+  if (state.mediaRecorder && state.isRecording) {
+    state.mediaRecorder.stop();
+    state.isRecording = false;
+    clearInterval(state.timerInterval);
+  }
+  state.recordedBlob = null;
+  const audio = document.getElementById('playbackAudio');
+  audio.src = '';
+  audio.className = '';
+  document.getElementById('clearBtn').classList.add('hidden');
+  document.getElementById('uploadBtn').classList.add('hidden');
+  document.getElementById('recTimer').textContent = '0:00';
+  document.getElementById('recTimer').className = 'timer';
+  const btn = document.getElementById('recBtn');
+  btn.className = 'btn btn-danger';
+  btn.innerHTML = '<span>●</span> 開始錄音';
+  hideStatus('recStatus');
+}
+
+// ── Upload ──
+async function uploadRecording() {
+  if (!state.recordedBlob) { alert('請先錄音'); return; }
+  const btn = document.getElementById('uploadBtn');
+  btn.disabled = true;
+  btn.textContent = '上傳中…';
+  showStatus('recStatus', '上傳中，請稍候…', 'info');
+
+  const fd = new FormData();
+  fd.append('contributor_name', state.name);
+  fd.append('grade', state.grade);
+  fd.append('lesson_id', state.selectedLesson.id);
+  fd.append('version', state.version);
+  fd.append('audio', state.recordedBlob, `${state.selectedLesson.id}_${state.version}.webm`);
+
+  try {
+    const res = await fetch(`${apiBase()}/api/testset/upload`, {
+      method: 'POST',
+      body: fd,
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.detail || `HTTP ${res.status}`);
+    }
+    state.uploadedItems.push({
+      lesson: state.selectedLesson.title,
+      lessonId: state.selectedLesson.id,
+      version: state.version,
+      id: data.id,
+    });
+    showStep4();
+  } catch (err) {
+    showStatus('recStatus', `上傳失敗：${err.message}`, 'error');
+    btn.disabled = false;
+    btn.textContent = '重試上傳';
+  }
+}
+
+function showStep4() {
+  renderUploadedList();
+  setStep(4);
+}
+
+function renderUploadedList() {
+  const list = document.getElementById('uploadedList');
+  list.innerHTML = '';
+  if (state.uploadedItems.length === 0) {
+    list.innerHTML = '<div style="color:#64748b;font-size:.85rem">還沒有上傳的錄音</div>';
+    return;
+  }
+  state.uploadedItems.forEach(item => {
+    const div = document.createElement('div');
+    div.className = 'uploaded-item';
+    div.innerHTML = `
+      <span style="flex:1">${item.lesson}</span>
+      <span class="badge ${item.version}">${item.version === 'correct' ? '正確版' : '錯誤版'}</span>
+      <span style="color:#16a34a;font-size:.85rem">✓ #${item.id}</span>
+    `;
+    list.appendChild(div);
+  });
+}
+
+function addAnother() {
+  // Keep identity + lesson, go back to recording step
+  clearRecording();
+  setStep(3);
+}
+
+// ── Status helpers ──
+function showStatus(id, msg, type) {
+  const el = document.getElementById(id);
+  el.textContent = msg;
+  el.className = `status-msg show ${type}`;
+}
+
+function hideStatus(id) {
+  const el = document.getElementById(id);
+  el.className = 'status-msg';
+}
+
+// ── Init ──
+setStep(1);
+</script>
+</body>
+</html>

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>測試集錄音清單 (Owner) — LingoLeap</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Noto Sans TC', sans-serif; background: #f8fafc; color: #1e293b; }
+    .header { background: #1e3a5f; color: white; padding: 1rem 1.5rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+    .header-left h1 { font-size: 1.1rem; font-weight: 700; }
+    .header-left small { font-size: .75rem; opacity: .75; }
+    .share-btn { display: inline-flex; align-items: center; gap: .4rem; padding: .5rem 1rem; background: #3b82f6; color: white; border: none; border-radius: 8px; font-size: .85rem; font-weight: 600; cursor: pointer; transition: background .15s; text-decoration: none; }
+    .share-btn:hover { background: #2563eb; }
+    .container { max-width: 1000px; margin: 1.5rem auto; padding: 0 1rem; }
+    .stats-row { display: flex; gap: 1rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .stat-card { flex: 1; min-width: 120px; background: white; border-radius: 10px; border: 1px solid #e2e8f0; padding: .9rem 1rem; box-shadow: 0 1px 3px rgba(0,0,0,.05); }
+    .stat-num { font-size: 1.8rem; font-weight: 800; color: #1e40af; }
+    .stat-label { font-size: .75rem; color: #64748b; margin-top: .2rem; }
+    .filter-row { display: flex; gap: .75rem; margin-bottom: 1rem; flex-wrap: wrap; align-items: center; }
+    .filter-row select, .filter-row input { padding: .45rem .7rem; border: 1.5px solid #cbd5e1; border-radius: 8px; font-size: .85rem; outline: none; }
+    .filter-row select:focus, .filter-row input:focus { border-color: #3b82f6; }
+    .refresh-btn { padding: .45rem .9rem; background: #f1f5f9; border: 1.5px solid #cbd5e1; border-radius: 8px; font-size: .85rem; cursor: pointer; }
+    .refresh-btn:hover { background: #e2e8f0; }
+    .table-wrap { background: white; border-radius: 12px; border: 1px solid #e2e8f0; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
+    table { width: 100%; border-collapse: collapse; }
+    thead { background: #f8fafc; }
+    th { padding: .75rem 1rem; font-size: .75rem; font-weight: 700; color: #64748b; text-align: left; border-bottom: 1px solid #e2e8f0; white-space: nowrap; }
+    td { padding: .7rem 1rem; font-size: .85rem; border-bottom: 1px solid #f1f5f9; vertical-align: middle; }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: #f8fafc; }
+    .badge { display: inline-block; font-size: .7rem; padding: .18rem .55rem; border-radius: 99px; font-weight: 600; }
+    .badge.correct { background: #dcfce7; color: #166534; }
+    .badge.error { background: #fee2e2; color: #991b1b; }
+    audio { max-width: 220px; height: 32px; }
+    .dl-btn { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .7rem; background: #f1f5f9; border: 1px solid #cbd5e1; border-radius: 6px; font-size: .75rem; color: #374151; cursor: pointer; text-decoration: none; }
+    .dl-btn:hover { background: #e2e8f0; }
+    .empty { text-align: center; padding: 3rem; color: #94a3b8; font-size: .95rem; }
+    .loading { text-align: center; padding: 2rem; color: #64748b; }
+    .error-msg { background: #fee2e2; color: #991b1b; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: .88rem; }
+    .copy-toast { position: fixed; bottom: 1.5rem; right: 1.5rem; background: #1e293b; color: white; padding: .6rem 1.2rem; border-radius: 8px; font-size: .85rem; opacity: 0; transition: opacity .3s; pointer-events: none; z-index: 999; }
+    .copy-toast.show { opacity: 1; }
+    .contributor-url-box { background: #f1f5f9; border: 1.5px solid #cbd5e1; border-radius: 8px; padding: .65rem 1rem; margin-bottom: 1.25rem; display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
+    .contributor-url-box span { font-size: .82rem; color: #475569; font-family: monospace; flex: 1; word-break: break-all; }
+    .contributor-url-box button { padding: .4rem .8rem; background: #1e40af; color: white; border: none; border-radius: 6px; font-size: .78rem; cursor: pointer; white-space: nowrap; }
+  </style>
+</head>
+<body>
+<div class="header">
+  <div class="header-left">
+    <h1>測試集錄音清單 (Owner 頁)</h1>
+    <small>LingoLeap 人聲測試集 — 只有拿到這連結的人可以看</small>
+  </div>
+  <div style="display:flex;gap:.5rem;align-items:center">
+    <a href="./index.html" class="share-btn" target="_blank">開貢獻者頁</a>
+    <button class="share-btn" onclick="copyContributorLink()">複製貢獻者連結</button>
+  </div>
+</div>
+
+<div class="container">
+
+  <!-- Contributor URL box -->
+  <div class="contributor-url-box">
+    <span id="contributorUrl"></span>
+    <button onclick="copyContributorLink()">複製連結</button>
+  </div>
+
+  <!-- Stats -->
+  <div class="stats-row">
+    <div class="stat-card">
+      <div class="stat-num" id="statTotal">—</div>
+      <div class="stat-label">總錄音數</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-num" id="statContributors">—</div>
+      <div class="stat-label">貢獻者人數</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-num" id="statCorrect">—</div>
+      <div class="stat-label">正確版</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-num" id="statError">—</div>
+      <div class="stat-label">錯誤版</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-num" id="statLessons">—</div>
+      <div class="stat-label">涵蓋課文數</div>
+    </div>
+  </div>
+
+  <!-- Filters -->
+  <div class="filter-row">
+    <select id="filterVersion" onchange="applyFilter()">
+      <option value="">所有版本</option>
+      <option value="correct">正確版</option>
+      <option value="error">錯誤版</option>
+    </select>
+    <select id="filterLesson" onchange="applyFilter()">
+      <option value="">所有課文</option>
+    </select>
+    <input type="text" id="filterName" placeholder="搜尋貢獻者名字…" oninput="applyFilter()" />
+    <button class="refresh-btn" onclick="loadData()">重新整理</button>
+    <span id="filterCount" style="font-size:.82rem;color:#64748b"></span>
+  </div>
+
+  <div id="errorMsg" class="error-msg" style="display:none"></div>
+
+  <!-- Table -->
+  <div class="table-wrap">
+    <div class="loading" id="loadingMsg">載入中…</div>
+    <table id="recTable" style="display:none">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>貢獻者</th>
+          <th>年級</th>
+          <th>課文</th>
+          <th>版本</th>
+          <th>上傳時間</th>
+          <th>播放</th>
+        </tr>
+      </thead>
+      <tbody id="recTbody"></tbody>
+    </table>
+    <div class="empty hidden" id="emptyMsg">目前還沒有錄音，分享貢獻者連結開始收集！</div>
+  </div>
+</div>
+
+<div class="copy-toast" id="copyToast">連結已複製！</div>
+
+<script>
+let allData = [];
+
+function apiBase() {
+  if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+    return 'http://localhost:8000';
+  }
+  return '';
+}
+
+function contributorUrl() {
+  return location.origin + location.pathname.replace('list.html', 'index.html');
+}
+
+// Set contributor URL display
+document.getElementById('contributorUrl').textContent = contributorUrl();
+
+function copyContributorLink() {
+  const url = contributorUrl();
+  navigator.clipboard.writeText(url).then(() => {
+    const t = document.getElementById('copyToast');
+    t.className = 'copy-toast show';
+    setTimeout(() => { t.className = 'copy-toast'; }, 2000);
+  });
+}
+
+async function loadData() {
+  document.getElementById('loadingMsg').style.display = 'block';
+  document.getElementById('recTable').style.display = 'none';
+  document.getElementById('emptyMsg').classList.add('hidden');
+  document.getElementById('errorMsg').style.display = 'none';
+
+  try {
+    const res = await fetch(`${apiBase()}/api/testset/list?limit=500`);
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      throw new Error(d.detail || `HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    allData = data.recordings || [];
+    populateLessonFilter();
+    updateStats();
+    applyFilter();
+  } catch (err) {
+    document.getElementById('loadingMsg').style.display = 'none';
+    const msg = document.getElementById('errorMsg');
+    msg.textContent = `載入失敗：${err.message}`;
+    msg.style.display = 'block';
+  }
+}
+
+function populateLessonFilter() {
+  const lessons = [...new Set(allData.map(r => r.lesson_id))].sort();
+  const sel = document.getElementById('filterLesson');
+  sel.innerHTML = '<option value="">所有課文</option>';
+  lessons.forEach(l => {
+    const opt = document.createElement('option');
+    opt.value = l;
+    opt.textContent = l;
+    sel.appendChild(opt);
+  });
+}
+
+function updateStats() {
+  document.getElementById('statTotal').textContent = allData.length;
+  document.getElementById('statContributors').textContent = new Set(allData.map(r => r.contributor_name)).size;
+  document.getElementById('statCorrect').textContent = allData.filter(r => r.version === 'correct').length;
+  document.getElementById('statError').textContent = allData.filter(r => r.version === 'error').length;
+  document.getElementById('statLessons').textContent = new Set(allData.map(r => r.lesson_id)).size;
+}
+
+function applyFilter() {
+  const version = document.getElementById('filterVersion').value;
+  const lesson = document.getElementById('filterLesson').value;
+  const name = document.getElementById('filterName').value.toLowerCase().trim();
+
+  const filtered = allData.filter(r => {
+    if (version && r.version !== version) return false;
+    if (lesson && r.lesson_id !== lesson) return false;
+    if (name && !r.contributor_name.toLowerCase().includes(name)) return false;
+    return true;
+  });
+
+  renderTable(filtered);
+  document.getElementById('filterCount').textContent = filtered.length < allData.length
+    ? `顯示 ${filtered.length} / ${allData.length} 筆`
+    : '';
+}
+
+function renderTable(rows) {
+  document.getElementById('loadingMsg').style.display = 'none';
+
+  if (rows.length === 0) {
+    document.getElementById('recTable').style.display = 'none';
+    document.getElementById('emptyMsg').classList.remove('hidden');
+    return;
+  }
+
+  document.getElementById('emptyMsg').classList.add('hidden');
+  document.getElementById('recTable').style.display = 'table';
+
+  const tbody = document.getElementById('recTbody');
+  tbody.innerHTML = '';
+
+  rows.forEach((r, idx) => {
+    const tr = document.createElement('tr');
+    const uploadedAt = new Date(r.created_at).toLocaleString('zh-TW', {
+      month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    });
+
+    // GCS path → can't play directly (private bucket).
+    // Show path for reference; download requires signed URL (v2 feature).
+    tr.innerHTML = `
+      <td style="color:#94a3b8;font-size:.75rem">${r.id}</td>
+      <td style="font-weight:600">${escHtml(r.contributor_name)}</td>
+      <td>${escHtml(r.grade)}</td>
+      <td style="font-family:monospace;font-size:.8rem">${escHtml(r.lesson_id)}</td>
+      <td><span class="badge ${r.version}">${r.version === 'correct' ? '正確版' : '錯誤版'}</span></td>
+      <td style="color:#64748b;font-size:.78rem;white-space:nowrap">${uploadedAt}</td>
+      <td>
+        <span style="font-size:.72rem;color:#94a3b8;font-family:monospace" title="${escHtml(r.audio_gcs_path)}">
+          ${escHtml(r.audio_gcs_path.split('/').pop())}
+        </span>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Init
+loadData();
+</script>
+</body>
+</html>

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -643,7 +643,7 @@ modules:
   - 2205
   source_meetings:
   - docs/professor-7-lessons-block-decomposition.md
-  last_reviewed: 2026-06-18
+  last_reviewed: 2026-06-20
   owner: young
   intent: specs/modules/spotlight_v2/INTENT.md
 - spec_id: step.sequence.registry


### PR DESCRIPTION
Fixes #2287

## Summary

建立最小可用的人聲測試集收集平台，含兩個頁面 + 兩個 API endpoint：

### 前端（純靜態 HTML，無需 React build）
- `frontend/public/testset/index.html` — 貢獻者頁（無登入）
  - 填名字 + 年級 → 選 5 篇課文 → 錄音（MediaRecorder）→ 回放確認 → 上傳
  - 支援正確版 + 刻意錯誤版
- `frontend/public/testset/list.html` — Owner 清單頁
  - 統計卡（總錄音數、貢獻者人數、正確/錯誤版、涵蓋課文）
  - 可篩選版本 / 課文 / 貢獻者名字
  - 一鍵複製貢獻者連結按鈕

### 後端
- `POST /api/testset/upload` — 公開上傳 endpoint（無 auth）
  - Rate-limit：10 次 / 分鐘 per IP
  - Size cap：15 MB
  - Content-type 驗證：audio/* 前綴
  - Fail-closed：GCS 或 DB 失敗 → 503
  - GCS path：`test-dataset/{contributor_slug}/{lesson_slug}/{version}_{ts}.webm`
- `GET /api/testset/list` — 清單 endpoint（無 auth，v1）

### DB
- 新 model：`TestsetRecording`（standalone，無 FK）
- Migration：`b3c4d5e6f7g8`（idempotent DDL，`IF NOT EXISTS`）

## Migration — ⚠️ 需在 deploy 後手動跑

```bash
cd backend && alembic upgrade head
```

Staging DB 已設 `READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio`，migration 後即可測試上傳。

## Test plan

1. 開 PR Preview URL `/testset/` → 輸入名字 + 年級 → 選課文 → 錄音 → 上傳
2. 確認上傳回 HTTP 200 + response JSON 含 `id`
3. 開 `/testset/list.html` → 確認清單出現剛才的錄音
4. 確認統計數字正確
5. 確認「複製貢獻者連結」按鈕可用

## Checklist

- [x] rate-limit + size cap + fail-closed
- [x] SQLAlchemy model safety (no FK, server_default timestamps)
- [x] Idempotent migration (IF NOT EXISTS DDL)
- [x] 兩個 HTML 頁面（貢獻者 + owner list）
- [x] specs/run-ci.sh --quick 通過
- [x] Critic review: APPROVE
- [ ] Migration 跑完（Staging deploy 後手動跑）
- [ ] End-to-end 錄音上傳驗證

🤖 由 Claude AI 代發（非 Young 本人）