### PR TITLE
fix(testset): hotfix double-Depends on require_role (Fixes #2318 regression)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -123,7 +123,7 @@ async def testset_upload(
 
 @router.get(
     "/testset/recordings",
-    dependencies=[Depends(require_role("system_admin", "teacher"))],
+    dependencies=[require_role("system_admin", "teacher")],
 )
 def testset_recordings(current_user: User = Depends(get_current_user)):
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

**Hotfix #2319 regression**：#2319 把 `require_role(...)` 包進 `Depends()`，但 factory 本身已 `return Depends(_check_role)` → 雙重包 → `AssertionError: parameter-less dependency must have a callable dependency` → `test_rate_limiting.py` collection error → Backend Tests 紅。

我犯的錯：#2319 merge 前 watch exit 0 ≠ CI 綠，沒等真綠就 merge。本 PR 改回 `dependencies=[require_role(...)]`。

**這次嚴格等 Backend Tests 真綠才 merge。**