### PR TITLE
fix(security): codex review — testset list role-gate + save-audio MIME deny (Fixes #2318)

### DIFF
--- a/backend/app/routes/learning/learning_save_audio.py
+++ b/backend/app/routes/learning/learning_save_audio.py
@@ -114,7 +114,14 @@ async def save_reading_audio(
         )
         return SaveAudioResponse(ok=False, reason="invalid_audio_size")
 
-    raw_mime = audio.content_type or "audio/webm"
+    # MIME: deny empty/unsupported (codex review — was fail-open to webm/.audio)
+    raw_mime = audio.content_type or ""
+    if _normalise_mime(raw_mime) not in _MIME_TO_EXT:
+        logger.warning(
+            "save-audio: unsupported MIME %r for user=%d session=%s",
+            raw_mime, current_user.id, session_id,
+        )
+        return SaveAudioResponse(ok=False, reason="unsupported_audio_type")
 
     # ── 2. IDOR: verify session ownership ────────────────────────────────────
     owned_session = (

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
-from ..auth.dependencies import get_current_user
+from ..auth.dependencies import get_current_user, require_role
 from ..models.user import User
 from ..services.audio_upload_service import (
     _get_gcs_bucket,
@@ -121,13 +121,16 @@ async def testset_upload(
     return {"ok": True, "path": audio_path}
 
 
-@router.get("/testset/recordings")
+@router.get(
+    "/testset/recordings",
+    dependencies=[Depends(require_role("system_admin", "teacher"))],
+)
 def testset_recordings(current_user: User = Depends(get_current_user)):
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
 
-    需登入（get_current_user）→ 擋掉匿名公開抓取貢獻者 PII（security #2304）。
-    list.html 讀 localStorage `lingoleap_token` 帶 Bearer；未登入 → 401。
-    （v2：再收斂成 admin/teacher role only。）
+    限 system_admin / teacher（codex review #2304-followup）→ 一般登入學生
+    不得抓取貢獻者 PII（名字/年級/可播放錄音）。list.html 讀 localStorage
+    `lingoleap_token` 帶 Bearer；未登入 → 401、權限不足 → 403。
     """
     bucket = _get_gcs_bucket()
     if bucket is None:


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

codex review FIX-FIRST，修兩個驗證屬實的：
- #2 HIGH：/api/testset/recordings any-authenticated → require_role(system_admin,teacher)（學生無法列貢獻者 PII，403）
- #4 MED：/api/reading/save-audio MIME fail-open → 拒非白名單 unsupported_audio_type

Deferred（已評估）：#1 durable quota(Redis/Cloud Armor=v2)、#3 list 分頁(role-gate 後緩解)、#5 覆蓋(最新 take 可接受)。
驗：py_compile OK；CI Backend Tests 驗 wiring。