### PR TITLE
fix(reading-eval): silence gate — prevent Gemini STT hallucination on silent audio (Fixes #2321)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -483,6 +483,12 @@ async def evaluate_reading_endpoint(
 # Hard limits (enforced before hitting Gemini)
 _MAX_AUDIO_BYTES = 10 * 1024 * 1024   # 10 MB
 _MAX_TARGET_CHARS = 3000               # ≈ longest G9 lesson
+# Issue #2321 — Gate 2: minimum duration below which we skip STT entirely.
+# Frontend Gate 1 (volume + 1 500 ms) is the primary filter; this is a backend
+# safety net for clients that bypass the frontend (or have no AnalyserNode).
+# 1 000 ms chosen conservatively: real speech takes ≥ 200 ms per syllable even
+# at fast pace; anything under 1 s almost certainly contains no useful audio.
+_MIN_AUDIO_DURATION_MS = 1000          # 1 second
 
 
 class TranscribeReadingResponse(BaseModel):
@@ -498,7 +504,7 @@ class TranscribeReadingResponse(BaseModel):
     """Gemini's 1-2 sentence explanation (for teacher audit). None on fallback."""
 
     reason: str | None = None
-    """Fallback reason classification: 'timeout' | 'safety' | 'decode' | 'empty' | 'error'.
+    """Fallback reason classification: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | 'too_short'.
     Only present when method='fallback'. Used by frontend to show appropriate alert."""
 
 
@@ -578,6 +584,29 @@ async def transcribe_reading_endpoint(
         )
     if len(audio_bytes) == 0:
         raise HTTPException(status_code=400, detail="Audio file is empty.")
+
+    # ── 2.5. Issue #2321 — Gate 2: duration too short → return fallback immediately ─
+    # Frontend Gate 1 (volume + 1 500 ms) is the primary filter.  This backend gate
+    # protects against clients that supply duration_ms but bypass the frontend check.
+    # Only applied when duration_ms is explicitly provided and below the threshold —
+    # absent duration_ms means the client did not send it, not that the audio is short.
+    if duration_ms is not None and duration_ms < _MIN_AUDIO_DURATION_MS:
+        logger.warning(
+            "Reading transcribe skipped — audio too short: user=%d duration_ms=%d",
+            current_user.id,
+            duration_ms,
+            extra={
+                "event": "reading_transcribe_fallback",
+                "reason": "too_short",
+                "user_id": current_user.id,
+                "duration_ms": duration_ms,
+            },
+        )
+        return TranscribeReadingResponse(
+            transcript=None,
+            method="fallback",
+            reason="too_short",
+        )
 
     # ── 3. Cap target_text ───────────────────────────────────────────────────
     if len(target_text) > _MAX_TARGET_CHARS:

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -27,6 +27,12 @@ export interface AudioRecorderActions {
   stopAndGetBlob: () => Promise<Blob | null>;
   /** Elapsed ms since startRecording() — 0 if not started. */
   getRecordingDurationMs: () => number;
+  /**
+   * Returns the peak volume (0-1) observed during the last recording session.
+   * Used by callers to detect silence before sending audio to STT (Issue #2321).
+   * Reset to 0 on startRecording().
+   */
+  getPeakVolume: () => number;
   clearRecording: () => void;
 }
 
@@ -62,6 +68,12 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
   const analyserRef = useRef<AnalyserNode | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const rafRef = useRef<number | null>(null);
+  /**
+   * Issue #2321 — Silence gate: tracks the maximum volume (0-1) seen during
+   * the current recording session.  Reset on startRecording(); read via getPeakVolume()
+   * after stopAndGetBlob() to decide whether to send the audio to STT.
+   */
+  const peakVolumeRef = useRef<number>(0);
   /** P1#1 fix: resolver for stopAndGetBlob() — resolved by onstop handler. */
   const stopResolverRef = useRef<((blob: Blob | null) => void) | null>(null);
 
@@ -110,6 +122,7 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     setErrorMessage('');
     setElapsedSeconds(0);
     chunksRef.current = [];
+    peakVolumeRef.current = 0; // Issue #2321: reset silence gate for new session
 
     setStatus('requesting');
 
@@ -200,7 +213,12 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
         if (!analyserRef.current) return;
         analyserRef.current.getByteFrequencyData(dataArray);
         const avg = dataArray.reduce((sum, v) => sum + v, 0) / dataArray.length;
-        setVolumeLevel(Math.min(1, avg / 128));
+        const level = Math.min(1, avg / 128);
+        setVolumeLevel(level);
+        // Issue #2321: track session peak for silence detection after recording ends.
+        if (level > peakVolumeRef.current) {
+          peakVolumeRef.current = level;
+        }
         if (rafRef.current !== null) {
           rafRef.current = requestAnimationFrame(updateVolume);
         }
@@ -279,6 +297,15 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     return Date.now() - startTimeRef.current;
   }, []);
 
+  /**
+   * Issue #2321 — Returns the peak volume level (0-1) observed during the
+   * last recording session.  Call AFTER stopAndGetBlob() resolves.
+   * A value below SILENT_PEAK_THRESHOLD indicates no audible speech was captured.
+   */
+  const getPeakVolume = useCallback((): number => {
+    return peakVolumeRef.current;
+  }, []);
+
   const clearRecording = useCallback(() => {
     // Cancel any pending stopAndGetBlob promise so it doesn't hang.
     if (stopResolverRef.current) {
@@ -324,6 +351,7 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     stopRecording,
     stopAndGetBlob,
     getRecordingDurationMs,
+    getPeakVolume,
     clearRecording,
   };
 }

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -21,6 +21,23 @@ import { cancelTts } from '../services/ttsApi';
 import { saveReadingHistory } from '../services/readingHistoryApi';
 import { transcribeReading, saveReadingAudio } from '../services/learning/session';
 
+/**
+ * Issue #2321 — Silence gate constants.
+ *
+ * SILENT_PEAK_THRESHOLD: peak volume (0-1) below which we consider the recording
+ * silent.  The AnalyserNode returns average byte frequency; 0.05 corresponds to
+ * ~6.4/128 — well below conversational speech (~0.15-0.4) but above true silence.
+ * Conservative: a very soft whisper may still exceed this threshold, which is
+ * intentional — we prefer the occasional STT hallucination over blocking a
+ * real-but-quiet reader.
+ *
+ * SILENT_MIN_DURATION_MS: minimum recording duration below which we skip STT.
+ * 1 500 ms is comfortably longer than an accidental tap but shorter than even
+ * a single Chinese syllable at slow reading speed (~300-400 ms).
+ */
+const SILENT_PEAK_THRESHOLD = 0.05;   // gate: peak volume must exceed this
+const SILENT_MIN_DURATION_MS = 1500;  // gate: recording must be at least 1.5 s
+
 export interface SavedResult {
   matchRate: number;
   feedback: string;
@@ -142,6 +159,19 @@ export function useFullReadingSession({
       return;
     }
 
+    /* Issue #2321 — Silence gate (Gate 1, frontend):
+     * If the recording was too short OR entirely silent, skip STT to prevent
+     * Gemini from hallucinating the lesson text back when given a blank audio.
+     * Uses peakVolume tracked by useAudioRecorder's AnalyserNode loop.
+     * Reuses the existing micError path — no new UI component needed. */
+    const peakVolume = audioRecorder.getPeakVolume();
+    const isSilentByVolume = peakVolume < SILENT_PEAK_THRESHOLD;
+    const isTooShort = durationMs < SILENT_MIN_DURATION_MS;
+    if (isSilentByVolume || isTooShort) {
+      setMicError('未偵測到語音，請重試。');
+      return;
+    }
+
     /* --- Gemini audio transcription (Issue #2131 / #2156 / #2266) ---
      * NOTE: Real audio E2E requires a microphone — cannot be tested headless.
      *       The transcribeReading() wrapper is unit-tested with mocks (vitest). */
@@ -208,7 +238,7 @@ export function useFullReadingSession({
       // No token — cannot reach Gemini.
       setMicError('未偵測到語音，請重試。');
     }
-  }, [fullText, stopSession, token, storyId, dbSessionId, onResultReady, audioRecorder.stopAndGetBlob]);
+  }, [fullText, stopSession, token, storyId, dbSessionId, onResultReady, audioRecorder.stopAndGetBlob, audioRecorder.getPeakVolume]);
 
   return {
     isSessionActive,


### PR DESCRIPTION
Fixes #2321

## 問題根因
`reading_transcription_service.py` system_prompt 把課文原文餵給 Gemini 作為「校正參考」→ 靜音時 Gemini 手上有整篇課文 → 直接吐課文開頭 → deterministic scorer 拿幻覺字比對 → 前 2-3 句假性通過。

## 修法（兩道 gate，不動 system_prompt / scorer / DB）

### Gate 1 — 前端能量門檻（主，源頭斷）
`frontend/src/hooks/useAudioRecorder.ts`
- 在現有 AnalyserNode `updateVolume` loop 加 `peakVolumeRef` 追蹤錄音期間最高音量
- 暴露 `getPeakVolume()` 方法（重置於 `startRecording()`）

`frontend/src/hooks/useFullReadingSession.ts`
- 加常數 `SILENT_PEAK_THRESHOLD = 0.05`、`SILENT_MIN_DURATION_MS = 1500`
- `submitReading()` 在 `stopAndGetBlob()` 之後、送 transcribe 之前：
  - `peakVolume < 0.05` OR `durationMs < 1500ms` → 走現有 `micError` 路徑（「未偵測到語音，請重試。」），不送 STT
- 複用既有 UI，無新元件

### Gate 2 — 後端時長下限（第二層保險）
`backend/app/routes/learning/learning_reading.py`
- 加常數 `_MIN_AUDIO_DURATION_MS = 1000`
- 讀完 audio bytes 之後：若 `duration_ms` 有值且 `< 1000ms` → 直接回傳既有 fallback contract `{transcript: null, method: "fallback", reason: "too_short"}`，不叫 Gemini

## 閾值設計（保守）
| 門檻 | 值 | 理由 |
|------|---|------|
| 前端 peak volume | 0.05 | 真正靜音 ≈ 0；正常朗讀 0.15-0.4；寧可漏擋小聲 |
| 前端最短時長 | 1500ms | 單字最快 200-400ms；1.5s 才能唸 1-2 個字 |
| 後端最短時長 | 1000ms | 後端保險用，更寬鬆 |

## 確認沒動
- `system_prompt`（reading_transcription_service.py 完全未改）
- 評分邏輯（analyzeFluency / scorer）
- DB schema / migration
- 新 React component / 新 state

## 測試結果
- `npm run lint`：0 errors（21 warnings 均為既有 pre-existing）
- `npm run test -- src/__smoke__/`：13/13 passed
- `python3 -m py_compile`：COMPILE_OK（backend 兩個相關檔案）
- Critic review：APPROVE（code-reviewer agent）

## 驗證說明
- Gate 2 可 curl 驗證：送 `duration_ms=500` → 回傳 `{method: "fallback", reason: "too_short"}`
- Gate 1 靜音實測需真實麥克風 → 請案主 stgst / Young 真機測試確認

> 🤖 由 Claude AI 代發（非 Young 本人）