### PR TITLE
fix(testset): recordings list 不限 admin（任何登入者可看）Fixes #2329

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
-from ..auth.dependencies import get_current_user, require_role
+from ..auth.dependencies import get_current_user
 from ..models.user import User
 from ..services.audio_upload_service import (
     _get_gcs_bucket,
@@ -121,16 +121,14 @@ async def testset_upload(
     return {"ok": True, "path": audio_path}
 
 
-@router.get(
-    "/testset/recordings",
-    dependencies=[require_role("system_admin", "teacher")],
-)
+@router.get("/testset/recordings")
 def testset_recordings(current_user: User = Depends(get_current_user)):
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
 
-    限 system_admin / teacher（codex review #2304-followup）→ 一般登入學生
-    不得抓取貢獻者 PII（名字/年級/可播放錄音）。list.html 讀 localStorage
-    `lingoleap_token` 帶 Bearer；未登入 → 401、權限不足 → 403。
+    任何登入者可看（Young 2026-06-21：先不限 admin/teacher）。仍需登入，
+    擋匿名公開抓取貢獻者 PII（名字/年級/可播放錄音）。list.html 讀 localStorage
+    `lingoleap_token` 帶 Bearer；未登入 → 401。
+    （v2 若要全公開或收回 admin-only 再調；codex #2304 的 role gate 暫移除。）
     """
     bucket = _get_gcs_bucket()
     if bucket is None:

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -83,7 +83,7 @@ async function load(){
     var token=localStorage.getItem('lingoleap_token');
     var r=await fetch(API+'/api/testset/recordings',{headers: token?{'Authorization':'Bearer '+token}:{}});
     if(r.status===401||r.status===403){
-      document.getElementById('matrixWrap').innerHTML='<div class="err">這是管理頁，請先到主站登入（管理員/老師）後再開此頁。<br><a href="/login">前往登入 →</a></div>';
+      document.getElementById('matrixWrap').innerHTML='<div class="err">請先到主站登入（任何帳號皆可）後再開此頁。<br><a href="/login">前往登入 →</a></div>';
       return;
     }
     var j=await r.json();


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Young 指示「先不要限制 admin」。移除 `/api/testset/recordings` 的 `require_role(system_admin,teacher)`，保留 `get_current_user`（仍需登入、擋匿名 PII）。list.html 401 提示改「任何帳號皆可」。
codex #2304 role-gate 暫移除；v2 要全公開或收回 admin-only 再調。
py_compile OK。