### PR TITLE
feat: testset v2 — per-lesson pages + owner dashboard (Fixes #2332)

### DIFF
--- a/frontend/public/testset/index.html
+++ b/frontend/public/testset/index.html
@@ -3,197 +3,69 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>朗讀錄音貢獻 · LingoLeap 測試集</title>
+<title>朗讀錄音貢獻 · LingoLeap</title>
 <style>
-  :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--green:#16a34a;--red:#dc2626;--chip:#efe9ff}
+  :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--chip:#efe9ff}
   *{box-sizing:border-box}
-  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:24px 16px;line-height:1.7}
-  .wrap{max-width:680px;margin:0 auto}
-  h1{color:var(--purple);font-size:1.4rem;margin:0 0 4px}
-  .sub{color:var(--muted);font-size:.9rem;margin:0 0 20px}
-  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
-  .step{font-weight:700;color:var(--purple);margin-bottom:10px}
-  label{display:block;font-size:.85rem;color:var(--muted);margin:8px 0 4px}
-  input,select{width:100%;padding:10px;border:1px solid var(--line);border-radius:8px;font:inherit;background:#fff}
-  .lessons{display:flex;flex-direction:column;gap:8px}
-  .lesson{padding:12px;border:1px solid var(--line);border-radius:8px;cursor:pointer;background:#fff}
-  .lesson.sel{border-color:var(--purple);background:var(--chip)}
-  .lesson .t{font-weight:600}
-  .passage{background:#faf7f0;border-left:3px solid var(--purple);padding:12px;border-radius:8px;margin:10px 0;font-size:1.05rem;line-height:2}
-  .vtabs{display:flex;gap:8px;margin:10px 0}
-  .vtab{flex:1;padding:10px;border:1px solid var(--line);border-radius:8px;background:#fff;cursor:pointer;text-align:center;font-weight:600}
-  .vtab.sel{border-color:var(--purple);background:var(--chip);color:var(--purple)}
-  .vtab .hint{display:block;font-size:.72rem;color:var(--muted);font-weight:400}
-  .btn{padding:12px 18px;border:none;border-radius:10px;font:inherit;font-weight:700;cursor:pointer}
-  .btn-rec{background:var(--red);color:#fff;width:100%}
-  .btn-rec.recording{background:#7f1d1d}
-  .btn-up{background:var(--purple);color:#fff;width:100%}
-  .btn:disabled{opacity:.4;cursor:not-allowed}
-  audio{width:100%;margin-top:10px}
-  .status{font-size:.85rem;margin-top:8px}
-  .ok{color:var(--green);font-weight:700}
-  .err{color:var(--red)}
-  .grid{display:grid;grid-template-columns:1fr auto auto;gap:6px 10px;font-size:.85rem;margin-top:6px;align-items:center}
-  .dot{width:14px;height:14px;border-radius:50%;background:#ddd;display:inline-block}
-  .dot.done{background:var(--green)}
-  .muted{color:var(--muted)}
-  .thanks{text-align:center;padding:30px;color:var(--green);font-weight:700;font-size:1.2rem}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:40px 16px;line-height:1.7;text-align:center}
+  .wrap{max-width:480px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.4rem;margin:0 0 8px}
+  .sub{color:var(--muted);font-size:.95rem;margin:0 0 32px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:24px;box-shadow:0 1px 4px rgba(0,0,0,.07);margin-bottom:16px}
+  .btn-main{display:block;width:100%;padding:14px;border:none;border-radius:10px;font:inherit;font-size:1rem;font-weight:700;cursor:pointer;background:var(--purple);color:#fff;text-decoration:none;text-align:center;margin-bottom:12px}
+  .btn-main:hover{opacity:.88}
+  .btn-sec{display:block;width:100%;padding:12px;border:1px solid var(--purple);border-radius:10px;font:inherit;font-size:.9rem;font-weight:600;cursor:pointer;background:#fff;color:var(--purple);text-decoration:none;text-align:center}
+  .btn-sec:hover{background:var(--chip)}
+  .note{font-size:.82rem;color:var(--muted);margin-top:16px}
+  .icon{font-size:2.5rem;margin-bottom:12px}
 </style>
 </head>
 <body>
 <div class="wrap">
+  <div class="icon">🎙</div>
   <h1>朗讀錄音貢獻</h1>
-  <p class="sub">幫 LingoLeap 蒐集真人朗讀，訓練/驗證 AI 朗讀評分。大約 10–15 分鐘。謝謝你！</p>
-
-  <div class="card" id="who-card">
-    <div class="step">① 你是誰</div>
-    <label>名字（暱稱即可）</label>
-    <input id="name" placeholder="例如：小明 / Amy">
-    <label>年級</label>
-    <select id="grade">
-      <option value="">請選擇</option>
-      <option>國小三年級</option><option>國小四年級</option><option>國小五年級</option><option>國小六年級</option>
-      <option>國中七年級</option><option>國中八年級</option><option>國中九年級</option>
-      <option>高中以上</option>
-    </select>
-  </div>
+  <p class="sub">幫 LingoLeap 蒐集真人朗讀，訓練與驗證 AI 朗讀評分</p>
 
   <div class="card">
-    <div class="step">② 選一篇課文</div>
-    <div class="lessons" id="lessons"></div>
+    <p style="margin:0 0 16px;font-weight:600">請從下方選擇要錄音的課文</p>
+    <div id="lessonList">載入中…</div>
   </div>
 
-  <div class="card" id="read-card" style="display:none">
-    <div class="step">③ 照著念 + 錄音</div>
-    <div class="passage" id="passage"></div>
-    <div class="vtabs">
-      <div class="vtab sel" data-v="correct" onclick="selVersion('correct')">正確版<span class="hint">盡量念對</span></div>
-      <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
-    </div>
-    <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
-    <audio id="player" controls style="display:none"></audio>
-    <button class="btn btn-up" id="upBtn" onclick="upload()" disabled style="margin-top:10px">⬆ 上傳這段</button>
-    <div class="status" id="status"></div>
-  </div>
-
-  <div class="card">
-    <div class="step">④ 我的進度</div>
-    <div class="grid" id="progress"></div>
-    <p class="muted" id="allDone" style="display:none">🎉 都錄完了，太感謝你！可以關掉了。</p>
-  </div>
+  <a class="btn-sec" href="./list.html">查看收集現況（管理員）</a>
+  <p class="note">每篇課文請錄「正確版」+ 「刻意錯誤版」各一段</p>
 </div>
 
 <script>
-// ── API base：從前端 hostname 推後端（Cloud Run -frontend- → -backend-）──
 function apiBase(){
   var h=location.origin;
   if(h.indexOf('-frontend-')>-1) return h.replace('-frontend-','-backend-');
   if(h.indexOf('localhost')>-1||h.indexOf('127.0.0.1')>-1) return 'http://localhost:8000';
-  // firebase / 其他 → 用 staging backend 後備
   return 'https://lingoleap-backend-staging-958347263320.asia-east1.run.app';
 }
 var API=apiBase();
 
-var LESSONS=[
-  {id:'L01',title:'贏得喝采的輸家',text:'「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳～」這一句洗腦的廣告臺詞，是否也在你的周遭出現？她就是台灣第一人，累計二一四週排名世界第一的球后──戴資穎。'},
-  {id:'L02',title:'十秒的背後',text:'十秒鐘你能做什麼？裝一杯水、哼一段小曲、等待手機略過廣告？這十秒可能還不夠呢。這轉瞬即逝的十秒，對於百尺短跑的選手來說，足以決定一場令人血脈賁張、緊張刺激的勝負。'},
-  {id:'L03',title:'長高的祕密',text:'開學後不久，又是到健康中心量身高體重的時候。同學們嘰嘰喳喳講個不停，有人會開始炫耀自己的身高，有人則是會隱藏自己的體重。'},
-  {id:'L04',title:'運動科學',text:'漫畫《一拳超人》中的埼玉老師堅持了三年，每天做一百次的伏地挺身、一百次的仰臥起坐、一百次的深蹲、十公里的長跑，終於擁有一拳就能打倒所有敵人的實力。'},
-  {id:'L05',title:'穿越極限的跑者',text:'「一個夢想如果可以被想像，那就有存在的價值，但重點是你要怎麼計劃並且執行。」臺灣極地超級馬拉松好手陳彥博說。他跑過沙漠、高山和冰原，是第一位勇奪四大極地超級馬拉松巡迴賽總冠軍的亞洲人。'},
-  {id:'L06',title:'第一百碗麵',text:'在一個寒冷的晚上，一位在社區做資源回收的老人穿著反光背心，手上提著一個垃圾袋，袋子裡的寶特瓶、鋁罐已經半滿。他左手牽著一個小男孩，拐了個彎，走進那個賣麵的小攤子。'},
-  {id:'L07',title:'黑猩猩的守護者',text:'珍古德因為家庭經濟因素，高中畢業後沒有繼續念大學。她小時候最喜愛《杜立德醫生非洲歷險記》這本書，書中描述杜立德醫生到非洲，把一群得了瘟疫的猴子拯救出來的故事。'},
-  {id:'L08',title:'奧運銀牌的自我鍛鍊',text:'他緊緊抓住對手的柔道衣，隨時感受對手重心的移動，一抓到時機，就運用技巧和力量，將對手狠狠摔在地板上。他是目前男子六十公斤量級世界第一的柔道選手──楊勇緯。'}
-];
-var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 
-var cur={lesson:null,version:'correct'};
-var done=JSON.parse(localStorage.getItem('testset_done')||'{}'); // {L01_correct:true}
-var mediaRec=null, chunks=[], blob=null;
-
-function renderLessons(){
-  var el=document.getElementById('lessons'); el.innerHTML='';
-  LESSONS.forEach(function(L){
-    var d=document.createElement('div'); d.className='lesson'+(cur.lesson&&cur.lesson.id===L.id?' sel':'');
-    d.innerHTML='<div class="t">'+L.title+'</div><div class="muted" style="font-size:.8rem">'+L.id+'</div>';
-    d.onclick=function(){ cur.lesson=L; renderLessons(); openRead(); };
-    el.appendChild(d);
-  });
-}
-function openRead(){
-  document.getElementById('read-card').style.display='block';
-  document.getElementById('passage').innerText=cur.lesson.text;
-  resetRec();
-}
-function selVersion(v){
-  cur.version=v;
-  document.querySelectorAll('.vtab').forEach(function(t){t.classList.toggle('sel',t.dataset.v===v)});
-  resetRec();
-}
-function resetRec(){
-  blob=null;
-  var p=document.getElementById('player'); p.style.display='none'; p.src='';
-  document.getElementById('upBtn').disabled=true;
-  document.getElementById('status').innerHTML='';
-  var b=document.getElementById('recBtn'); b.classList.remove('recording'); b.textContent='● 開始錄音';
-}
-async function toggleRec(){
-  var b=document.getElementById('recBtn');
-  if(mediaRec&&mediaRec.state==='recording'){ mediaRec.stop(); return; }
+async function loadLessons(){
+  var el=document.getElementById('lessonList');
   try{
-    var stream=await navigator.mediaDevices.getUserMedia({audio:true});
-    chunks=[]; mediaRec=new MediaRecorder(stream);
-    mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
-    mediaRec.onstop=function(){
-      blob=new Blob(chunks,{type:'audio/webm'});
-      var p=document.getElementById('player'); p.src=URL.createObjectURL(blob); p.style.display='block';
-      document.getElementById('upBtn').disabled=false;
-      stream.getTracks().forEach(function(t){t.stop()});
-      b.classList.remove('recording'); b.textContent='● 重新錄音';
-    };
-    mediaRec.start(); b.classList.add('recording'); b.textContent='■ 停止錄音';
-    document.getElementById('status').innerHTML='<span class="muted">錄音中…照著上面念</span>';
-  }catch(e){
-    document.getElementById('status').innerHTML='<span class="err">無法存取麥克風，請允許權限後再試</span>';
-  }
-}
-async function upload(){
-  var name=document.getElementById('name').value.trim();
-  var grade=document.getElementById('grade').value;
-  if(!name||!grade){ document.getElementById('status').innerHTML='<span class="err">請先在①填名字和年級</span>'; window.scrollTo(0,0); return; }
-  if(!blob){ return; }
-  document.getElementById('upBtn').disabled=true;
-  document.getElementById('status').innerHTML='<span class="muted">上傳中…</span>';
-  var fd=new FormData();
-  fd.append('contributor_name',name); fd.append('grade',grade);
-  fd.append('lesson_id',cur.lesson.id); fd.append('version',cur.version);
-  fd.append('audio',blob,cur.lesson.id+'_'+cur.version+'.webm');
-  try{
-    var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
-    if(!r.ok){ throw new Error('HTTP '+r.status); }
-    done[cur.lesson.id+'_'+cur.version]=true;
-    localStorage.setItem('testset_done',JSON.stringify(done));
-    document.getElementById('status').innerHTML='<span class="ok">✓ 已上傳！</span>';
-    renderProgress();
-  }catch(e){
-    document.getElementById('upBtn').disabled=false;
-    document.getElementById('status').innerHTML='<span class="err">上傳失敗，請再試一次（'+e.message+'）</span>';
-  }
-}
-function renderProgress(){
-  var el=document.getElementById('progress'); el.innerHTML='';
-  var total=LESSONS.length*VERSIONS.length, n=0;
-  LESSONS.forEach(function(L){
-    var row=document.createElement('div'); row.textContent=L.title; el.appendChild(row);
-    VERSIONS.forEach(function(V){
-      var ok=done[L.id+'_'+V.k]; if(ok)n++;
-      var c=document.createElement('div'); c.style.textAlign='center';
-      c.innerHTML='<span class="dot'+(ok?' done':'')+'" title="'+V.n+'"></span><div class="muted" style="font-size:.7rem">'+V.n+'</div>';
-      el.appendChild(c);
+    var r=await fetch(API+'/api/stories?page_size=300');
+    if(!r.ok) throw new Error('HTTP '+r.status);
+    var j=await r.json();
+    var stories=j.stories||[];
+    if(!stories.length){ el.textContent='暫無課文'; return; }
+    var h='';
+    stories.forEach(function(s){
+      var url='./record.html?lesson='+encodeURIComponent(s.id);
+      h+='<a class="btn-main" href="'+esc(url)+'">'+esc(s.title)+'<span style="display:block;font-size:.75rem;opacity:.7;font-weight:400">'+esc(s.id)+'</span></a>';
     });
-  });
-  document.getElementById('allDone').style.display = n>=total ? 'block':'none';
+    el.innerHTML=h;
+  }catch(e){
+    el.innerHTML='<p style="color:#dc2626;font-size:.9rem">課文清單載入失敗：'+esc(e.message)+'<br><button onclick="loadLessons()" style="margin-top:8px;padding:6px 14px;cursor:pointer;border:1px solid #dc2626;background:#fff;border-radius:6px;color:#dc2626">重試</button></p>';
+  }
 }
-renderLessons(); renderProgress();
+
+loadLessons();
 </script>
 </body>
 </html>

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -8,58 +8,63 @@
   :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--green:#16a34a;--amber:#d97706;--red:#dc2626;--chip:#efe9ff}
   *{box-sizing:border-box}
   body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:28px 18px;line-height:1.6}
-  .wrap{max-width:1000px;margin:0 auto}
+  .wrap{max-width:1100px;margin:0 auto}
   h1{color:var(--purple);font-size:1.5rem;margin:0 0 4px}
   .sub{color:var(--muted);margin:0 0 18px}
-  .share{display:flex;align-items:center;gap:12px;background:var(--chip);border:1px solid var(--purple);border-radius:12px;padding:14px 18px;margin-bottom:20px;flex-wrap:wrap}
-  .share .lbl{font-weight:700;color:var(--purple)}
-  .share a{color:var(--purple);font-weight:600;word-break:break-all}
-  .share button{padding:8px 14px;border:1px solid var(--purple);background:#fff;color:var(--purple);border-radius:8px;font:inherit;font-weight:600;cursor:pointer}
+  .auth-banner{background:#fef9c3;border:1px solid var(--amber);border-radius:10px;padding:14px 18px;margin-bottom:18px;color:#92400e;font-size:.9rem}
+  .auth-banner a{color:var(--purple);font-weight:600}
   .stats{display:flex;gap:12px;margin-bottom:18px;flex-wrap:wrap}
   .stat{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:12px 18px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
   .stat .n{font-size:1.6rem;font-weight:800;color:var(--purple)}
   .stat .l{font-size:.8rem;color:var(--muted)}
   h2{font-size:1.1rem;color:var(--ink);margin:22px 0 10px}
   table{width:100%;border-collapse:collapse;background:var(--card);border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06);font-size:.9rem}
-  th,td{padding:11px 13px;border-bottom:1px solid var(--line);text-align:left;vertical-align:middle}
-  th{background:#f3eee4;font-size:.82rem}
+  th,td{padding:10px 12px;border-bottom:1px solid var(--line);text-align:left;vertical-align:middle}
+  th{background:#f3eee4;font-size:.82rem;white-space:nowrap}
+  tr.data-row:hover td{background:#faf7f0}
   tr:last-child td{border-bottom:none}
-  .cell{display:flex;align-items:center;gap:8px}
   .pill{display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:24px;padding:0 8px;border-radius:20px;font-size:.82rem;font-weight:700}
   .pill.zero{background:#f3f0e8;color:var(--muted)}
   .pill.some{background:#dcfce7;color:var(--green)}
-  .names{font-size:.78rem;color:var(--muted)}
-  .det{font-size:.86rem}
-  .det td{padding:9px 13px}
-  audio{height:30px;vertical-align:middle}
-  .muted{color:var(--muted)}
+  .lesson-title{font-weight:600}
+  .lesson-id{font-size:.78rem;color:var(--muted)}
+  .ai-badge{background:#f3f0e8;color:var(--muted);font-size:.75rem;padding:2px 8px;border-radius:20px;white-space:nowrap}
+  .copy-btn{padding:5px 11px;border:1px solid var(--purple);background:#fff;color:var(--purple);border-radius:8px;font:inherit;font-size:.8rem;font-weight:600;cursor:pointer;white-space:nowrap}
+  .copy-btn:hover{background:var(--chip)}
+  .copy-btn.copied{border-color:var(--green);color:var(--green)}
+  .open-btn{padding:5px 11px;border:none;background:var(--purple);color:#fff;border-radius:8px;font:inherit;font-size:.8rem;font-weight:600;cursor:pointer;text-decoration:none;display:inline-block;white-space:nowrap}
+  .open-btn:hover{opacity:.85}
+  .expand-btn{background:none;border:none;color:var(--purple);cursor:pointer;font-size:.78rem;font-weight:600;padding:0;white-space:nowrap;text-decoration:underline}
+  .action-cell{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
   .loading{text-align:center;padding:40px;color:var(--muted)}
-  .err{color:var(--red);text-align:center;padding:20px}
-  code{background:#f3eee4;padding:1px 6px;border-radius:4px}
+  .detail-row{display:none;background:#faf7f0}
+  .detail-row>td{padding:10px 14px}
+  .detail-inner{max-height:220px;overflow-y:auto}
+  .det-table{width:100%;font-size:.82rem;border-collapse:collapse}
+  .det-table th,.det-table td{padding:5px 8px;border-bottom:1px solid var(--line);text-align:left}
+  .det-table th{background:#ede8de}
+  audio{height:28px;vertical-align:middle}
+  .muted{color:var(--muted)}
 </style>
 </head>
 <body>
 <div class="wrap">
   <h1>測試集收集現況</h1>
-  <p class="sub">真人朗讀錄音蒐集進度 — 每篇課文各需「正確版 + 刻意錯誤版」</p>
+  <p class="sub">每篇課文各需「正確版 + 刻意錯誤版」— 複製各課分享連結傳給貢獻者錄音</p>
 
-  <div class="share">
-    <span class="lbl">📣 分享給貢獻者：</span>
-    <a id="shareLink" href="./index.html">./index.html</a>
-    <button onclick="copyLink()">複製連結</button>
-    <a href="./index.html" target="_blank" style="margin-left:auto"><button>開啟錄音頁 →</button></a>
+  <div id="authBanner" class="auth-banner" style="display:none">
+    錄音明細需要教師/管理員登入才能查看。<a href="/login">前往登入 →</a>
+    <br><small>各課的「複製連結」功能無需登入，可直接分享給貢獻者。</small>
   </div>
 
-  <div class="stats" id="stats"></div>
+  <div class="stats" id="stats"><div class="loading">載入中…</div></div>
 
-  <h2>覆蓋率矩陣（課文 × 版本）</h2>
-  <div id="matrixWrap"><div class="loading">載入中…</div></div>
-
-  <h2>所有錄音明細</h2>
-  <div id="detailWrap"></div>
+  <h2>所有課文</h2>
+  <div id="tableWrap"><div class="loading">載入課文清單…</div></div>
 </div>
 
 <script>
+/* ── API base ── */
 function apiBase(){
   var h=location.origin;
   if(h.indexOf('-frontend-')>-1) return h.replace('-frontend-','-backend-');
@@ -67,75 +72,168 @@ function apiBase(){
   return 'https://lingoleap-backend-staging-958347263320.asia-east1.run.app';
 }
 var API=apiBase();
-var LESSON_TITLES={L01:'贏得喝采的輸家',L02:'十秒的背後',L03:'長高的祕密',L04:'運動科學',L05:'穿越極限的跑者',L06:'第一百碗麵',L07:'黑猩猩的守護者',L08:'奧運銀牌的自我鍛鍊'};
-var EXPECTED=['L01','L02','L03','L04','L05','L06','L07','L08'];
-var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 
-document.getElementById('shareLink').textContent=location.origin+location.pathname.replace('list.html','index.html');
-document.getElementById('shareLink').href=location.origin+location.pathname.replace('list.html','index.html');
-function copyLink(){ navigator.clipboard.writeText(location.origin+location.pathname.replace('list.html','index.html')); }
+function recordUrl(lessonId){
+  return location.origin+'/testset/record.html?lesson='+encodeURIComponent(lessonId);
+}
 
-function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
+function esc(s){
+  return String(s==null?'':s)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
 
+/* ── copy button ── */
+function copyLink(btn,url){
+  navigator.clipboard.writeText(url).then(function(){
+    btn.textContent='已複製';
+    btn.classList.add('copied');
+    setTimeout(function(){ btn.textContent='複製連結'; btn.classList.remove('copied'); },2000);
+  }).catch(function(){
+    var t=document.createElement('textarea'); t.value=url;
+    t.style.position='fixed'; t.style.left='-9999px';
+    document.body.appendChild(t); t.select(); document.execCommand('copy'); document.body.removeChild(t);
+    btn.textContent='已複製'; btn.classList.add('copied');
+    setTimeout(function(){ btn.textContent='複製連結'; btn.classList.remove('copied'); },2000);
+  });
+}
+
+/* ── expand detail ── */
+function toggleDetail(id){
+  var row=document.getElementById('det-'+id);
+  if(!row) return;
+  var shown=row.style.display==='table-row';
+  row.style.display=shown?'none':'table-row';
+  var btn=document.querySelector('[data-expand="'+id+'"]');
+  if(btn) btn.textContent=shown?'展開 ▼':'收起 ▲';
+}
+
+/* ── load ── */
 async function load(){
-  var recs=[];
+  // 1. story list — public endpoint, no auth needed
+  var stories=[];
   try{
-    var token=localStorage.getItem('lingoleap_token');
-    var r=await fetch(API+'/api/testset/recordings',{headers: token?{'Authorization':'Bearer '+token}:{}});
-    if(r.status===401||r.status===403){
-      document.getElementById('matrixWrap').innerHTML='<div class="err">請先到主站登入（任何帳號皆可）後再開此頁。<br><a href="/login">前往登入 →</a></div>';
-      return;
-    }
+    var r=await fetch(API+'/api/stories?page_size=300');
+    if(!r.ok) throw new Error('HTTP '+r.status);
     var j=await r.json();
-    recs=j.recordings||[];
+    stories=j.stories||[];
   }catch(e){
-    document.getElementById('matrixWrap').innerHTML='<div class="err">讀取失敗：'+esc(e.message)+'</div>';
+    document.getElementById('tableWrap').innerHTML='<div class="loading" style="color:var(--red)">課文清單載入失敗：'+esc(e.message)+'</div>';
+    document.getElementById('stats').innerHTML='';
     return;
   }
-  // lessons = expected ∪ seen
-  var lessons={}; EXPECTED.forEach(function(id){lessons[id]=true});
-  recs.forEach(function(m){ if(m.lesson_id) lessons[m.lesson_id]=true; });
-  var lessonIds=Object.keys(lessons);
 
-  // index by lesson+version
-  var idx={}; var contributors={};
+  // 2. recordings — requires teacher/admin Bearer token
+  var recs=[];
+  var authOk=false;
+  try{
+    var token=localStorage.getItem('lingoleap_token');
+    if(token){
+      var r2=await fetch(API+'/api/testset/recordings',{headers:{'Authorization':'Bearer '+token}});
+      if(r2.status===401||r2.status===403){
+        document.getElementById('authBanner').style.display='block';
+      } else if(r2.ok){
+        var j2=await r2.json();
+        recs=j2.recordings||[];
+        authOk=true;
+      }
+    } else {
+      document.getElementById('authBanner').style.display='block';
+    }
+  }catch(e){
+    // recordings optional
+  }
+
+  // 3. index: lesson_id + version → list of recordings
+  var idx={};
+  var contribSet={};
   recs.forEach(function(m){
-    var k=m.lesson_id+'_'+m.version; (idx[k]=idx[k]||[]).push(m);
-    if(m.contributor_name) contributors[m.contributor_name+'｜'+(m.grade||'')]=true;
+    var k=m.lesson_id+'||'+m.version;
+    (idx[k]=idx[k]||[]).push(m);
+    if(m.contributor_name) contribSet[m.contributor_name]=true;
   });
 
-  // stats
-  var total=recs.length, cells=lessonIds.length*VERSIONS.length, filled=0;
-  lessonIds.forEach(function(id){VERSIONS.forEach(function(v){ if((idx[id+'_'+v.k]||[]).length) filled++; })});
+  // 4. stats
+  var totalRecs=recs.length;
+  var coveredCells=0;
+  stories.forEach(function(s){
+    if((idx[s.id+'||correct']||[]).length) coveredCells++;
+    if((idx[s.id+'||error']||[]).length) coveredCells++;
+  });
+  var totalCells=stories.length*2;
+
   document.getElementById('stats').innerHTML=
-    stat(total,'總錄音數')+stat(filled+' / '+cells,'已覆蓋格')+stat(Object.keys(contributors).length,'貢獻者')+stat(lessonIds.length,'課文數');
+    statCard(stories.length,'課文總數')+
+    statCard(authOk?totalRecs:'—','總錄音數')+
+    statCard(authOk?(coveredCells+' / '+totalCells):'— / '+totalCells,'已覆蓋格')+
+    statCard(authOk?Object.keys(contribSet).length:'—','貢獻者數');
 
-  // matrix
-  var h='<table><thead><tr><th>課文</th>'+VERSIONS.map(function(v){return '<th>'+v.n+'</th>'}).join('')+'</tr></thead><tbody>';
-  lessonIds.forEach(function(id){
-    h+='<tr><td><b>'+esc(LESSON_TITLES[id]||id)+'</b><div class="muted" style="font-size:.78rem">'+esc(id)+'</div></td>';
-    VERSIONS.forEach(function(v){
-      var list=idx[id+'_'+v.k]||[]; var n=list.length;
-      var names=list.map(function(m){return esc(m.contributor_name)}).filter(function(x,i,a){return a.indexOf(x)===i}).join('、');
-      h+='<td><div class="cell"><span class="pill '+(n?'some':'zero')+'">'+n+'</span>'+(names?'<span class="names">'+names+'</span>':'<span class="names">尚無</span>')+'</div></td>';
+  // 5. build table
+  var h='<table><thead><tr>'+
+    '<th>#</th>'+
+    '<th>課文</th>'+
+    '<th>正確版</th>'+
+    '<th>錯誤版</th>'+
+    '<th>貢獻者</th>'+
+    '<th>AI 判斷</th>'+
+    '<th>分享與操作</th>'+
+    '</tr></thead><tbody>';
+
+  stories.forEach(function(s,i){
+    var id=s.id;
+    var url=recordUrl(id);
+    var correctList=idx[id+'||correct']||[];
+    var errorList=idx[id+'||error']||[];
+    var allRecs=correctList.concat(errorList);
+    var contribs=[];
+    allRecs.forEach(function(m){
+      if(m.contributor_name&&contribs.indexOf(m.contributor_name)<0) contribs.push(m.contributor_name);
     });
-    h+='</tr>';
-  });
-  h+='</tbody></table>';
-  document.getElementById('matrixWrap').innerHTML=h;
+    var hasDetail=authOk&&allRecs.length>0;
 
-  // detail
-  if(!recs.length){ document.getElementById('detailWrap').innerHTML='<p class="muted">還沒有任何錄音。把上面的連結分享出去吧！</p>'; return; }
-  var d='<table class="det"><thead><tr><th>課文</th><th>版本</th><th>貢獻者</th><th>年級</th><th>時間</th><th>播放</th></tr></thead><tbody>';
-  recs.forEach(function(m){
-    var vn=(VERSIONS.filter(function(v){return v.k===m.version})[0]||{}).n||m.version;
-    var t=(m.created_at||'').replace('T',' ').slice(0,16);
-    d+='<tr><td>'+esc(LESSON_TITLES[m.lesson_id]||m.lesson_id)+'</td><td>'+vn+'</td><td>'+esc(m.contributor_name)+'</td><td>'+esc(m.grade)+'</td><td class="muted">'+esc(t)+'</td><td>'+(m.play_url?'<audio controls preload="none" src="'+esc(m.play_url)+'"></audio>':'<span class="muted">—</span>')+'</td></tr>';
+    h+='<tr class="data-row">';
+    h+='<td class="muted" style="font-size:.8rem">'+(i+1)+'</td>';
+    h+='<td><div class="lesson-title">'+esc(s.title)+'</div><div class="lesson-id">'+esc(id)+'</div></td>';
+    h+='<td><span class="pill '+(correctList.length?'some':'zero')+'">'+correctList.length+'</span></td>';
+    h+='<td><span class="pill '+(errorList.length?'some':'zero')+'">'+errorList.length+'</span></td>';
+    h+='<td>'+(authOk?(contribs.length?('<span title="'+esc(contribs.join('、'))+'">'+esc(contribs.length+' 人')+'</span>'):'<span class="muted">—</span>'):'<span class="muted">需登入</span>')+'</td>';
+    h+='<td><span class="ai-badge">待對應</span></td>';
+    h+='<td><div class="action-cell">'+
+      '<button class="copy-btn" onclick="copyLink(this,\''+esc(url)+'\')">複製連結</button>'+
+      '<a class="open-btn" href="'+esc(url)+'" target="_blank">開啟</a>'+
+      (hasDetail?'<button class="expand-btn" data-expand="'+esc(id)+'" onclick="toggleDetail(\''+esc(id)+'\')">展開 ▼</button>':'')+
+      '</div></td>';
+    h+='</tr>';
+
+    // inline detail row (only when authed + has recs)
+    if(hasDetail){
+      h+='<tr class="detail-row" id="det-'+esc(id)+'"><td colspan="7"><div class="detail-inner">'+
+        '<table class="det-table"><thead><tr>'+
+        '<th>版本</th><th>貢獻者</th><th>年級</th><th>時間</th><th>播放</th>'+
+        '</tr></thead><tbody>';
+      allRecs.forEach(function(m){
+        var vn=m.version==='correct'?'正確版':'錯誤版';
+        var t=(m.created_at||'').replace('T',' ').slice(0,16);
+        h+='<tr>'+
+          '<td>'+vn+'</td>'+
+          '<td>'+esc(m.contributor_name)+'</td>'+
+          '<td>'+esc(m.grade)+'</td>'+
+          '<td class="muted">'+esc(t)+'</td>'+
+          '<td>'+(m.play_url?'<audio controls preload="none" src="'+esc(m.play_url)+'"></audio>':'<span class="muted">—</span>')+'</td>'+
+          '</tr>';
+      });
+      h+='</tbody></table></div></td></tr>';
+    }
   });
-  d+='</tbody></table>';
-  document.getElementById('detailWrap').innerHTML=d;
+
+  h+='</tbody></table>';
+  document.getElementById('tableWrap').innerHTML=h;
 }
-function stat(n,l){return '<div class="stat"><div class="n">'+n+'</div><div class="l">'+l+'</div></div>';}
+
+function statCard(n,l){
+  return '<div class="stat"><div class="n">'+n+'</div><div class="l">'+l+'</div></div>';
+}
+
 load();
 </script>
 </body>

--- a/frontend/public/testset/record.html
+++ b/frontend/public/testset/record.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>朗讀錄音貢獻 · LingoLeap</title>
+<style>
+  :root{--bg:#FDF8F0;--ink:#1a1a2e;--purple:#5B4FC4;--muted:#6b6b8a;--card:#fff;--line:#e7e2d8;--green:#16a34a;--red:#dc2626;--chip:#efe9ff}
+  *{box-sizing:border-box}
+  body{font-family:"Noto Sans TC",system-ui,sans-serif;background:var(--bg);color:var(--ink);margin:0;padding:24px 16px;line-height:1.7}
+  .wrap{max-width:700px;margin:0 auto}
+  h1{color:var(--purple);font-size:1.4rem;margin:0 0 4px}
+  .sub{color:var(--muted);font-size:.9rem;margin:0 0 20px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+  .step{font-weight:700;color:var(--purple);margin-bottom:10px}
+  label{display:block;font-size:.85rem;color:var(--muted);margin:8px 0 4px}
+  input,select{width:100%;padding:10px;border:1px solid var(--line);border-radius:8px;font:inherit;background:#fff}
+  .lesson-title{font-size:1.15rem;font-weight:800;color:var(--ink);margin:0 0 4px}
+  .lesson-id{font-size:.8rem;color:var(--muted);margin:0 0 14px}
+  .passage{background:#faf7f0;border-left:3px solid var(--purple);padding:14px 16px;border-radius:8px;margin:10px 0;font-size:1.08rem;line-height:2.1;max-height:380px;overflow-y:auto;white-space:pre-wrap;word-break:break-word}
+  .passage p{margin:0 0 .8em}
+  .passage p:last-child{margin:0}
+  .loading-text{color:var(--muted);font-size:.9rem;text-align:center;padding:24px 0}
+  .vtabs{display:flex;gap:8px;margin:10px 0}
+  .vtab{flex:1;padding:10px;border:1px solid var(--line);border-radius:8px;background:#fff;cursor:pointer;text-align:center;font-weight:600}
+  .vtab.sel{border-color:var(--purple);background:var(--chip);color:var(--purple)}
+  .vtab .hint{display:block;font-size:.72rem;color:var(--muted);font-weight:400}
+  .btn{padding:12px 18px;border:none;border-radius:10px;font:inherit;font-weight:700;cursor:pointer}
+  .btn-rec{background:var(--red);color:#fff;width:100%}
+  .btn-rec.recording{background:#7f1d1d}
+  .btn-up{background:var(--purple);color:#fff;width:100%}
+  .btn:disabled{opacity:.4;cursor:not-allowed}
+  audio{width:100%;margin-top:10px}
+  .status{font-size:.85rem;margin-top:8px}
+  .ok{color:var(--green);font-weight:700}
+  .err{color:var(--red)}
+  .done-banner{background:#dcfce7;border:1px solid var(--green);border-radius:10px;padding:16px;text-align:center;color:var(--green);font-weight:700;font-size:1.05rem;display:none}
+  .progress-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
+  .prog-item{display:flex;align-items:center;gap:8px;font-size:.88rem}
+  .dot{width:14px;height:14px;border-radius:50%;background:#ddd;flex-shrink:0}
+  .dot.done{background:var(--green)}
+  .back{display:inline-block;margin-bottom:16px;color:var(--purple);text-decoration:none;font-size:.88rem;font-weight:600}
+  .back:hover{text-decoration:underline}
+  .err-banner{background:#fee2e2;border:1px solid var(--red);border-radius:10px;padding:16px;text-align:center;color:var(--red);font-weight:600}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <a class="back" href="javascript:history.back()">← 返回</a>
+  <h1>朗讀錄音貢獻</h1>
+  <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
+
+  <div id="errBanner" class="err-banner" style="display:none"></div>
+
+  <!-- 貢獻者資訊 -->
+  <div class="card">
+    <div class="step">① 你是誰</div>
+    <label>名字（暱稱即可）</label>
+    <input id="name" placeholder="例如：小明 / Amy">
+    <label>年級</label>
+    <select id="grade">
+      <option value="">請選擇</option>
+      <option>國小三年級</option><option>國小四年級</option><option>國小五年級</option><option>國小六年級</option>
+      <option>國中七年級</option><option>國中八年級</option><option>國中九年級</option>
+      <option>高中以上</option>
+    </select>
+  </div>
+
+  <!-- 課文全文 -->
+  <div class="card" id="lesson-card">
+    <div class="step">② 這一課：<span id="lesson-title-inline" style="font-weight:400;color:var(--muted)">載入中…</span></div>
+    <div class="passage" id="passage"><div class="loading-text">載入課文中…</div></div>
+  </div>
+
+  <!-- 錄音 -->
+  <div class="card" id="rec-card">
+    <div class="step">③ 照著念 + 錄音</div>
+    <div class="vtabs">
+      <div class="vtab sel" data-v="correct" onclick="selVersion('correct')">正確版<span class="hint">盡量念正確</span></div>
+      <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
+    </div>
+    <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
+    <audio id="player" controls style="display:none"></audio>
+    <button class="btn btn-up" id="upBtn" onclick="upload()" disabled style="margin-top:10px">上傳這段</button>
+    <div class="status" id="status"></div>
+  </div>
+
+  <!-- 進度 -->
+  <div class="card">
+    <div class="step">④ 我的進度（此課）</div>
+    <div class="progress-grid" id="progress"></div>
+    <div class="done-banner" id="doneBanner">
+      本課正確版 + 錯誤版都錄完了，太謝謝你了！
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── helpers ── */
+function apiBase(){
+  var h=location.origin;
+  if(h.indexOf('-frontend-')>-1) return h.replace('-frontend-','-backend-');
+  if(h.indexOf('localhost')>-1||h.indexOf('127.0.0.1')>-1) return 'http://localhost:8000';
+  return 'https://lingoleap-backend-staging-958347263320.asia-east1.run.app';
+}
+var API=apiBase();
+
+function qs(key){
+  return new URLSearchParams(location.search).get(key);
+}
+
+var lessonId=qs('lesson')||'';
+var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
+var cur={version:'correct'};
+var done=JSON.parse(localStorage.getItem('testset_done_v2_'+lessonId)||'{}');
+var mediaRec=null,chunks=[],blob=null;
+
+/* ── load story ── */
+async function loadStory(){
+  if(!lessonId){
+    document.getElementById('errBanner').textContent='缺少 ?lesson= 參數。請從 owner dashboard 複製連結開啟此頁。';
+    document.getElementById('errBanner').style.display='block';
+    document.getElementById('lesson-card').style.display='none';
+    document.getElementById('rec-card').style.display='none';
+    return;
+  }
+
+  // normalize: if "L06" strip L prefix for numeric lookup
+  var lookupId=lessonId;
+
+  try{
+    var r=await fetch(API+'/api/stories/'+encodeURIComponent(lookupId));
+    if(!r.ok) throw new Error('HTTP '+r.status);
+    var data=await r.json();
+
+    var title=data.title||lessonId;
+    document.title=title+' · 朗讀錄音貢獻 · LingoLeap';
+    document.getElementById('lesson-title-inline').textContent=title;
+
+    // Build full text from paragraphs
+    var passage=document.getElementById('passage');
+    passage.innerHTML='';
+    var paragraphs=[];
+
+    if(data.paragraphs&&data.paragraphs.length){
+      paragraphs=data.paragraphs;
+    } else if(data.text){
+      paragraphs=[{content:data.text}];
+    }
+
+    if(paragraphs.length===0){
+      passage.innerHTML='<span style="color:var(--muted)">（課文資料暫時無法載入）</span>';
+    } else {
+      // paragraphs is a list of strings from the API
+      paragraphs.forEach(function(p){
+        var txt=typeof p==='string'?p.trim():'';
+        if(!txt) return;
+        var el=document.createElement('p');
+        el.textContent=txt;
+        passage.appendChild(el);
+      });
+    }
+  }catch(e){
+    document.getElementById('errBanner').textContent='課文載入失敗（'+lessonId+'）: '+e.message+'。請確認 lesson ID 正確。';
+    document.getElementById('errBanner').style.display='block';
+    document.getElementById('passage').innerHTML='<span style="color:var(--red)">載入失敗，請重新整理。</span>';
+  }
+}
+
+/* ── recording ── */
+function selVersion(v){
+  cur.version=v;
+  document.querySelectorAll('.vtab').forEach(function(t){t.classList.toggle('sel',t.dataset.v===v)});
+  resetRec();
+}
+
+function resetRec(){
+  blob=null;
+  var p=document.getElementById('player'); p.style.display='none'; p.src='';
+  document.getElementById('upBtn').disabled=true;
+  document.getElementById('status').innerHTML='';
+  var b=document.getElementById('recBtn'); b.classList.remove('recording'); b.textContent='● 開始錄音';
+}
+
+async function toggleRec(){
+  var b=document.getElementById('recBtn');
+  if(mediaRec&&mediaRec.state==='recording'){ mediaRec.stop(); return; }
+  try{
+    var stream=await navigator.mediaDevices.getUserMedia({audio:true});
+    chunks=[]; mediaRec=new MediaRecorder(stream);
+    mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
+    mediaRec.onstop=function(){
+      blob=new Blob(chunks,{type:'audio/webm'});
+      var p=document.getElementById('player'); p.src=URL.createObjectURL(blob); p.style.display='block';
+      document.getElementById('upBtn').disabled=false;
+      stream.getTracks().forEach(function(t){t.stop()});
+      b.classList.remove('recording'); b.textContent='● 重新錄音';
+    };
+    mediaRec.start(); b.classList.add('recording'); b.textContent='■ 停止錄音';
+    document.getElementById('status').innerHTML='<span style="color:var(--muted)">錄音中…照著上面的課文念</span>';
+  }catch(e){
+    document.getElementById('status').innerHTML='<span class="err">無法存取麥克風，請允許瀏覽器麥克風權限後再試。</span>';
+  }
+}
+
+async function upload(){
+  var name=document.getElementById('name').value.trim();
+  var grade=document.getElementById('grade').value;
+  if(!name||!grade){
+    document.getElementById('status').innerHTML='<span class="err">請先填①的名字和年級</span>';
+    window.scrollTo(0,0); return;
+  }
+  if(!blob) return;
+  if(!lessonId){
+    document.getElementById('status').innerHTML='<span class="err">缺少 lesson ID，無法上傳</span>'; return;
+  }
+  document.getElementById('upBtn').disabled=true;
+  document.getElementById('status').innerHTML='<span style="color:var(--muted)">上傳中…</span>';
+  var fd=new FormData();
+  fd.append('contributor_name',name);
+  fd.append('grade',grade);
+  fd.append('lesson_id',lessonId);
+  fd.append('version',cur.version);
+  fd.append('audio',blob,lessonId+'_'+cur.version+'.webm');
+  try{
+    var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
+    if(!r.ok){ throw new Error('HTTP '+r.status); }
+    done[cur.version]=true;
+    localStorage.setItem('testset_done_v2_'+lessonId,JSON.stringify(done));
+    document.getElementById('status').innerHTML='<span class="ok">✓ 已上傳！可以繼續錄另一個版本。</span>';
+    renderProgress();
+  }catch(e){
+    document.getElementById('upBtn').disabled=false;
+    document.getElementById('status').innerHTML='<span class="err">上傳失敗，請再試一次（'+e.message+'）</span>';
+  }
+}
+
+function renderProgress(){
+  var el=document.getElementById('progress'); el.innerHTML='';
+  var allDone=true;
+  VERSIONS.forEach(function(V){
+    var ok=!!done[V.k];
+    if(!ok) allDone=false;
+    var div=document.createElement('div'); div.className='prog-item';
+    div.innerHTML='<span class="dot'+(ok?' done':'')+'"></span><span>'+(ok?'✓ ':'')+V.n+'</span>';
+    el.appendChild(div);
+  });
+  document.getElementById('doneBanner').style.display=allDone?'block':'none';
+}
+
+loadStory();
+renderProgress();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #2332

> 🤖 由 Claude AI 代發（非 Young 本人）

## Summary

- **新增 `testset/record.html`** — per-課貢獻者頁。讀 `?lesson=<id>`，從 `GET /api/stories/{id}` 抓完整 paragraphs 顯示全文（可捲動），錄正確版+錯誤版，上傳至 `POST /api/testset/upload`（無需登入）
- **改寫 `testset/list.html`** — owner dashboard 改為所有課文 table。課文清單從 `GET /api/stories?page_size=300` 動態載入（公開 API），每 row 顯示正確版/錯誤版 count、貢獻者數、AI 判斷佔位欄（deferred）、每課「複製連結」鈕複製 `{origin}/testset/record.html?lesson=<id>`。錄音明細需 teacher/admin 登入，展開 inline detail row
- **改寫 `testset/index.html`** — 砍掉舊 all-in-one（名字→選課→錄音擠一頁），改為動態課文清單，每課一個連結直接進 `record.html?lesson=<id>`

## Architecture

- GCS-only，零 DB/migration（alembic multi-head 鐵律）
- 全文來源：`GET /api/stories/{id}` → `paragraphs`（list of strings，公開 endpoint）
- 分享 URL pattern：`{origin}/testset/record.html?lesson=<id>`

## Test plan

- [ ] `list.html`：列出所有課文（動態，非寫死 8 課）
- [ ] `list.html`：每 row「複製連結」鈕可複製 per-課 URL
- [ ] `list.html`：未登入 → 顯示 auth banner，counts 顯示「—」
- [ ] `record.html?lesson=<id>`：顯示該課完整全文（多段落，可捲動）
- [ ] `record.html?lesson=<id>`：錄音 → 上傳 → 顯示 ✓
- [ ] `index.html`：顯示動態課文清單，點擊進 record.html 對應課文
- [ ] console 乾淨，無 JS error

## Notes

- AI 判斷欄顯示「待對應」badge — v2 先佔位，真正 pipeline deferred
- Security scan 偵測到 `Bearer` 字串 → 確認是讀 localStorage，非 hardcoded secret（同 v1 pattern）