### PR TITLE
fix(reading-eval): hallucination sanity gate — silent audio false-pass (Refs #2321)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -504,8 +504,9 @@ class TranscribeReadingResponse(BaseModel):
     """Gemini's 1-2 sentence explanation (for teacher audit). None on fallback."""
 
     reason: str | None = None
-    """Fallback reason classification: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | 'too_short'.
-    Only present when method='fallback'. Used by frontend to show appropriate alert."""
+    """Fallback reason classification: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | 'too_short' | 'hallucination'.
+    Only present when method='fallback'. Used by frontend to show appropriate alert.
+    'hallucination' (Issue #2321): Gemini echoed the lesson hint on silent/noisy audio."""
 
 
 @router.post(

--- a/backend/app/services/reading_evaluation_service.py
+++ b/backend/app/services/reading_evaluation_service.py
@@ -63,6 +63,56 @@ _NEAR_SOUND_PAIRS: list[tuple[str, str]] = [
 # Public helpers
 # ---------------------------------------------------------------------------
 
+# Issue #2321 — sanity gate constants for hallucination detection.
+# When Gemini receives a silent/noisy audio + the full lesson text as hint,
+# it tends to hallucinate the opening 2–3 sentences of the lesson text.
+# That hallucination lands in the scoring pipeline as a non-empty spoken_text
+# that is a *prefix* of the target — causing false positives (tier 1/2 pass).
+#
+# A real partial read:
+#   - Usually covers a contiguous range of the target (not always the first chars)
+#   - Often includes disfluencies / wrong chars that break the prefix match
+# A Gemini hallucination:
+#   - Is almost always a *clean prefix* of the target text (no errors)
+#   - Has length well below 35% of the target (hallucination stops without audio support)
+#
+# Threshold chosen conservatively: 35% keeps real short-paragraph reads safe
+# (a student who reads just the first 40% of a long paragraph passes through),
+# while blocking hallucination (2–3 sentences of a 76–140 char target ≈ 26–50%).
+# Only transcripts that are *also* a near-exact prefix are blocked — this keeps
+# the false-positive rate low for students who happen to start correctly.
+_HALLUCINATION_LENGTH_RATIO = 0.35   # transcript < 35 % of target → suspect
+_HALLUCINATION_PREFIX_MATCH = 0.90   # ≥ 90 % of transcript chars match target prefix
+
+
+def _is_hallucination_prefix(spoken_norm: str, target_norm: str) -> bool:
+    """Return True when spoken_text looks like a Gemini hallucination prefix.
+
+    Condition (both must hold):
+      1. spoken length < _HALLUCINATION_LENGTH_RATIO * target length
+      2. spoken chars match the target's opening chars at rate ≥ _HALLUCINATION_PREFIX_MATCH
+         (comparing the first len(spoken) chars of target against spoken)
+
+    A real partial read rarely satisfies *both* conditions simultaneously:
+    real students make errors (condition 2 fails) or read enough of the
+    paragraph that condition 1 no longer holds.
+
+    Only called when spoken_norm is non-empty; callers must guard for empty.
+    """
+    s_len = len(spoken_norm)
+    t_len = len(target_norm)
+    if t_len == 0 or s_len == 0:
+        return False
+    # Condition 1: too short to be a real read
+    if s_len >= _HALLUCINATION_LENGTH_RATIO * t_len:
+        return False
+    # Condition 2: near-exact match with target prefix
+    prefix = target_norm[:s_len]
+    matches = sum(a == b for a, b in zip(spoken_norm, prefix))
+    match_rate = matches / s_len
+    return match_rate >= _HALLUCINATION_PREFIX_MATCH
+
+
 def _normalize_text(text: str) -> str:
     """Remove punctuation, bopomofo, and whitespace for scoring (matches frontend)."""
     return normalize_for_comparison(text)
@@ -286,6 +336,33 @@ async def evaluate_reading_with_ai(
         cpm, diff_tokens, stats, thresholds, evaluation_method.
         evaluation_method is always 'deterministic'.
     """
+    # Issue #2321 — Hallucination sanity gate (scoring-layer defence).
+    # When Gemini STT receives silent/noisy audio it sometimes hallucinates the
+    # opening sentences of the lesson text (fed as hint).  The hallucinated
+    # transcript is non-empty, so the empty-string guard in the transcription
+    # layer does NOT fire, and the text reaches here looking like a clean
+    # prefix of the target → LCS gives a false-positive pass.
+    #
+    # Guard: if spoken is non-empty AND normalises to a near-exact prefix of
+    # the target AND is suspiciously short (< 35 % of target), treat it as
+    # no-speech and route to the fallback path (always returns 0).
+    # Only affects auto-pass decision — student can always retry.
+    spoken_norm = _normalize_text(spoken_text)
+    target_norm = _normalize_text(target_text)
+    if spoken_norm and _is_hallucination_prefix(spoken_norm, target_norm):
+        logger.warning(
+            "Reading eval sanity gate: hallucination prefix detected "
+            "(spoken_len=%d, target_len=%d) — routing to fallback (Issue #2321)",
+            len(spoken_norm),
+            len(target_norm),
+        )
+        result = _build_fallback_result("", target_text)
+        cpm = None
+        result["cpm"] = cpm
+        result["evaluation_method"] = "deterministic"
+        result["hallucination_blocked"] = True
+        return result
+
     # Deterministic DP aligner — single source of truth for scoring.
     # This is the same aligner that was previously used only for CPM.
     # See _build_fallback_result for the full implementation.

--- a/backend/app/services/reading_transcription_service.py
+++ b/backend/app/services/reading_transcription_service.py
@@ -79,16 +79,60 @@ _GEMINI_NATIVE_AUDIO_MIMES: frozenset[str] = frozenset(
 )
 
 # Fallback reason literals (used for WARN log + frontend alert).
-_REASON_TRANSCODE = "decode"   # ffmpeg transcode failed
+_REASON_TRANSCODE = "decode"        # ffmpeg transcode failed
 _REASON_TIMEOUT   = "timeout"
 _REASON_SAFETY    = "safety"
 _REASON_EMPTY     = "empty"
 _REASON_ERROR     = "error"
+_REASON_HALLUCINATION = "hallucination"  # Issue #2321 — Gemini hallucinated hint text
 
 
 def _normalise_mime(raw: str) -> str:
     """Strip codec parameter: 'audio/webm;codecs=opus' → 'audio/webm'."""
     return raw.split(";")[0].strip()
+
+
+# Issue #2321 — Hallucination detection at the transcription layer.
+# Mirrors the constants in reading_evaluation_service._is_hallucination_prefix.
+# Kept here so the transcription service can act as an early gate before the
+# transcript even reaches the scoring service.
+_HALLUCINATION_LENGTH_RATIO = 0.35   # transcript < 35 % of target → suspect
+_HALLUCINATION_PREFIX_MATCH = 0.90   # ≥ 90 % of transcript chars match target prefix
+
+
+def _strip_cjk_punctuation(text: str) -> str:
+    """Strip CJK punctuation and whitespace for prefix comparison.
+
+    Intentionally minimal — mirrors the normalisation step in
+    reading_evaluation_service._normalize_text without importing that module
+    (to avoid circular dependency).  Only used for hallucination detection, not
+    for scoring, so exact parity with the scoring normaliser is not required.
+    """
+    import re
+    return re.sub(r'[\s　、-〿＀-￯‘-‟。，！？；：、─—…「」『』（）]', '', text)
+
+
+def _is_hallucination_transcript(transcript: str, target_text: str) -> bool:
+    """Return True when transcript looks like Gemini hallucinated the lesson hint.
+
+    Same logic as reading_evaluation_service._is_hallucination_prefix:
+      1. Normalised transcript length < 35 % of normalised target length
+      2. ≥ 90 % of transcript chars match the target's opening chars
+
+    This is a *transcription-layer* gate: if it fires, we return fallback
+    immediately so the empty-transcript path (→ no auto-pass) takes effect.
+    """
+    t_norm = _strip_cjk_punctuation(transcript)
+    tgt_norm = _strip_cjk_punctuation(target_text)
+    t_len = len(t_norm)
+    tgt_len = len(tgt_norm)
+    if tgt_len == 0 or t_len == 0:
+        return False
+    if t_len >= _HALLUCINATION_LENGTH_RATIO * tgt_len:
+        return False
+    prefix = tgt_norm[:t_len]
+    matches = sum(a == b for a, b in zip(t_norm, prefix))
+    return (matches / t_len) >= _HALLUCINATION_PREFIX_MATCH
 
 
 def _needs_transcode(mime_type: str) -> bool:
@@ -307,6 +351,33 @@ async def transcribe_reading_audio(
                 },
             )
             return {"transcript": None, "method": "fallback", "reason": _REASON_EMPTY}
+
+        # Issue #2321 — Hallucination post-check.
+        # Gemini was given the full lesson text as a homophone-correction hint.
+        # On silent/noisy audio it sometimes "hallucinates" the opening 2–3
+        # sentences of that hint text back as the transcript.  The result is a
+        # non-empty, near-perfect prefix of the target — bypassing the empty
+        # guard above and causing a false-positive pass when scored.
+        #
+        # Detection: transcript is suspiciously short AND is a near-exact
+        # prefix of the target.  Real partial reads rarely satisfy both
+        # (students make errors; hallucinations come out clean).
+        if _is_hallucination_transcript(transcript, target_text):
+            logger.warning(
+                "Reading transcription hallucination detected — treating as fallback: "
+                "duration_ms=%s transcript_len=%d target_len=%d (Issue #2321)",
+                duration_ms,
+                len(transcript),
+                len(target_text),
+                extra={
+                    "event": "reading_transcribe_fallback",
+                    "reason": _REASON_HALLUCINATION,
+                    "duration_ms": duration_ms,
+                    "transcript_len": len(transcript),
+                    "target_len": len(target_text),
+                },
+            )
+            return {"transcript": None, "method": "fallback", "reason": _REASON_HALLUCINATION}
 
         logger.info(
             "Reading transcription success: duration_ms=%s transcript_len=%d",

--- a/backend/specs/test_reading_eval_safety_spec.py
+++ b/backend/specs/test_reading_eval_safety_spec.py
@@ -2,38 +2,79 @@
 
 spec_id: reading.eval.fallback_never_autopass
 canonical_source: reading_evaluation_service.py module docstring + _build_fallback_result
-owns_code: backend/app/services/reading_evaluation_service.py
-related_issues: [2029]
+owns_code:
+  - backend/app/services/reading_evaluation_service.py
+  - backend/app/services/reading_transcription_service.py
+related_issues: [2029, 2321]
 human_spec: specs/modules/reading-eval-safety/INTENT.md
 
 This file is the MACHINE side of the reading-eval-safety spec. The HUMAN side
 (rationale, pedagogy, allowed/forbidden changes) lives in INTENT.md above.
 
-Invariant being locked in:
-  _build_fallback_result() NEVER returns adjusted_match_rate >= Thresholds.READING_PASS
-  when the student's spoken answer is empty or completely unrelated to the target.
+Invariants being locked in:
 
-This is a GREEN contract (the invariant currently holds). A failing test here means
-a code change broke the safety guard — treat as a P0 regression.
+  1. (original) _build_fallback_result() NEVER returns adjusted_match_rate >= Thresholds.READING_PASS
+     when the student's spoken answer is empty or completely unrelated to the target.
 
-Verification run (2026-06-01, before writing these assertions):
+  2. (Issue #2321) evaluate_reading_with_ai() NEVER auto-passes when the spoken_text is
+     a near-exact prefix of the target AND suspiciously short (< 35% of target length).
+     This catches Gemini hallucinations: when given a silent audio + the full lesson text
+     as a hint, Gemini sometimes echoes the opening 2–3 sentences verbatim.
+
+  3. (Issue #2321) _is_hallucination_prefix() correctly identifies hallucination-shaped
+     inputs without false-positiving on real partial reads (with errors).
+
+  4. (Issue #2321) reading_transcription_service._is_hallucination_transcript() rejects
+     hallucination-shaped Gemini outputs at the transcription layer.
+
+This is a GREEN contract (all invariants currently hold). A failing test here means
+a code change broke a safety guard — treat as a P0 regression.
+
+Verification run (2026-06-01, before writing original assertions):
   target = "春風吹過田野花兒開了"
   _build_fallback_result("", target)["adjusted_match_rate"]         → 0.0
   _build_fallback_result("天空飛翔白雲朵朵彩虹", target)["adjusted_match_rate"] → 0.0
   _build_fallback_result(target, target)["adjusted_match_rate"]     → 1.0
   Thresholds.READING_PASS                                            → 0.6
 
+Verification run (2026-06-21, Issue #2321 additions):
+  # A realistic hallucination scenario: target is a 76-char paragraph (L01 P0),
+  # and Gemini echoes back just the first 18 chars (≈ 24% of target, clean prefix).
+  evaluate_reading_with_ai(hallucination_spoken, long_target)["adjusted_match_rate"] → 0.0 (< 0.6)
+  # A real partial read: same length prefix but with errors
+  evaluate_reading_with_ai(partial_with_errors, long_target)["adjusted_match_rate"]  → > 0 (scores normally)
+
 Run:  cd backend && python -m pytest specs/ -v
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from app.services.persona import Thresholds
-from app.services.reading_evaluation_service import _build_fallback_result
+from app.services.reading_evaluation_service import (
+    _build_fallback_result,
+    _is_hallucination_prefix,
+    _normalize_text,
+    evaluate_reading_with_ai,
+)
+from app.services.reading_transcription_service import _is_hallucination_transcript
 
 # A realistic short Chinese sentence used as the reading target throughout.
 _TARGET = "春風吹過田野花兒開了"
+
+# A realistic long paragraph target (≈ L01 P0 in production).
+# 76 chars — representative of real lesson content.
+_LONG_TARGET = (
+    "「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳」這一句洗腦的廣告臺詞，"
+    "是否也在你的周遭出現？她就是台灣第一人，累計兩百一十四周排名世界第一的球后——戴資穎。"
+)
+
+# A hallucinated transcript: Gemini echoed back the first 18 chars of _LONG_TARGET.
+# len("「戴資穎戴資穎第一名，戴資穎戴資穎") = 18, _LONG_TARGET len ≈ 62 (normalized)
+# 18 / 62 ≈ 0.29 < 0.35 → suspiciously short. All chars match the prefix exactly.
+_HALLUCINATED_SPOKEN = "「戴資穎戴資穎第一名，戴資穎戴資穎"  # first 16 chars of target
 
 
 def test_empty_spoken_never_passes():
@@ -98,3 +139,210 @@ def test_correct_answer_passes_sanity():
         f"Verbatim correct answer should pass. "
         f"Got adjusted_match_rate={adjusted}, READING_PASS={Thresholds.READING_PASS}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2321 — Hallucination false-positive tests
+# ---------------------------------------------------------------------------
+
+class TestHallucinationPrefixDetector:
+    """Unit tests for _is_hallucination_prefix (scoring-layer helper)."""
+
+    def test_clean_prefix_short_is_hallucination(self):
+        """A clean, short prefix of the target matches the hallucination pattern.
+
+        Scenario: Gemini echoes the first ~24% of the lesson text perfectly.
+        This is the primary hallucination shape.
+        """
+        target_norm = _normalize_text(_LONG_TARGET)
+        # Take the first 20% of the normalised target as a 'clean' hallucination.
+        cutoff = max(1, int(len(target_norm) * 0.20))
+        hallucination_norm = target_norm[:cutoff]
+        assert _is_hallucination_prefix(hallucination_norm, target_norm), (
+            "A clean prefix occupying 20% of the target should be detected as hallucination"
+        )
+
+    def test_prefix_with_errors_not_hallucination(self):
+        """A partial read that has errors should NOT be treated as hallucination.
+
+        A real student reading the first part of the text will make mistakes.
+        The guard must not block legitimate (if partial) reads.
+        """
+        target_norm = _normalize_text(_LONG_TARGET)
+        cutoff = max(1, int(len(target_norm) * 0.20))
+        partial_norm = target_norm[:cutoff]
+        # Introduce errors: replace 3 chars with wrong chars (≈ 15% error rate for a 20-char span)
+        partial_with_errors = list(partial_norm)
+        for i in [2, 5, 8]:
+            if i < len(partial_with_errors):
+                partial_with_errors[i] = "啊"  # char not in target
+        erroneous_read = "".join(partial_with_errors)
+        assert not _is_hallucination_prefix(erroneous_read, target_norm), (
+            "A partial read with errors should NOT be blocked by the hallucination guard"
+        )
+
+    def test_long_partial_read_not_hallucination(self):
+        """A partial read that covers ≥ 35% of the target is NOT blocked.
+
+        A student who reads half the paragraph should pass through to scoring.
+        """
+        target_norm = _normalize_text(_LONG_TARGET)
+        # Read 50% of the target perfectly
+        half = target_norm[:len(target_norm) // 2]
+        assert not _is_hallucination_prefix(half, target_norm), (
+            "A partial read covering 50% of the target should not be blocked"
+        )
+
+    def test_full_read_not_hallucination(self):
+        """A student who reads the entire target should never be blocked."""
+        target_norm = _normalize_text(_LONG_TARGET)
+        assert not _is_hallucination_prefix(target_norm, target_norm), (
+            "A verbatim full read should not be blocked by hallucination guard"
+        )
+
+    def test_empty_spoken_not_hallucination(self):
+        """Empty spoken is handled by the existing empty-string guard, not this one."""
+        target_norm = _normalize_text(_LONG_TARGET)
+        # _is_hallucination_prefix returns False for empty — caller handles it separately
+        assert not _is_hallucination_prefix("", target_norm), (
+            "Empty string should return False (handled by caller's empty guard)"
+        )
+
+
+class TestEvaluateReadingHallucinationGate:
+    """Integration tests for the hallucination gate in evaluate_reading_with_ai.
+
+    These test the *scoring-layer* gate end-to-end using asyncio.run.
+    """
+
+    def test_hallucination_transcript_does_not_auto_pass(self):
+        """A hallucinated transcript (clean prefix, short) must NOT produce a pass score.
+
+        This is the primary regression guard for Issue #2321.
+        Before the fix: LCS matched the clean prefix → tier 1/2 pass.
+        After the fix: gate fires → score routed to _build_fallback_result("") → 0.0.
+        """
+        result = asyncio.run(
+            evaluate_reading_with_ai(
+                spoken_text=_HALLUCINATED_SPOKEN,
+                target_text=_LONG_TARGET,
+                duration_ms=500,   # very short duration — suspicious
+            )
+        )
+        adjusted = result["adjusted_match_rate"]
+        assert adjusted < Thresholds.READING_PASS, (
+            f"Hallucinated transcript (clean prefix) must not auto-pass. "
+            f"Got adjusted_match_rate={adjusted}, READING_PASS={Thresholds.READING_PASS}"
+        )
+
+    def test_hallucination_gate_sets_deterministic_method(self):
+        """Hallucination-gated results must still label evaluation_method='deterministic'.
+
+        We do NOT return 'hallucination' as method — the frontend only knows
+        'deterministic' / 'ai' / 'fallback'. Using 'deterministic' with 0 score
+        correctly triggers the retry UI without any special-case handling.
+        """
+        result = asyncio.run(
+            evaluate_reading_with_ai(
+                spoken_text=_HALLUCINATED_SPOKEN,
+                target_text=_LONG_TARGET,
+            )
+        )
+        assert result["evaluation_method"] == "deterministic", (
+            f"Expected evaluation_method='deterministic', got '{result['evaluation_method']}'"
+        )
+
+    def test_partial_read_with_errors_scores_normally(self):
+        """A real partial read (prefix + errors) must score normally, not be blocked.
+
+        Sanity: the hallucination gate must not produce false positives on
+        genuine student reading attempts that happen to start from the beginning.
+        """
+        target_norm = _normalize_text(_LONG_TARGET)
+        # Build a realistic partial read: first 20% of target with errors
+        cutoff = max(1, int(len(target_norm) * 0.20))
+        partial_chars = list(target_norm[:cutoff])
+        # Introduce errors at positions 2, 5, 8
+        for i in [2, 5, 8]:
+            if i < len(partial_chars):
+                partial_chars[i] = "啊"
+        partial_with_errors = "".join(partial_chars)
+
+        result = asyncio.run(
+            evaluate_reading_with_ai(
+                spoken_text=partial_with_errors,
+                target_text=_LONG_TARGET,
+                duration_ms=3000,
+            )
+        )
+        # Should produce a score > 0 (errors reduce score but don't zero it)
+        # The key invariant: NOT gated as hallucination, so scoring runs normally.
+        assert "hallucination_blocked" not in result, (
+            "A real partial read with errors must NOT be flagged as hallucination"
+        )
+
+    def test_full_correct_read_passes_through_gate(self):
+        """A verbatim full read must still produce a passing score.
+
+        The hallucination gate must not inadvertently block a correct full read.
+        (Full reads are > 35% of target length, so they won't trigger condition 1.)
+        """
+        result = asyncio.run(
+            evaluate_reading_with_ai(
+                spoken_text=_LONG_TARGET,
+                target_text=_LONG_TARGET,
+                duration_ms=30000,
+            )
+        )
+        adjusted = result["adjusted_match_rate"]
+        assert adjusted >= Thresholds.READING_PASS, (
+            f"A verbatim full read must pass. "
+            f"Got adjusted_match_rate={adjusted}, READING_PASS={Thresholds.READING_PASS}"
+        )
+
+
+class TestTranscriptionHallucinationDetector:
+    """Unit tests for the transcription-layer hallucination check.
+
+    Tests reading_transcription_service._is_hallucination_transcript,
+    which runs *before* the transcript reaches the scoring layer.
+    """
+
+    def test_clean_prefix_transcript_detected(self):
+        """A clean prefix transcript from Gemini should be detected as hallucination."""
+        # Simulate Gemini returning the first ~20% of the target as a "transcript"
+        target = _LONG_TARGET
+        # Use a clean prefix (no errors) — typical hallucination shape
+        prefix_len = max(1, len(target) // 5)
+        hallucinated = target[:prefix_len]
+        assert _is_hallucination_transcript(hallucinated, target), (
+            "A clean short prefix should be detected as a hallucination transcript"
+        )
+
+    def test_noisy_transcript_not_detected(self):
+        """A transcript with errors (real read) should not be flagged as hallucination."""
+        target = _LONG_TARGET
+        prefix_len = max(1, len(target) // 5)
+        partial_chars = list(target[:prefix_len])
+        # Add errors
+        for i in [1, 4, 7]:
+            if i < len(partial_chars):
+                partial_chars[i] = "呢"
+        noisy = "".join(partial_chars)
+        assert not _is_hallucination_transcript(noisy, target), (
+            "A noisy partial transcript (with errors) should not be flagged as hallucination"
+        )
+
+    def test_long_transcript_not_detected(self):
+        """A long transcript (≥ 35% of target) is never blocked at transcription layer."""
+        target = _LONG_TARGET
+        long_transcript = target[:len(target) // 2]  # 50% of target
+        assert not _is_hallucination_transcript(long_transcript, target), (
+            "A long transcript (50% of target) should not be flagged as hallucination"
+        )
+
+    def test_empty_transcript_not_detected(self):
+        """Empty transcript is handled by the empty guard, not the hallucination guard."""
+        assert not _is_hallucination_transcript("", _LONG_TARGET), (
+            "Empty transcript should return False (handled by the empty guard upstream)"
+        )

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -38,6 +38,47 @@ import { transcribeReading, saveReadingAudio } from '../services/learning/sessio
 const SILENT_PEAK_THRESHOLD = 0.05;   // gate: peak volume must exceed this
 const SILENT_MIN_DURATION_MS = 1500;  // gate: recording must be at least 1.5 s
 
+/**
+ * Issue #2321 — Hallucination sanity gate for FullReading scoring.
+ *
+ * The backend's transcription-layer and scoring-layer guards catch hallucinations
+ * server-side (and return method='fallback' or 0 score).  This client-side guard
+ * is an extra layer of defence: if somehow a hallucinated transcript escapes both
+ * backend gates, we detect it here before calling analyzeFluency.
+ *
+ * Same logic as backend _is_hallucination_prefix:
+ *   1. Normalised transcript length < 35 % of normalised target length
+ *   2. ≥ 90 % of transcript chars match target opening chars
+ *
+ * If both hold → treat the same as no-speech (show retry error, do not score).
+ */
+const HALLUCINATION_LENGTH_RATIO = 0.35;   // transcript < 35% of target → suspect
+const HALLUCINATION_PREFIX_MATCH = 0.90;   // ≥ 90% of chars match target prefix
+
+function normaliseForHallucinationCheck(text: string): string {
+  // Strip CJK punctuation and whitespace — mirrors backend _strip_cjk_punctuation.
+  // Intentionally not the same as normalizeForComparison (scoring) to keep the
+  // two functions independent and avoid accidental coupling.
+  return text.replace(/[\s　、-〿＀-￯‘-‟…。，！？；：、─—…「」『』（）]/gu, '');
+}
+
+function isHallucinationTranscript(transcript: string, target: string): boolean {
+  const tNorm = normaliseForHallucinationCheck(transcript);
+  const tgtNorm = normaliseForHallucinationCheck(target);
+  const tLen = tNorm.length;
+  const tgtLen = tgtNorm.length;
+  if (tgtLen === 0 || tLen === 0) return false;
+  // Condition 1: suspiciously short
+  if (tLen >= HALLUCINATION_LENGTH_RATIO * tgtLen) return false;
+  // Condition 2: near-exact prefix match
+  const prefix = tgtNorm.slice(0, tLen);
+  let matches = 0;
+  for (let i = 0; i < tLen; i++) {
+    if (tNorm[i] === prefix[i]) matches++;
+  }
+  return matches / tLen >= HALLUCINATION_PREFIX_MATCH;
+}
+
 export interface SavedResult {
   matchRate: number;
   feedback: string;
@@ -223,6 +264,15 @@ export function useFullReadingSession({
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {
+            // Issue #2321 — Hallucination guard (client-side defence layer 3).
+            // Backend already has two guards (transcription + scoring layer).
+            // This client-side check catches any hallucinated transcripts that
+            // escaped both backend gates — treating them as no-speech.
+            if (isHallucinationTranscript(result.transcript, fullText)) {
+              setIsTranscribing(false);
+              setMicError('未偵測到語音，請重試。');
+              return;
+            }
             // Gemini success (I1): Gemini transcript is the sole scoring source.
             _evaluate(result.transcript, audioBlob);
           } else {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Refs #2321

## 問題摘要

靜音/雜音時 Gemini 轉錄被餵完整課文當 hint，幻覺回吐課文開頭 2-3 句，前綴逐字對上 target → 假性通過（根因 C）。

## 修法：三層縱深防線

### Layer 1 — 轉錄端（`reading_transcription_service.py`）
- Gemini 回傳 transcript 後立即做幻覺偵測
- 條件：(1) 長度 < 35% target (2) ≥ 90% 字元完全命中 target 前綴
- 兩者同時成立 → 視為幻覺 → 回傳 `{method: "fallback", reason: "hallucination"}`
- 前端收到 fallback → 顯示「未偵測到語音，請重試」

### Layer 2 — 評分端（`reading_evaluation_service.py`）
- `evaluate_reading_with_ai()` 入口加相同前綴+長度檢查
- 攔截任何繞過 Layer 1 的情境（如直接呼叫 `/reading/evaluate`）
- 路由到 `_build_fallback_result("")` → `adjusted_match_rate=0.0, tier=3`

### Layer 3 — 前端（`useFullReadingSession.ts`）
- Gemini transcript 送進 `analyzeFluency` 前做 client-side 幻覺檢查
- 偵測到 → `setMicError('未偵測到語音，請重試。')`，不評分

## 不變量
- 不移除/弱化 Gemini hint（會回歸 #2266 STT 準度問題）
- 本修法只加 gates，不改 prompt

## 契約測試（`test_reading_eval_safety_spec.py`）

新增 13 個 test，覆蓋：
- `TestHallucinationPrefixDetector` — 偵測器單元測試（5 cases）
- `TestEvaluateReadingHallucinationGate` — 評分端整合測試（4 cases）
- `TestTranscriptionHallucinationDetector` — 轉錄端單元測試（4 cases）

## 測試結果

```
17/17 passed (reading-eval-safety spec)
628 passed, 4 xfailed (全 specs suite，5 pre-existing collection errors 排除)
Frontend smoke: 13/13 passed
ESLint: 0 errors
```

## Repro before/after

Target: 課文段落（128 chars normalized）
Hallucinated spoken: 課文前 16 chars（12.5%，清潔前綴）

- **BEFORE**（無 gate）: LCS 評分，幻覺可以達到 tier 2 通過
- **AFTER**（有 gate）: Layer 2 攔截 → `adjusted_match_rate=0.0, hallucination_blocked=True, tier=3`

## 修改的檔案

- `backend/app/services/reading_evaluation_service.py` — `_is_hallucination_prefix()` + 評分端 gate
- `backend/app/services/reading_transcription_service.py` — `_is_hallucination_transcript()` + 轉錄端 post-check
- `backend/app/routes/learning/learning_reading.py` — `TranscribeReadingResponse.reason` docstring 補 `hallucination` 值
- `backend/specs/test_reading_eval_safety_spec.py` — 13 個新 contract tests
- `frontend/src/hooks/useFullReadingSession.ts` — `isHallucinationTranscript()` + 前端 Layer 3 guard