### PR TITLE
feat(teacher): add audio replay button to submission table (Fixes #2326)

### DIFF
--- a/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
+++ b/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
@@ -231,6 +231,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
         submissions={detail.submissions}
         groups={groups}
         useGrouped={useGrouped}
+        assignmentId={assignmentId}
         gradeForm={{
           gradingId: gradeForm.gradingId,
           gradeInput: gradeForm.gradeInput,

--- a/frontend/src/pages/teacher/components/AssignmentSubmissionTable.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentSubmissionTable.tsx
@@ -9,7 +9,7 @@
  *   - Expand/collapse reading metrics per row
  *   - Expand/collapse attempt history for multi-attempt students
  */
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import type {
   SubmissionResponse,
   StudentAttemptGroup,
@@ -17,6 +17,89 @@ import type {
 import ReadingMetricsPanel from './ReadingMetricsPanel';
 import AttemptHistoryPanel from './AttemptHistoryPanel';
 import { statusBadge, formatDate } from '../assignmentDetailUtils.tsx';
+import { getSubmissionReadingAudio } from '../../../services/teacherApi';
+
+// ── PlayAudioButton — inline audio replay for a submission (Issue #2326) ──────
+/** Fetches a 10-min signed URL and plays the student's reading recording.
+ *  Gracefully shows "無錄音" when the backend returns 404 (no recording).
+ *  Declared BEFORE the table component to avoid TDZ (frontend-render-safety rule). */
+interface PlayAudioButtonProps {
+  assignmentId: number;
+  submissionId: number;
+}
+
+const PlayAudioButton: React.FC<PlayAudioButtonProps> = ({
+  assignmentId,
+  submissionId,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [noAudio, setNoAudio] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const stopPlayback = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    // Toggle stop if already playing
+    if (isPlaying) {
+      stopPlayback();
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await getSubmissionReadingAudio('', assignmentId, submissionId);
+      if (!result) {
+        setNoAudio(true);
+        return;
+      }
+      const audio = new Audio(result.signed_url);
+      audioRef.current = audio;
+      audio.onended = () => {
+        setIsPlaying(false);
+        audioRef.current = null;
+      };
+      audio.onerror = () => {
+        setIsPlaying(false);
+        audioRef.current = null;
+      };
+      audio.play().then(() => {
+        setIsPlaying(true);
+      }).catch(() => {
+        setIsPlaying(false);
+        audioRef.current = null;
+      });
+    } catch (_e) {
+      // Unexpected error — surface as no audio
+      setNoAudio(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [assignmentId, submissionId, isPlaying, stopPlayback]);
+
+  if (noAudio) {
+    return <span className="text-gray-300 text-xs">無錄音</span>;
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={loading}
+      title={isPlaying ? '停止播放' : '播放錄音'}
+      className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-green-200 text-green-700 text-xs hover:bg-green-50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors"
+    >
+      {loading ? '...' : isPlaying ? '■ 停止' : '▶ 聽錄音'}
+    </button>
+  );
+};
+
 
 export interface GradeFormProps {
   gradingId: number | null;
@@ -35,6 +118,8 @@ interface Props {
   groups: StudentAttemptGroup[];
   useGrouped: boolean;
   gradeForm: GradeFormProps;
+  /** Assignment ID passed down for audio replay (grouped rows lack it on AttemptResponse). */
+  assignmentId: number;
 }
 
 const AssignmentSubmissionTable: React.FC<Props> = ({
@@ -42,6 +127,7 @@ const AssignmentSubmissionTable: React.FC<Props> = ({
   groups,
   useGrouped,
   gradeForm,
+  assignmentId,
 }) => {
   const {
     gradingId,
@@ -162,6 +248,15 @@ const AssignmentSubmissionTable: React.FC<Props> = ({
           </p>
         </div>
       ) : null}
+
+      {(sub.status === 'submitted' || sub.status === 'graded') && (
+        <div>
+          <PlayAudioButton
+            assignmentId={sub.assignment_id}
+            submissionId={sub.id}
+          />
+        </div>
+      )}
     </div>
   );
 
@@ -278,10 +373,20 @@ const AssignmentSubmissionTable: React.FC<Props> = ({
                 <span className="text-gray-300">—</span>
               )}
             </td>
+            <td className="py-1.5 text-center">
+              {(latest.status === 'submitted' || latest.status === 'graded') ? (
+                <PlayAudioButton
+                  assignmentId={assignmentId}
+                  submissionId={latest.id}
+                />
+              ) : (
+                <span className="text-gray-300">—</span>
+              )}
+            </td>
           </tr>
           {expandedMetricsId === latest.id && (
             <tr>
-              <td colSpan={7} className="pb-2 pt-0">
+              <td colSpan={8} className="pb-2 pt-0">
                 <ReadingMetricsPanel
                   studentName={group.student_name}
                   readingAccuracy={latest.reading_accuracy}
@@ -394,10 +499,20 @@ const AssignmentSubmissionTable: React.FC<Props> = ({
               <span className="text-gray-300">—</span>
             )}
           </td>
+          <td className="py-1.5 text-center">
+            {(sub.status === 'submitted' || sub.status === 'graded') ? (
+              <PlayAudioButton
+                assignmentId={sub.assignment_id}
+                submissionId={sub.id}
+              />
+            ) : (
+              <span className="text-gray-300">—</span>
+            )}
+          </td>
         </tr>
         {expandedMetricsId === sub.id && (
           <tr>
-            <td colSpan={7} className="pb-2 pt-0">
+            <td colSpan={8} className="pb-2 pt-0">
               <ReadingMetricsPanel
                 studentName={sub.student_name}
                 readingAccuracy={sub.reading_accuracy}
@@ -429,6 +544,7 @@ const AssignmentSubmissionTable: React.FC<Props> = ({
               <th className="pb-1.5 font-medium text-center">朗讀數據</th>
               <th className="pb-1.5 font-medium">評語</th>
               <th className="pb-1.5 font-medium text-center">批改</th>
+              <th className="pb-1.5 font-medium text-center">錄音</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -648,3 +648,23 @@ export function generateAIComment(
 ): Promise<{ ai_comment: string }> {
   return post(`/api/teacher/students/${studentId}/sessions/${sessionId}/generate-ai-comment`, {});
 }
+
+// ── Teacher Audio Replay (Issue #2326, Related to #2266 #2286) ────────────────
+
+/** Fetch a 10-minute signed URL so the teacher can replay a student's submission recording.
+ *  Returns null when no recording exists (404) — callers should show a disabled state.
+ */
+export async function getSubmissionReadingAudio(
+  _token: string,
+  assignmentId: number,
+  submissionId: number,
+): Promise<{ signed_url: string; expires_in: number } | null> {
+  try {
+    return await get<{ signed_url: string; expires_in: number }>(
+      `/api/teacher/assignments/${assignmentId}/submissions/${submissionId}/reading-audio`,
+    );
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) return null;
+    throw e;
+  }
+}


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2326

Related to #2266 #2286

## Summary

- **teacherApi.ts** — 新增 `getSubmissionReadingAudio(assignmentId, submissionId)` wrapper，呼叫 `GET /api/teacher/assignments/{id}/submissions/{id}/reading-audio`，404 回 null（無錄音時 graceful）
- **AssignmentSubmissionTable.tsx** — 新增 `PlayAudioButton` component，點擊後拿 signed URL → `new Audio(url).play()`（仿 LiveTutorControls handlePlayback 模式）；`setIsPlaying(true)` 在 play() resolve 後才設定避免閃爍；無錄音顯示「無錄音」不報錯
- 鈕出現在桌面 table 新「錄音」欄（colSpan 7→8）、grouped rows、flat rows、行動卡
- **AssignmentDetailPanel.tsx** — 把 `assignmentId` prop 傳入 table（grouped rows 的 `AttemptResponse` 沒有 assignment_id，需從上層傳）

## What was NOT changed
- 後端不動（#2286 endpoint 已 ready on staging）
- 不加新頁面/新路由
- 不動評分/錄音/DB

## Test plan
- [ ] 老師登入 → 進作業詳情 → 找有提交的學生 → 看到「▶ 聽錄音」鈕
- [ ] 點鈕：有錄音 → 播放；無錄音 → 顯示「無錄音」（不報錯）
- [ ] 桌面 table 出現「錄音」欄；行動卡顯示鈕
- [ ] `npm run lint` 0 errors
- [ ] smoke tests 13/13 pass