### PR TITLE
fix(deploy): set READING_AUDIO_GCS_BUCKET on staging+prod (Fixes #2311)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --max-instances=3 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio"
 
       - name: Verify backend health
         run: |

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-staging-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::JWT_SECRET_KEY=${{ secrets.STAGING_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::JWT_SECRET_KEY=${{ secrets.STAGING_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio"
 
       - name: Promote backend traffic to latest revision (Fixes #1449)
         run: |


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

reading-audio GCS 儲存在 staging+prod **一直失效**：兩個 deploy workflow 的 `--set-env-vars`（每次 deploy 全覆蓋）從沒含 `READING_AUDIO_GCS_BUCKET` → `_get_gcs_bucket()` 回 None → 所有 reading-audio / testset 上傳都 503。

加 `READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio`（bucket 名非 secret，bucket 已存在）到 staging-deploy.yml + deploy.yml。

修好：學生朗讀錄音留存/回放（#2283 #2286）+ testset 上傳（#2287）才會真存。

驗證（merge+deploy 後）：staging `POST /api/testset/upload` 應從 503 → 200 + GCS 有物件。