### PR TITLE
feat(presentation): spotlight + keypoints pipeline boards (Fixes #2309)

### DIFF
--- a/frontend/public/presentation/keypoints-pipeline.html
+++ b/frontend/public/presentation/keypoints-pipeline.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>文章重點表 Keypoints Pipeline — 架構 / 開發 / QA / 資料 / 缺口&債</title>
+<style>
+  :root{
+    --bg:#FDF8F0; --ink:#1a1a2e; --purple:#5B4FC4; --muted:#6b6b8a;
+    --card:#fff; --line:#e7e2d8; --green:#16a34a; --red:#dc2626; --amber:#d97706;
+    --chip:#efe9ff;
+  }
+  *{box-sizing:border-box}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:32px 20px;line-height:1.6}
+  .container{max-width:1080px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.6rem;margin:0 0 6px}
+  .subtitle{color:var(--muted);margin:0 0 6px}
+  .oneliner{background:var(--chip);border-left:4px solid var(--purple);padding:10px 14px;border-radius:8px;margin:14px 0 4px;font-size:.95rem}
+  .updated{color:var(--muted);font-size:.78rem;margin-bottom:18px}
+  /* tabs */
+  .tabs{display:flex;gap:8px;flex-wrap:wrap;border-bottom:2px solid var(--line);margin-bottom:22px}
+  .tab{padding:10px 16px;border:none;background:none;font:inherit;font-weight:600;color:var(--muted);cursor:pointer;border-bottom:3px solid transparent;margin-bottom:-2px}
+  .tab.active{color:var(--purple);border-bottom-color:var(--purple)}
+  .pane{display:none}
+  .pane.active{display:block;animation:fade .2s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* flow — arch tab */
+  .flow{display:flex;flex-direction:column;gap:0;align-items:center}
+  .node-row{display:flex;gap:16px;align-items:flex-start;background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 16px;width:100%;max-width:760px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .node-row.branch{border-style:dashed;border-color:var(--purple)}
+  .node-text{flex:1;min-width:0}
+  .node-text .t{font-weight:700}
+  .node-text .s{font-size:.82rem;color:var(--muted);margin-top:2px}
+  .node-text .side{font-size:.72rem;display:inline-block;background:var(--chip);color:var(--purple);border-radius:6px;padding:1px 7px;margin-left:6px}
+  .node-demo{flex:0 0 160px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:80px;gap:6px}
+  @media(max-width:640px){.node-row{flex-direction:column}.node-demo{flex:none;width:100%}}
+  .arrow{color:var(--purple);font-size:1.2rem;line-height:1.1;margin:4px 0}
+  /* table */
+  table{width:100%;border-collapse:collapse;background:var(--card);border-radius:10px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06);font-size:.86rem}
+  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:#f3eee4;color:var(--ink);font-size:.8rem}
+  .nowrap{white-space:nowrap}
+  tr:last-child td{border-bottom:none}
+  code{background:#f3eee4;padding:1px 5px;border-radius:4px;font-size:.82em}
+  a{color:var(--purple);text-decoration:none}
+  a:hover{text-decoration:underline}
+  .ok{color:var(--green);font-weight:700}
+  .badword{color:var(--red);font-weight:700}
+  .pill{display:inline-block;font-size:.72rem;padding:1px 7px;border-radius:20px;background:var(--chip);color:var(--purple);margin:2px 3px 2px 0}
+  .pill.fe{background:#e0f2fe;color:#0369a1}
+  .pill.be{background:#dcfce7;color:#15803d}
+  .pill.llm{background:#fef3c7;color:#b45309}
+  .pill.sc{background:#f0fdf4;color:#166534}
+  .unverified{background:#fee2e2;color:var(--red);font-weight:700;padding:1px 7px;border-radius:6px;font-size:.78rem}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:16px 18px;margin-bottom:14px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .card h3{margin:0 0 8px;font-size:1.05rem;color:var(--purple)}
+  .debt{border-left:4px solid var(--red)}
+  .rule{border-left:4px solid var(--purple);background:var(--chip)}
+  ul{margin:6px 0;padding-left:20px}
+  li{margin:3px 0}
+  .legend{font-size:.78rem;color:var(--muted);margin-top:10px}
+
+  /* arch node animations */
+  /* DOCX table grid animation */
+  .docx-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:3px;width:120px}
+  .docx-cell{background:#e7e2d8;border-radius:3px;height:16px;animation:cellpop .8s ease-in-out infinite alternate}
+  .docx-cell:nth-child(1){animation-delay:0s}
+  .docx-cell:nth-child(2){animation-delay:.1s}
+  .docx-cell:nth-child(3){animation-delay:.2s}
+  .docx-cell:nth-child(4){animation-delay:.3s}
+  .docx-cell:nth-child(5){animation-delay:.4s}
+  .docx-cell:nth-child(6){animation-delay:.5s}
+  @keyframes cellpop{from{background:#e7e2d8}to{background:var(--purple);opacity:.7}}
+
+  /* YAML rows stacking */
+  .yaml-rows{display:flex;flex-direction:column;gap:4px;width:130px}
+  .yaml-row{height:12px;border-radius:3px;background:var(--chip);border-left:3px solid var(--purple);animation:sliderow .6s ease-in-out infinite alternate}
+  .yaml-row:nth-child(1){animation-delay:0s;width:100%}
+  .yaml-row:nth-child(2){animation-delay:.15s;width:80%}
+  .yaml-row:nth-child(3){animation-delay:.3s;width:90%}
+  .yaml-row:nth-child(4){animation-delay:.45s;width:70%}
+  @keyframes sliderow{from{opacity:.4;transform:translateX(-4px)}to{opacity:1;transform:none}}
+
+  /* server box */
+  .server-box{background:var(--chip);border:2px solid var(--purple);border-radius:8px;padding:8px 14px;text-align:center;font-size:.75rem;font-weight:700;color:var(--purple)}
+  .server-pulse{width:8px;height:8px;border-radius:50%;background:var(--green);margin:4px auto;animation:pulse 1.2s ease-in-out infinite}
+  @keyframes pulse{0%,100%{opacity:.4;transform:scale(.8)}50%{opacity:1;transform:scale(1.2)}}
+
+  /* table rows appearing */
+  .table-anim{width:130px;border:1px solid var(--line);border-radius:6px;overflow:hidden}
+  .table-row-anim{height:14px;border-bottom:1px solid var(--line);display:flex;align-items:center;padding:0 6px;gap:4px;animation:rowin .5s ease-in-out infinite alternate}
+  .table-row-anim:nth-child(1){animation-delay:0s}
+  .table-row-anim:nth-child(2){animation-delay:.2s}
+  .table-row-anim:nth-child(3){animation-delay:.4s}
+  .table-row-anim:last-child{border-bottom:none}
+  .table-cell-dot{width:24px;height:8px;border-radius:3px;background:#e7e2d8}
+  .table-cell-dot.ok-dot{background:#dcfce7}
+  @keyframes rowin{from{background:#fff}to{background:#f9f6ff}}
+
+  /* QA matrix */
+  .matrix-wrap{overflow-x:auto;margin-bottom:12px}
+  .filter-bar{margin-bottom:12px;font-size:.9rem}
+  .filter-bar select{margin-left:6px;padding:3px 8px;border:1px solid var(--line);border-radius:6px;background:#fff}
+  .cell-ok{color:var(--green);font-weight:600;text-align:center}
+  .cell-fail{color:var(--red);font-weight:600;text-align:center;cursor:help}
+  .cell-warn{color:var(--amber);text-align:center}
+  .lesson-id{font-size:.78rem;color:var(--muted);white-space:nowrap}
+  .lesson-title{font-size:.82rem;max-width:160px}
+  .qa-stat-bar{background:var(--chip);border-radius:8px;padding:10px 14px;margin-bottom:14px;display:flex;gap:16px;flex-wrap:wrap;font-size:.9rem}
+  .stat-ok{color:var(--green);font-weight:700}
+  .stat-fail{color:var(--red);font-weight:700}
+  .stat-gen{color:var(--muted);font-size:.8rem}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>文章重點表 Keypoints Pipeline · 集成板</h1>
+  <p class="subtitle">架構 / 開發 / QA / 資料 / 缺口&amp;債 — all in one</p>
+  <div class="oneliner"><b>一句話分工：</b>前端管「重點表渲染 + 互動」，後端管「從 DOCX table parser → YAML sync → API」；<b>LLM 為 fallback</b>（無 story_structure_table 時才呼叫 Gemini）。</div>
+  <p class="updated">最後更新 2026-06-20 · base staging · commit <code>63de7bad</code>（151 課 manifest）· issue <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2309">#2309</a></p>
+
+  <div class="tabs">
+    <button class="tab active" data-pane="arch">① 架構</button>
+    <button class="tab" data-pane="dev">② 開發</button>
+    <button class="tab" data-pane="qa">③ QA result</button>
+    <button class="tab" data-pane="data">④ 資料</button>
+    <button class="tab" data-pane="debt">⑤ 缺口&amp;債</button>
+  </div>
+
+  <!-- ① 架構 -->
+  <div class="pane active" id="arch">
+    <div class="flow">
+
+      <!-- node 1 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">① DOCX 表格解析 <span class="side">script</span></div>
+          <div class="s"><code>build_lesson_schema.py</code> · regex table parser · 無 LLM</div>
+        </div>
+        <div class="node-demo">
+          <div class="docx-grid">
+            <div class="docx-cell"></div><div class="docx-cell"></div><div class="docx-cell"></div>
+            <div class="docx-cell"></div><div class="docx-cell"></div><div class="docx-cell"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- node 2 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">② keypoints.yml 產出 <span class="side">script</span></div>
+          <div class="s">row / blank / checkbox cells per lesson</div>
+        </div>
+        <div class="node-demo">
+          <div class="yaml-rows">
+            <div class="yaml-row"></div>
+            <div class="yaml-row"></div>
+            <div class="yaml-row"></div>
+            <div class="yaml-row"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- node 3 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">③ keypoints_table_sync.py <span class="side">script</span></div>
+          <div class="s">sync 進 lesson YAML → <code>story_structure_table</code></div>
+        </div>
+        <div class="node-demo">
+          <div id="sync-anim" style="font-size:.9rem;color:var(--purple);font-family:monospace;">syncing</div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- node 4 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">④ build_keypoints_qa_manifest.py <span class="side">script</span></div>
+          <div class="s">生成 <code>keypoints_manifest.json</code>（151 課）</div>
+        </div>
+        <div class="node-demo">
+          <div id="counter-anim" style="font-size:1.6rem;font-weight:700;color:var(--purple);text-align:center;">0 課</div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- node 5 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">⑤ API + cell parser <span class="side">後端</span></div>
+          <div class="s"><code>GET /api/stories/{id}/structure</code> → <code>story_structure_cell_parser.py</code> → frontend props</div>
+        </div>
+        <div class="node-demo">
+          <div class="server-box">
+            API
+            <div class="server-pulse"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- node 6 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">⑥ StoryStructureLabPage.tsx <span class="side">前端</span></div>
+          <div class="s">渲染重點表格 / LLM fallback 標示</div>
+        </div>
+        <div class="node-demo">
+          <div class="table-anim">
+            <div class="table-row-anim"><div class="table-cell-dot"></div><div class="table-cell-dot ok-dot"></div></div>
+            <div class="table-row-anim"><div class="table-cell-dot"></div><div class="table-cell-dot ok-dot"></div></div>
+            <div class="table-row-anim"><div class="table-cell-dot"></div><div class="table-cell-dot ok-dot"></div></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <p class="legend">LLM 僅 fallback（無 story_structure_table 時 generate_story_structure() → Gemini 2.5 Flash）；①-⑤ 全無 LLM</p>
+  </div>
+
+  <!-- ② 開發 -->
+  <div class="pane" id="dev">
+    <table>
+      <thead>
+        <tr>
+          <th class="nowrap">階段</th>
+          <th>端</th>
+          <th>功能</th>
+          <th>檔案</th>
+          <th>commit</th>
+          <th>狀態</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="nowrap">① DOCX table 解析</td>
+          <td><span class="pill sc">script</span></td>
+          <td>regex 抽 keypoints 表</td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/scripts/build_lesson_schema.py"><code>scripts/build_lesson_schema.py</code></a></td>
+          <td><code>9a737860</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">② keypoints.yml</td>
+          <td><span class="pill sc">script</span></td>
+          <td>row/blank cell schema</td>
+          <td><code>backend/data/lessons/*.yml</code>（keypoints key）</td>
+          <td><code>680c656a</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">③ sync 進 lesson YAML</td>
+          <td><span class="pill sc">script</span></td>
+          <td>keypoints_table_sync.py</td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/scripts/keypoints_table_sync.py"><code>scripts/keypoints_table_sync.py</code></a></td>
+          <td><code>680c656a</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">④ QA manifest 生成</td>
+          <td><span class="pill sc">script</span></td>
+          <td>151 課 gate 驗證</td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/scripts/build_keypoints_qa_manifest.py"><code>scripts/build_keypoints_qa_manifest.py</code></a></td>
+          <td><code>63de7bad</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">⑤ API + cell parser</td>
+          <td><span class="pill be">後端</span></td>
+          <td>story_structure_cell_parser → typed cells</td>
+          <td>
+            <a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/services/story_structure_cell_parser.py"><code>story_structure_cell_parser.py</code></a><br>
+            <a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/routes/stories.py"><code>backend/app/routes/stories.py</code></a>
+          </td>
+          <td><code>9a737860</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">⑥ StoryStructureLabPage</td>
+          <td><span class="pill fe">前端</span></td>
+          <td>重點表渲染</td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/frontend/src/pages/admin/story-structure-lab/StoryStructureLabPage.tsx"><code>StoryStructureLabPage.tsx</code></a></td>
+          <td><code>9a737860</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">LLM fallback</td>
+          <td><span class="pill llm">後端·LLM</span></td>
+          <td>generate_story_structure() Gemini 2.5 Flash</td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/routes/stories.py"><code>backend/app/routes/stories.py</code></a></td>
+          <td><code>9a737860</code> · 僅 fallback 路徑</td>
+          <td class="badword">⚠️ fallback</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="legend">前端 <span class="pill fe">前</span> · 後端 <span class="pill be">後</span> · 腳本 <span class="pill sc">script</span> · LLM <span class="pill llm">LLM</span></p>
+  </div>
+
+  <!-- ③ QA result -->
+  <div class="pane" id="qa">
+    <div id="qa-summary">載入中...</div>
+    <div class="filter-bar">
+      <label>年級篩選：</label>
+      <select id="grade-filter">
+        <option value="">全部</option>
+        <option value="G4">G4</option>
+        <option value="G5">G5</option>
+        <option value="G6">G6</option>
+        <option value="G7">G7</option>
+        <option value="G8">G8</option>
+        <option value="G9">G9</option>
+        <option value="文">文言文</option>
+      </select>
+    </div>
+    <div class="matrix-wrap">
+      <table id="kp-table">
+        <thead id="kp-head"></thead>
+        <tbody id="kp-body"></tbody>
+      </table>
+    </div>
+    <div id="kp-generated"></div>
+    <div class="card" style="margin-top:20px;border-left:4px solid var(--amber)">
+      <h3>Flow 覆蓋範圍說明</h3>
+      <p>此矩陣驗證 YAML 資料結構完整性（L1-L4 gates）。<b>StoryStructureLabPage 實際渲染 QA</b>（UI 呈現、互動、學生流程整合）尚無結構化資料，追蹤在 <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2309">issue #2309</a>。</p>
+    </div>
+  </div>
+
+  <!-- ④ 資料 -->
+  <div class="pane" id="data">
+    <div class="card">
+      <h3>manifest 來源</h3>
+      <ul>
+        <li>路徑：<code>frontend/public/presentation/data/keypoints_manifest.json</code></li>
+        <li>總課數：<b>151 課</b></li>
+        <li>Gates：L1 / L2 / L3_catalog / L3</li>
+        <li>生成腳本：<code>scripts/build_keypoints_qa_manifest.py</code></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>Gate 說明</h3>
+      <table>
+        <thead><tr><th>Gate</th><th>說明</th></tr></thead>
+        <tbody>
+          <tr><td><b>L1</b></td><td>row 結構存在 + blank recall 正確</td></tr>
+          <tr><td><b>L2</b></td><td>checkbox / fill_blank 格式正確</td></tr>
+          <tr><td><b>L3_catalog</b></td><td>lesson catalog 中有對應條目</td></tr>
+          <tr><td><b>L3</b></td><td>story_structure_table profile 完整</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="card">
+      <h3>tier 說明</h3>
+      <table>
+        <thead><tr><th>tier</th><th>說明</th></tr></thead>
+        <tbody>
+          <tr><td><span class="pill sc">docx_keypoints</span></td><td>從 DOCX 直接抽取（優先）</td></tr>
+          <tr><td><span class="pill">catalog_fallback</span></td><td>從 catalog 推導</td></tr>
+          <tr><td><span class="pill llm">llm_generated</span></td><td>LLM 生成（fallback）</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- ⑤ 缺口&債 -->
+  <div class="pane" id="debt">
+    <div class="card debt">
+      <h3>缺口 1：llm_generated 課文需人工驗證</h3>
+      <p>151 課全通 L1-L3 gates，但 <code>tier=llm_generated</code> 的課文由 Gemini 生成內容，尚無人工抽驗流程確保品質一致性。建議：逐課核對 keypoints 是否與紙本學習單吻合。</p>
+    </div>
+    <div class="card debt">
+      <h3>缺口 2：StoryStructureLabPage 僅後台可見</h3>
+      <p>重點表 UI（<code>StoryStructureLabPage.tsx</code>）目前只在 <b>admin 後台</b>路由可見，尚未整合進學生正式學習流程（7 步驟 stepper）。7/1 deadline 前需確認整合範圍。</p>
+    </div>
+    <div class="card rule">
+      <h3>設計鐵律</h3>
+      <ul>
+        <li>每格現況必須掛可點的證明連結（PR / commit / curl output）</li>
+        <li>無證明 → 標 <span class="unverified">未驗證</span>，不得宣稱完成</li>
+        <li>tier=llm_generated 課文需附人工複核紀錄才算完整</li>
+      </ul>
+    </div>
+  </div>
+
+</div>
+
+<script>
+// Inline KP data
+var KP_DATA = {"schema_version":1,"generated_at":"2026-06-20T04:52:33.530540+00:00","summary":{"total":151,"pass":151,"fail":0,"known_gap_count":0,"failure_count":0},"lessons":[{"lesson_id":"G4-L1","title":"贏得喝󠇡采的輸家","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["WARN label_family_correct=false"]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L10","title":"美好的一天","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L11","title":"誤會","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L12","title":"黃絲帶","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L13","title":"第一百碗麵","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L14","title":"白牙的最後一戰","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L15","title":"感情小日記1──是友情還是愛情？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L16","title":"感情小日記2──喜歡是什麼？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L17","title":"把球打好，就夠了嗎？ ──阿耀與健豪學長的通信（一）","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L18","title":"想讀書，該從哪裡著手？ ──阿耀與健豪學長的通信（二）","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L19","title":"救援大隊的好幫手","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L2","title":"十秒的背後","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L20","title":"物以稀為貴： 從「供給」和「需求」談物價波動","tier":"no_structure","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L23","title":"心，也要一起練","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L24","title":"成為身體的最佳夥伴","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L25","title":"身體，謝謝你","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L26","title":"專注當下：關掉內心的批評噪音","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L27","title":"從白熊到藍海豚：學習與念頭和平相處","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L3","title":"長高的祕密","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L4","title":"運動科學","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L5","title":"穿越極限的跑者","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L6","title":"這是什麼「意思」？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L7","title":"正太與小豬：武僧的養成之路","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L8","title":"最美的畫面","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G4-L9","title":"大自然的氣象小幫手","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L1","title":"兵來將擋，水來土掩","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L10","title":"從童工到大學教授之路","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L11","title":"「拳」力出擊──陳念琴","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L12","title":"六塊肌、六塊雞","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L13","title":"小丑醫生","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L14","title":"垃圾食物的誘惑與代價","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L15","title":"信件的力量──寫信馬拉松","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L16","title":"臺灣棒球先驅──來自花蓮的能高團","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L17","title":"掃雷英雄馬嘎瓦","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L18","title":"魚來了，叮咚叮咚請開門","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L19","title":"感情小日記3──吃醋的滋味","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L2","title":"以植物為師的科學","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L20","title":"感情小日記4──我被告白了","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L21","title":"抗拒指尖上的誘惑","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L22","title":"我有一個棒球夢","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L23","title":"我的電競夢：從熬夜打遊戲到拿下全國冠軍","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L24","title":"牧羊少年的逆轉勝","tier":"no_structure","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L26","title":"數字記憶的奧秘","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L27","title":"重複朗讀的重要性：柳丁和文旦的比喻","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L3","title":"工地大嫂","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L4","title":"災難預言準不準？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L5","title":"比運氣更重要的事：《長腿叔叔》的啟發","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L6","title":"堅持到底的棒球人生──周思齊(前篇)","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L7","title":"堅持到底的棒球人生──周思齊(後篇)","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L8","title":"奧運銀牌的自我鍛鍊","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G5-L9","title":"周天成的一天──頂尖選手的養成","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L1","title":"運動傷害，怎麼辦？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L10","title":"末日種子庫","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L11","title":"古代畫家心中的仙境","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L12","title":"愛冒險逞強的雄性動物","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L13","title":"森林大軍的守護者","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L14","title":"植物獵人","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L15","title":"小藍鯨之死","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L16","title":"奇蹟行動","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L17","title":"給神明發會診單","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L18","title":"把手上的餅吃香一點！","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L19","title":"紅領帶","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L2","title":"與小學說再見","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L20","title":"感情小日記5──我該告白嗎？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L21","title":"感情小日記6──我失戀了","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L22","title":"小兵立大功：雞鳴狗盜的故事","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L23","title":"老鷹紅豆的故事","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L24","title":"白鯨救援：一場人與自然的協奏曲","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L25","title":"荷蘭東印度公司：全世界第一張股票的誕生","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L3","title":"昆蟲會思考嗎?","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L4","title":"兩千五百歲的酷老師","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L5","title":"卡通人氣王票選政見發表會","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L6","title":"心理出狀況，是壞事導致的嗎？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L7","title":"黑猩猩的守護者","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L8","title":"動物談情說愛的方式","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G6-L9","title":"祝你好眠","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L1","title":"長大後，我才讀懂〈夏夜〉","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L10","title":"塑膠，好用不好甩","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L11","title":"AI什麼都會，我們還要學什麼？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L12","title":"你以為的浪漫可能是跟騷","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L13","title":"綠色賽事","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L14","title":"隱藏在日常對話中的微歧視","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L15","title":"看到了嗎？然後呢？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L16","title":"果醬男孩","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L17","title":"用科學方法伸張正義的神探","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L18","title":"一封向醫師求助的信","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L19","title":"「背影」讀書會","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L2","title":"澳洲奧運金牌的X機密","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L20","title":"網紅的電子煙實驗：偽科學的陷阱","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L21","title":"別上「誘餌式標題」的鉤","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L22","title":"信眾與教主","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L23","title":"最後一隻旅人鴿","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L24","title":"未來的農夫","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L25","title":"當全世界都在笑你，你可以怎麼做？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L26","title":"小米酒的祝福","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L27","title":"帶著「血拼清單」閱讀","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L28","title":"看不見的兇手:以實驗破解肉湯腐敗之謎","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L29","title":"從四張圖，看地球暖化的現象","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L3","title":"女性太空人登月","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L30","title":"都是八哥，為什麼命運不一樣？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L4","title":"從〈螞蟻與蟋蟀〉看生命的多樣性","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L5","title":"爺爺奶奶來了以後","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L6","title":"奧運性別平等這條路","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L7","title":"你看見時代的灰犀牛了嗎？談人口負成長","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L8","title":"科學怪人","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G7-L9","title":"吐瓦魯：逐漸被淹沒的島國","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L1","title":"致台東：一封過客的情書","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L10","title":"「按讚」背後的真相","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L11","title":"虎襲事件的真相：誰才是受害者？","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L12","title":"語言的足跡：從臺北萬華到南太平洋的航海之路","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L13","title":"構樹：南島祖先「出台灣說」的植物證據","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L14","title":"科學辦案：破解蝴蝶蘭的花期密碼","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L15","title":"球場上的另類指揮家","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L16","title":"我的阿嬤","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L17","title":"我能不能選擇告別方式?","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L18","title":"石虎保育：遷移與否的兩難","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L19","title":"核能的兩難抉擇","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L2","title":"爸爸的恩人們","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L3","title":"當壞事已不可逆轉：集中營裡的一門課","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L4","title":"新奇!「植物肉」你聽過嗎?","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L5","title":"好心沒好報玻璃娃娃爭議事件","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L6","title":"戲院、賭場、檳榔攤：在時代夾縫中成長的我","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L7","title":"讓你口中的甜蜜成為遠方農民的希望","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L8","title":"隱形的征服者","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G8-L9","title":"讓黑猩猩被看見的人","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L1","title":"盡信書不如無書：從一件殺人案談起","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L10","title":"高地訓練有助於運動表現嗎?","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["WARN label_family_correct=false"]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L11","title":"見前人所未見—達爾文與長喙天蛾的故事","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L12","title":"臺灣的太空之眼","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L13","title":"樂觀者勝：向NBA球員學習「詮釋失敗」的智慧","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L14","title":"焚而不毀的倫敦","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L15","title":"未解之謎──石頭的祕密（一）：巨石陣","tier":"no_structure","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L17","title":"馬拉松王者──基普喬吉 (記敘文)","tier":"no_structure","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L2","title":"帝國家書：一個普通家庭的生與死","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L3","title":"國高中數學課當然可以使用計算機！","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L4","title":"預防近視？多點戶外活動就對了！","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L5","title":"#MeToo運動與我們的權利","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L6","title":"靈異與科學","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L7","title":"從基因來的特別禮物","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L8","title":"臺灣學生的閱讀力：美麗與哀愁","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"G9-L9","title":"力與美表現的競技體操","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L1","title":"這是假新聞嗎？--以「鞭虎救弟記」為例","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L10","title":"荒野救亡記","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L2","title":"文言文怎麼讀？-以「鞭虎救弟記」為例","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":["N/A no docx keypoints table"]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L3","title":"文-L3","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]}}},{"lesson_id":"文-L4","title":"文-L4","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]}}},{"lesson_id":"文-L5","title":"重義的荀巨伯","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L6","title":"江乙媽媽告御狀","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L7","title":"相隔千里的約定","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]},"L3_catalog":{"pass":true,"issues":[]},"L3":{"pass":true,"issues":[]}}},{"lesson_id":"文-L8","title":"文-L8","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]}}},{"lesson_id":"文-L9","title":"文-L9","tier":"docx_keypoints","known_data_gap":false,"overall_pass":true,"overall_status":"pass","gates":{"L1":{"pass":true,"issues":[]},"L2":{"pass":true,"issues":[]}}}]};
+
+// Tab switching
+document.querySelectorAll('.tab').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t){t.classList.remove('active')});
+    document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
+    btn.classList.add('active');
+    document.getElementById(btn.getAttribute('data-pane')).classList.add('active');
+  });
+});
+
+// Grade filter
+function setupGradeFilter(lessons) {
+  var sel = document.getElementById('grade-filter');
+  if (!sel) return;
+  sel.addEventListener('change', function() {
+    var val = this.value;
+    document.querySelectorAll('#kp-body tr').forEach(function(tr) {
+      var id = tr.getAttribute('data-lesson') || '';
+      var grade = val === '文' ? id.startsWith('文') : (val ? id.startsWith(val) : true);
+      tr.style.display = grade ? '' : 'none';
+    });
+  });
+}
+
+// Render keypoints matrix
+function renderKeypoints(kp) {
+  var lessons = kp.lessons || [];
+  var gates = ['L1','L2','L3_catalog','L3'];
+  var passed = lessons.filter(function(l){return l.overall_pass;}).length;
+  document.getElementById('qa-summary').innerHTML =
+    '<div class="qa-stat-bar"><span class="stat-ok">' + passed + ' / ' + lessons.length + ' 通過</span>' +
+    '<span class="stat-fail">' + (lessons.length - passed) + ' 失敗</span>' +
+    '<span class="stat-gen">資料更新：' + (kp.generated_at ? kp.generated_at.slice(0,10) : '?') + '</span></div>';
+
+  document.getElementById('kp-head').innerHTML = '<tr><th>課文 ID</th><th>標題</th><th>tier</th>' +
+    gates.map(function(g){return '<th>' + g + '</th>';}).join('') + '<th>Overall</th></tr>';
+
+  document.getElementById('kp-body').innerHTML = lessons.map(function(l) {
+    var cells = gates.map(function(g) {
+      var gate = l.gates[g];
+      if (!gate) return '<td>—</td>';
+      var issues = (gate.issues || []).join('\n');
+      return '<td class="' + (gate.pass ? 'cell-ok' : 'cell-fail') + '" title="' + issues.replace(/"/g,'&quot;') + '">' + (gate.pass ? '✅' : '❌') + '</td>';
+    }).join('');
+    return '<tr data-lesson="' + l.lesson_id + '"><td class="lesson-id">' + l.lesson_id + '</td>' +
+      '<td class="lesson-title">' + (l.title || '') + '</td>' +
+      '<td><span class="pill">' + (l.tier || '') + '</span></td>' +
+      cells +
+      '<td class="' + (l.overall_pass ? 'cell-ok' : 'cell-fail') + '">' + (l.overall_pass ? '✅' : '❌') + '</td></tr>';
+  }).join('');
+  document.getElementById('kp-generated').innerHTML = '<p class="legend">generated_at: ' + (kp.generated_at || '?') + ' · 共 ' + lessons.length + ' 課</p>';
+  setupGradeFilter(lessons);
+}
+
+// Counter animation for node ④
+(function() {
+  var el = document.getElementById('counter-anim');
+  if (!el) return;
+  var target = 151;
+  var start = null;
+  function step(ts) {
+    if (!start) start = ts;
+    var prog = Math.min((ts - start) / 2000, 1);
+    el.textContent = Math.floor(prog * target) + ' 課';
+    if (prog < 1) requestAnimationFrame(step);
+    else setTimeout(function(){ start = null; requestAnimationFrame(step); }, 1500);
+  }
+  requestAnimationFrame(step);
+})();
+
+// Sync animation for node ③
+(function() {
+  var el = document.getElementById('sync-anim');
+  if (!el) return;
+  var dots = 0;
+  setInterval(function(){
+    dots = (dots + 1) % 4;
+    el.textContent = 'syncing' + '.'.repeat(dots);
+  }, 500);
+})();
+
+// Init
+renderKeypoints(KP_DATA);
+</script>
+</body>
+</html>

--- a/frontend/public/presentation/pipelines.html
+++ b/frontend/public/presentation/pipelines.html
@@ -41,13 +41,13 @@
   </a>
 
   <a class="card" href="spotlight-pipeline.html">
-    <div class="row"><span class="ic s">🔦</span><span class="name">閱讀聚光燈 Spotlight</span><span class="badge wip">建置中</span></div>
+    <div class="row"><span class="ic s">🔦</span><span class="name">閱讀聚光燈 Spotlight</span><span class="badge live">可用</span></div>
     <div class="flow">DOCX → build_lesson_schema → spotlight.yml → spotlight_v2 loader → BlockSequenceRenderer</div>
-    <div class="meta">free_text 提交用 Gemini 批改 · dev7(7課) + test15(15課) 泛化 gate</div>
+    <div class="meta">free_text 提交用 Gemini 批改 · dev7(7課) + test15(15課) 泛化 gate · 7/7 通過</div>
   </a>
 
   <a class="card" href="keypoints-pipeline.html">
-    <div class="row"><span class="ic k">📋</span><span class="name">文章重點表 Keypoints</span><span class="badge wip">建置中</span></div>
+    <div class="row"><span class="ic k">📋</span><span class="name">文章重點表 Keypoints</span><span class="badge live">可用</span></div>
     <div class="flow">DOCX → keypoints.yml → sync 進 lesson YAML → manifest(151課) → StoryStructure 渲染</div>
     <div class="meta">L1–L3 gate（row/blank recall · checkbox/fill_blank · profile contract）· 151 課全綠</div>
   </a>

--- a/frontend/public/presentation/spotlight-pipeline.html
+++ b/frontend/public/presentation/spotlight-pipeline.html
@@ -1,0 +1,465 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>聚光燈 Spotlight Pipeline — 架構 / 開發 / QA / 資料 / 缺口&債 集成板</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#FDF8F0; --ink:#1a1a2e; --purple:#5B4FC4; --muted:#6b6b8a;
+    --card:#fff; --line:#e7e2d8; --green:#16a34a; --red:#dc2626; --amber:#d97706;
+    --chip:#efe9ff;
+  }
+  *{box-sizing:border-box}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:32px 20px;line-height:1.6}
+  .container{max-width:1080px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.6rem;margin:0 0 6px}
+  .subtitle{color:var(--muted);margin:0 0 6px}
+  .oneliner{background:var(--chip);border-left:4px solid var(--purple);padding:10px 14px;border-radius:8px;margin:14px 0 4px;font-size:.95rem}
+  .updated{color:var(--muted);font-size:.78rem;margin-bottom:18px}
+  /* tabs */
+  .tabs{display:flex;gap:8px;flex-wrap:wrap;border-bottom:2px solid var(--line);margin-bottom:22px}
+  .tab{padding:10px 16px;border:none;background:none;font:inherit;font-weight:600;color:var(--muted);cursor:pointer;border-bottom:3px solid transparent;margin-bottom:-2px}
+  .tab.active{color:var(--purple);border-bottom-color:var(--purple)}
+  .pane{display:none}
+  .pane.active{display:block;animation:fade .2s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* flow — arch tab */
+  .flow{display:flex;flex-direction:column;gap:0;align-items:center}
+  .node-row{display:flex;gap:16px;align-items:flex-start;background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 16px;width:100%;max-width:760px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .node-row.branch{border-style:dashed;border-color:var(--purple)}
+  .node-text{flex:1;min-width:0}
+  .node-text .t{font-weight:700}
+  .node-text .s{font-size:.82rem;color:var(--muted);margin-top:2px}
+  .node-text .side{font-size:.72rem;display:inline-block;background:var(--chip);color:var(--purple);border-radius:6px;padding:1px 7px;margin-left:6px}
+  .node-demo{flex:0 0 160px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:80px;gap:6px}
+  @media(max-width:640px){.node-row{flex-direction:column}.node-demo{flex:none;width:100%}}
+  .arrow{color:var(--purple);font-size:1.2rem;line-height:1.1;margin:4px 0}
+  /* table */
+  table{width:100%;border-collapse:collapse;background:var(--card);border-radius:10px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06);font-size:.86rem}
+  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:#f3eee4;color:var(--ink);font-size:.8rem}
+  .nowrap{white-space:nowrap}
+  tr:last-child td{border-bottom:none}
+  code{background:#f3eee4;padding:1px 5px;border-radius:4px;font-size:.82em}
+  a{color:var(--purple);text-decoration:none}
+  a:hover{text-decoration:underline}
+  .ok{color:var(--green);font-weight:700}
+  .badword{color:var(--red);font-weight:700}
+  .pill{display:inline-block;font-size:.72rem;padding:1px 7px;border-radius:20px;background:var(--chip);color:var(--purple);margin:2px 3px 2px 0}
+  .pill.fe{background:#e0f2fe;color:#0369a1}
+  .pill.be{background:#dcfce7;color:#15803d}
+  .pill.llm{background:#fef3c7;color:#b45309}
+  .pill.sc{background:#f3e8ff;color:#7c3aed}
+  .unverified{background:#fee2e2;color:var(--red);font-weight:700;padding:1px 7px;border-radius:6px;font-size:.78rem}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:16px 18px;margin-bottom:14px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .card h3{margin:0 0 8px;font-size:1.05rem;color:var(--purple)}
+  .big-link{display:flex;justify-content:space-between;align-items:center;padding:14px 18px;background:var(--card);border:1px solid var(--line);border-radius:10px;margin-bottom:10px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .big-link .lbl{font-weight:600}
+  .big-link .d{font-size:.82rem;color:var(--muted);margin-top:2px}
+  .debt{border-left:4px solid var(--red)}
+  .rule{border-left:4px solid var(--purple);background:var(--chip)}
+  ul{margin:6px 0;padding-left:20px}
+  li{margin:3px 0}
+  .legend{font-size:.78rem;color:var(--muted);margin-top:10px}
+
+  /* === 架構動畫 CSS === */
+
+  /* ① DOCX 解析 — pulsing doc icon */
+  .doc-wrap{display:flex;flex-direction:column;align-items:center;gap:4px}
+  .doc-icon{width:36px;height:44px;border:3px solid var(--purple);border-radius:4px;position:relative;animation:doc-pulse 2s ease-in-out infinite}
+  .doc-icon::before{content:'';position:absolute;top:0;right:0;width:10px;height:10px;background:var(--bg);border-left:3px solid var(--purple);border-bottom:3px solid var(--purple)}
+  .doc-lines{display:flex;flex-direction:column;gap:3px;margin-top:2px}
+  .doc-line{height:3px;border-radius:2px;background:var(--muted);animation:doc-line-pulse 2s ease-in-out infinite}
+  .doc-line:nth-child(1){width:44px;animation-delay:0s}
+  .doc-line:nth-child(2){width:36px;animation-delay:.3s}
+  .doc-line:nth-child(3){width:40px;animation-delay:.6s}
+  @keyframes doc-pulse{0%,100%{border-color:var(--purple);opacity:1}50%{border-color:var(--amber);opacity:.8}}
+  @keyframes doc-line-pulse{0%,100%{background:var(--muted)}50%{background:var(--purple)}}
+
+  /* ② YAML file icon */
+  .yaml-wrap{display:flex;flex-direction:column;gap:3px;align-items:center}
+  .yaml-label{font-size:.65rem;font-weight:700;color:var(--purple);letter-spacing:.05em}
+  .yaml-block{border-radius:3px;height:8px;animation:yaml-appear 1.6s ease-in-out infinite}
+  .yaml-block:nth-child(2){width:90px;background:#efe9ff;animation-delay:0s}
+  .yaml-block:nth-child(3){width:70px;background:#e0f2fe;animation-delay:.2s}
+  .yaml-block:nth-child(4){width:80px;background:#dcfce7;animation-delay:.4s}
+  .yaml-block:nth-child(5){width:60px;background:#fef3c7;animation-delay:.6s}
+  .yaml-block:nth-child(6){width:75px;background:#fee2e2;animation-delay:.8s}
+  @keyframes yaml-appear{0%{opacity:.3}50%{opacity:1}100%{opacity:.3}}
+
+  /* ③ Server box with blinking light */
+  .server-wrap{display:flex;flex-direction:column;align-items:center;gap:4px}
+  .server-box{width:64px;height:36px;background:#f3eee4;border:2px solid var(--purple);border-radius:6px;display:flex;align-items:center;justify-content:center;gap:6px;padding:0 8px}
+  .server-light{width:8px;height:8px;border-radius:50%;background:var(--green);animation:blink 1.2s ease-in-out infinite}
+  .server-label{font-size:.6rem;color:var(--muted);font-weight:600;letter-spacing:.04em}
+  .server-route{font-size:.6rem;color:var(--muted);text-align:center}
+  @keyframes blink{0%,100%{opacity:1;box-shadow:0 0 4px var(--green)}50%{opacity:.3;box-shadow:none}}
+
+  /* ④ Stacking blocks */
+  #block-anim{min-height:80px;display:flex;flex-direction:column;justify-content:center}
+
+  /* ⑤ Typing text → AI badge */
+  .ai-wrap{display:flex;flex-direction:column;align-items:center;gap:6px}
+  .typing-text{font-size:.72rem;color:var(--ink);background:#f9f6f0;border-radius:4px;padding:4px 6px;min-width:100px;text-align:left;min-height:1.4em}
+  .typing-cursor{display:inline-block;width:2px;height:12px;background:var(--purple);animation:cursor-blink .8s step-end infinite;vertical-align:middle}
+  .ai-badge{font-size:.68rem;font-weight:700;background:var(--chip);color:var(--purple);border-radius:6px;padding:2px 8px;border:1px solid var(--purple)}
+  .submit-arrow{color:var(--purple);font-size:.9rem}
+
+  /* === QA 矩陣 CSS === */
+  .matrix-wrap{overflow-x:auto;margin-bottom:12px}
+  .cell-ok{color:var(--green);font-weight:600;text-align:center}
+  .cell-fail{color:var(--red);font-weight:600;text-align:center;cursor:help}
+  .cell-warn{color:var(--amber);text-align:center}
+  .lesson-id{font-size:.78rem;color:var(--muted);white-space:nowrap}
+  .qa-stat-bar{background:var(--chip);border-radius:8px;padding:10px 14px;margin-bottom:14px;display:flex;gap:16px;flex-wrap:wrap;font-size:.9rem}
+  .stat-ok{color:var(--green);font-weight:700}
+  .stat-fail{color:var(--red);font-weight:700}
+  .stat-gen{color:var(--muted);font-size:.8rem}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>聚光燈 Spotlight Pipeline · 集成板</h1>
+  <p class="subtitle">架構 / 開發 / QA / 資料 / 缺口&amp;債 — all in one</p>
+  <div class="oneliner"><b>一句話分工：</b>前端管「區塊渲染 + 互動」，後端管「從 DOCX 解析 → YAML → API」；<b>LLM 只在最後 free_text 批改</b>，所有解析是 deterministic regex。</div>
+  <p class="updated">最後更新 2026-06-20 · base staging · issue <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2309">#2309</a></p>
+
+  <div class="tabs">
+    <button class="tab active" data-pane="arch">① 架構</button>
+    <button class="tab" data-pane="dev">② 開發</button>
+    <button class="tab" data-pane="qa">③ QA result</button>
+    <button class="tab" data-pane="data">④ 資料</button>
+    <button class="tab" data-pane="debt">⑤ 缺口&amp;債</button>
+  </div>
+
+  <!-- ① ARCH -->
+  <div class="pane active" id="arch">
+    <div class="flow">
+
+      <!-- ① DOCX 解析 -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">① DOCX 解析 <span class="side">script</span></div>
+          <div class="s"><code>build_lesson_schema.py</code> regex 抽取，無 LLM — deterministic block 切割</div>
+        </div>
+        <div class="node-demo">
+          <div class="doc-wrap">
+            <div class="doc-icon"></div>
+            <div class="doc-lines">
+              <div class="doc-line"></div>
+              <div class="doc-line"></div>
+              <div class="doc-line"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- ② spotlight.yml -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">② spotlight.yml 產出 <span class="side">script</span></div>
+          <div class="s">block schema：guide / passage / exercise / figure / fill_table / free_text / self_check</div>
+        </div>
+        <div class="node-demo">
+          <div class="yaml-wrap">
+            <div class="yaml-label">spotlight.yml</div>
+            <div class="yaml-block"></div>
+            <div class="yaml-block"></div>
+            <div class="yaml-block"></div>
+            <div class="yaml-block"></div>
+            <div class="yaml-block"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- ③ spotlight_v2_loader.py -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">③ spotlight_v2_loader.py <span class="side">後端</span></div>
+          <div class="s"><code>GET /api/stories/{id}/spotlight_v2</code> → BlockSequenceRenderer props（typed blocks 序列）</div>
+        </div>
+        <div class="node-demo">
+          <div class="server-wrap">
+            <div class="server-box">
+              <div class="server-light"></div>
+              <div class="server-label">API</div>
+            </div>
+            <div class="server-route">/spotlight_v2</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
+      <!-- ④ BlockSequenceRenderer -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">④ BlockSequenceRenderer.tsx <span class="side">前端</span></div>
+          <div class="s">渲染各 block type 區塊序列：guide / exercise / fill_table / figure / self_check</div>
+        </div>
+        <div class="node-demo">
+          <div id="block-anim"></div>
+        </div>
+      </div>
+
+      <div class="arrow">▼ （學生完成 free_text 書寫後提交）</div>
+
+      <!-- ⑤ free_text 批改 -->
+      <div class="node-row branch">
+        <div class="node-text">
+          <div class="t">⑤ free_text 提交 <span class="side">前端→後端 · LLM</span></div>
+          <div class="s"><code>POST /api/stories/{id}/blocks/{id}/grade</code> → <code>grade_story_structure()</code> → Gemini 2.5 Flash Lite</div>
+        </div>
+        <div class="node-demo">
+          <div class="ai-wrap">
+            <div class="typing-text" id="typing-demo">學生書寫中<span class="typing-cursor"></span></div>
+            <div class="submit-arrow">↓ 提交</div>
+            <div class="ai-badge">Gemini 2.5 Flash Lite</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <p class="legend">關鍵：<b>LLM 只在⑤ free_text 批改</b>；①–④全無 LLM（deterministic regex + 序列渲染）。</p>
+  </div>
+
+  <!-- ② DEV -->
+  <div class="pane" id="dev">
+    <table>
+      <thead>
+        <tr>
+          <th class="nowrap">階段</th>
+          <th>端</th>
+          <th>功能</th>
+          <th>檔案</th>
+          <th>PR / 證明</th>
+          <th>狀態</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="nowrap">① DOCX 解析</td>
+          <td><span class="pill sc">script</span></td>
+          <td>regex 無 LLM block 抽取</td>
+          <td><code>scripts/build_lesson_schema.py</code></td>
+          <td>commit <code>19e2a742</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">② spotlight.yml</td>
+          <td><span class="pill sc">script</span></td>
+          <td>block schema 序列化</td>
+          <td><code>backend/data/lessons/*.yml</code> (spotlight key)</td>
+          <td>commit <code>c4cee67b</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">③ API loader</td>
+          <td><span class="pill be">後端</span></td>
+          <td>spotlight_v2_loader → typed blocks</td>
+          <td><code>backend/app/services/spotlight_v2_loader.py</code></td>
+          <td>commit <code>4d8f71f7</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">④ BlockSequenceRenderer</td>
+          <td><span class="pill fe">前端</span></td>
+          <td>渲染 guide / exercise / fill_table / figure</td>
+          <td><code>frontend/src/components/reading-spotlight/BlockSequenceRenderer.tsx</code></td>
+          <td>commit <code>3d58059c</code></td>
+          <td class="ok">✅</td>
+        </tr>
+        <tr>
+          <td class="nowrap">⑤ free_text 批改</td>
+          <td><span class="pill be">後端</span> <span class="pill llm">LLM</span></td>
+          <td>grade_story_structure() → Gemini 2.5 Flash Lite</td>
+          <td><code>backend/app/routes/stories.py</code> · <code>backend/app/services/spotlight_contract.py</code></td>
+          <td>commit <code>c4cee67b</code></td>
+          <td class="ok">✅</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="legend">前端 <span class="pill fe">前</span> · 後端 <span class="pill be">後</span> · 用 LLM <span class="pill llm">LLM</span> · 工具腳本 <span class="pill sc">script</span></p>
+  </div>
+
+  <!-- ③ QA -->
+  <div class="pane" id="qa">
+    <div id="qa-summary">載入中...</div>
+    <div class="matrix-wrap">
+      <table id="sp-table">
+        <thead id="sp-head"></thead>
+        <tbody id="sp-body"></tbody>
+      </table>
+    </div>
+    <div class="card" style="margin-top:20px;border-left:4px solid var(--amber)">
+      <h3>尚未結構化的驗收</h3>
+      <p>逐段閱讀 flow 功能（能不能跑）的驗收結果<b>尚未做成結構化資料</b>，此矩陣沒有涵蓋。</p>
+    </div>
+  </div>
+
+  <!-- ④ DATA -->
+  <div class="pane" id="data">
+    <div class="card">
+      <h3>spotlight manifest 資料來源</h3>
+      <p><code>frontend/public/presentation/data/spotlight_manifest.json</code><br>
+      7 課 · schema_version 1 · 涵蓋 G6-L22~25（summary_pse × 4）、G7-L28~30（image_text × 2，table_text × 1）</p>
+    </div>
+
+    <div class="card">
+      <h3>block type 說明</h3>
+      <table>
+        <thead><tr><th>type</th><th>說明</th></tr></thead>
+        <tbody>
+          <tr><td><code>guide</code></td><td>學習引導說明文字</td></tr>
+          <tr><td><code>passage</code></td><td>課文段落</td></tr>
+          <tr><td><code>exercise</code></td><td>互動練習（select_one / fill_blank）</td></tr>
+          <tr><td><code>fill_table</code></td><td>表格填空</td></tr>
+          <tr><td><code>free_text</code></td><td>開放式書寫（LLM 批改）</td></tr>
+          <tr><td><code>figure</code></td><td>圖片</td></tr>
+          <tr><td><code>self_check</code></td><td>學生自我檢核</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h3>已驗證課文清單</h3>
+      <ul>
+        <li>G6-L22 · G6-L23 · G6-L24 · G6-L25 — <b>summary_pse</b> 策略 × 4 課</li>
+        <li>G7-L28 · G7-L29 — <b>image_text</b> 策略 × 2 課</li>
+        <li>G7-L30 — <b>table_text</b> 策略 × 1 課</li>
+      </ul>
+      <p style="margin:6px 0 0;color:var(--green);font-weight:700">7 課全通過 ✅</p>
+    </div>
+  </div>
+
+  <!-- ⑤ DEBT -->
+  <div class="pane" id="debt">
+    <div class="card debt">
+      <h3>缺口：其他 144 課 spotlight.yml 尚未建</h3>
+      <p>目前僅 7 課通過驗證。其餘 144 課（共 151 課）spotlight.yml 尚未建立，需批次跑 <code>build_lesson_schema.py</code> 補全，並逐一 QA。</p>
+    </div>
+
+    <div class="card debt">
+      <h3>缺口：偵測器仍需 generalize（5/8 非七課漏抓重點表）</h3>
+      <p>dev7 + test15 泛化測試已通過，但偵測器在非七課課文（5/8）仍漏抓重點表。需繼續調整通用規則，不針對七課 overfit。</p>
+    </div>
+
+    <div class="card rule">
+      <h3>規則：出問題修 SKILL 通用規則，不 overfit</h3>
+      <p>修正解析錯誤時，只能改 <code>build_lesson_schema.py</code> 的<b>通用規則</b>，禁止針對個別課文寫特例。Overfit = 下一課又壞。見 issue <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2309">#2309</a>。</p>
+    </div>
+  </div>
+
+</div>
+
+<script>
+/* ── Inline spotlight manifest data ── */
+var SP_DATA = {"schema_version":1,"lessons":[{"lesson_id":"G6-L22","strategy_type":"summary_pse","block_count":29,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":15,"mcq_option_guides":0,"semantic_pass":true,"semantic_errors":[]},"acceptance":{"pass":true,"failures":[]}},"gold":{"match":true,"diffs":{}},"type_histogram":{"fill_table":1,"free_text":1,"guide":8,"passage":4,"single":15}},{"lesson_id":"G6-L23","strategy_type":"summary_pse","block_count":43,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":2,"mcq_option_guides":0,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"fill_table":1,"free_text":13,"guide":20,"passage":6,"self_check":1,"single":2}},{"lesson_id":"G6-L24","strategy_type":"summary_pse","block_count":10,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":3,"mcq_option_guides":0,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"fill_table":1,"guide":5,"self_check":1,"single":3}},{"lesson_id":"G6-L25","strategy_type":"summary_pse","block_count":7,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":3,"mcq_option_guides":0,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"fill_table":1,"guide":2,"self_check":1,"single":3}},{"lesson_id":"G7-L28","strategy_type":"image_text","block_count":40,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":5,"mcq_option_guides":4,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"figure":1,"fill_table":1,"free_text":7,"guide":22,"passage":3,"self_check":1,"single":5}},{"lesson_id":"G7-L29","strategy_type":"image_text","block_count":68,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":24,"mcq_option_guides":0,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"figure":5,"free_text":6,"guide":32,"self_check":1,"single":24}},{"lesson_id":"G7-L30","strategy_type":"table_text","block_count":52,"overall_pass":true,"eval":{"pass":true,"guide_retained":true,"answer_recall":1.0,"mcq_leakage":0,"struct_errors":[],"semantic":{"single_count":19,"mcq_option_guides":2,"semantic_pass":true,"semantic_errors":[]},"acceptance":{}},"gold":{"match":true,"diffs":{}},"type_histogram":{"figure":5,"free_text":4,"guide":21,"passage":2,"self_check":1,"single":19}}],"summary":{"total":7,"pass":7,"fail":0}};
+
+/* ── QA rendering helpers ── */
+function cellBool(v) {
+  if (v === true) return '<td class="cell-ok">✅</td>';
+  if (v === false) return '<td class="cell-fail">❌</td>';
+  return '<td>—</td>';
+}
+function cellNum(v, invertGood) {
+  if (v === undefined || v === null) return '<td>—</td>';
+  var good = invertGood ? (v === 0) : (v >= 0.9);
+  return '<td class="' + (good ? 'cell-ok' : 'cell-warn') + '">' + (typeof v === 'number' ? v.toFixed(2) : v) + '</td>';
+}
+function renderSpotlight(sp) {
+  var lessons = sp.lessons || [];
+  var passed = lessons.filter(function(l){return l.overall_pass;}).length;
+  document.getElementById('qa-summary').innerHTML =
+    '<div class="qa-stat-bar"><span class="stat-ok">' + passed + ' / ' + lessons.length + ' 通過</span>' +
+    '<span class="stat-fail">' + (lessons.length - passed) + ' 失敗</span>' +
+    '<span class="stat-gen">資料更新：' + (sp.summary ? '7 課' : '?') + '</span></div>';
+
+  document.getElementById('sp-head').innerHTML = '<tr><th>課文</th><th>策略類型</th>' +
+    '<th>guide_retained</th><th>answer_recall</th><th>mcq_leakage</th><th>semantic_pass</th><th>acceptance</th><th>Overall</th></tr>';
+
+  document.getElementById('sp-body').innerHTML = lessons.map(function(l) {
+    var ev = l.eval || {};
+    return '<tr><td class="lesson-id">' + l.lesson_id + '</td><td>' + (l.strategy_type || '') + '</td>' +
+      cellBool(ev.guide_retained) +
+      cellNum(ev.answer_recall) +
+      cellNum(ev.mcq_leakage, true) +
+      cellBool(ev.semantic && ev.semantic.semantic_pass) +
+      cellBool(ev.acceptance && ev.acceptance.pass) +
+      '<td class="' + (l.overall_pass ? 'cell-ok' : 'cell-fail') + '">' + (l.overall_pass ? '✅' : '❌') + '</td></tr>';
+  }).join('');
+}
+renderSpotlight(SP_DATA);
+
+/* ── Tab switching ── */
+document.querySelectorAll('.tab').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t){t.classList.remove('active')});
+    document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
+    btn.classList.add('active');
+    document.getElementById(btn.getAttribute('data-pane')).classList.add('active');
+  });
+});
+
+/* ── Spotlight block animation — stacking colored blocks ── */
+(function() {
+  var blockColors = ['#efe9ff','#dcfce7','#fef3c7','#e0f2fe','#fee2e2'];
+  var container = document.getElementById('block-anim');
+  if (!container) return;
+  var idx = 0;
+  function addBlock() {
+    if (container.children.length >= 5) {
+      container.innerHTML = '';
+      idx = 0;
+    }
+    var b = document.createElement('div');
+    b.style.cssText = 'width:120px;height:14px;border-radius:4px;background:' + blockColors[idx % blockColors.length] + ';margin:3px auto;transition:all .3s';
+    container.appendChild(b);
+    idx++;
+    setTimeout(addBlock, 500);
+  }
+  addBlock();
+})();
+
+/* ── Typing animation for free_text demo ── */
+(function() {
+  var el = document.getElementById('typing-demo');
+  if (!el) return;
+  var phrases = ['學生書寫中', '這段描述了...', '主角面對困難'];
+  var phraseIdx = 0;
+  var charIdx = 0;
+  var deleting = false;
+
+  function tick() {
+    var current = phrases[phraseIdx];
+    if (!deleting) {
+      charIdx++;
+      el.innerHTML = current.slice(0, charIdx) + '<span class="typing-cursor"></span>';
+      if (charIdx >= current.length) {
+        deleting = true;
+        setTimeout(tick, 1400);
+        return;
+      }
+    } else {
+      charIdx--;
+      el.innerHTML = current.slice(0, charIdx) + '<span class="typing-cursor"></span>';
+      if (charIdx === 0) {
+        deleting = false;
+        phraseIdx = (phraseIdx + 1) % phrases.length;
+      }
+    }
+    setTimeout(tick, deleting ? 60 : 110);
+  }
+  tick();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #2309

## Summary

- Add `spotlight-pipeline.html` — 聚光燈模組集成板（5-node 架構 + 7 課 QA 矩陣）
- Add `keypoints-pipeline.html` — 重點表模組集成板（6-node 架構 + 151 課 QA 矩陣 + 年級篩選）
- Update `pipelines.html` — 兩張卡片 badge 從「建置中」改為「可用」

## Structure (both boards)

5-tab layout matching `reading-pipeline.html`:  ① 架構 / ② 開發 / ③ QA / ④ 資料 / ⑤ 缺口&債

- CSS variables reused exactly (--purple, --bg, --chip, etc.)
- Self-contained HTML (no external CDN, data inline as JS const)
- Arch tab with animated nodes, QA tab with client-side rendered matrix

## QA Matrix

| Board | Lessons | Gates | Source |
|-------|---------|-------|--------|
| spotlight | 7 | guide_retained / answer_recall / mcq_leakage / semantic_pass / acceptance | `data/spotlight_manifest.json` |
| keypoints | 151 | L1 / L2 / L3_catalog / L3 | `data/keypoints_manifest.json` |

## Test plan

- [ ] Open spotlight-pipeline.html locally — 5 tabs switch, arch animation nodes animate, QA matrix shows 7/7 ✅, 0 console errors
- [ ] Open keypoints-pipeline.html locally — 5 tabs switch, counter animates 0→151, grade filter (G4/G5/G6/G7/G8/G9/文) works, 151/151 ✅
- [ ] Open pipelines.html — spotlight and keypoints cards show 「可用」green badge
- [ ] PR Preview URL: verify all 3 files serve correctly