### PR TITLE
feat(testset): record 頁拿掉年級/返回 + 進度改 server-truth (#2335)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -59,7 +59,7 @@ def _slug(name: str) -> str:
 @router.post("/testset/upload")
 async def testset_upload(
     contributor_name: str = Form(...),
-    grade: str = Form(...),
+    grade: str = Form(""),  # 選填（Young 2026-06-21：錄音頁拿掉年級欄）
     lesson_id: str = Form(...),
     version: str = Form(...),
     audio: UploadFile = File(...),
@@ -71,8 +71,8 @@ async def testset_upload(
     # ── validate ──────────────────────────────────────────────────────────────
     if version not in _ALLOWED_VERSION:
         raise HTTPException(400, "version must be 'correct' or 'error'")
-    if not contributor_name.strip() or not grade.strip() or not lesson_id.strip():
-        raise HTTPException(400, "contributor_name, grade, lesson_id are required")
+    if not contributor_name.strip() or not lesson_id.strip():
+        raise HTTPException(400, "contributor_name, lesson_id are required")
     # HIGH: lesson_id 進 blob path → 白名單格式擋路徑注入 / 跨 prefix 寫入
     if not _LESSON_ID_RE.match(lesson_id.strip()):
         raise HTTPException(400, "invalid lesson_id")
@@ -119,6 +119,38 @@ async def testset_upload(
 
     logger.info("testset upload OK: %s (%d bytes)", audio_path, len(audio_bytes))
     return {"ok": True, "path": audio_path}
+
+
+@router.get("/testset/progress")
+def testset_progress(name: str = "", lesson: str = ""):
+    """錄音頁進度查詢（公開，server-truth）：某貢獻者某課是否已上傳 correct/error。
+
+    只回布林（不回名字/年級/play URL 等 PII），讓匿名 record.html 換裝置/清快取後
+    仍能讀回真實進度（取代純 localStorage 的 device-local 標記）。
+    """
+    empty = {"ok": False, "correct": False, "error": False}
+    if not name.strip() or not _LESSON_ID_RE.match(lesson.strip()):
+        return empty
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        return empty
+
+    slug = _slug(name)
+    lid = lesson.strip()
+    done = {"correct": False, "error": False}
+    try:
+        for blob in bucket.list_blobs(prefix=f"{_PREFIX}/{slug}/{lid}/", max_results=50):
+            fname = blob.name.rsplit("/", 1)[-1]
+            if not fname.endswith(".webm"):
+                continue
+            if fname.startswith("correct"):
+                done["correct"] = True
+            elif fname.startswith("error"):
+                done["error"] = True
+    except Exception as exc:
+        logger.warning("testset progress failed: %s", exc)
+        return empty
+    return {"ok": True, **done}
 
 
 @router.get("/testset/recordings")

--- a/frontend/public/testset/record.html
+++ b/frontend/public/testset/record.html
@@ -57,7 +57,6 @@
 </head>
 <body>
 <div class="wrap">
-  <a class="back" href="javascript:history.back()">← 返回</a>
   <h1>朗讀錄音貢獻</h1>
   <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
 
@@ -79,13 +78,6 @@
         <div class="step">① 你是誰</div>
         <label>名字（暱稱即可）</label>
         <input id="name" placeholder="例如：小明 / Amy">
-        <label>年級</label>
-        <select id="grade">
-          <option value="">請選擇</option>
-          <option>國小三年級</option><option>國小四年級</option><option>國小五年級</option><option>國小六年級</option>
-          <option>國中七年級</option><option>國中八年級</option><option>國中九年級</option>
-          <option>高中以上</option>
-        </select>
       </div>
 
       <!-- 錄音 -->
@@ -130,8 +122,26 @@ function qs(key){
 var lessonId=qs('lesson')||'';
 var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
+var NAME_KEY='testset_name';
 var done=JSON.parse(localStorage.getItem('testset_done_v2_'+lessonId)||'{}');
 var mediaRec=null,chunks=[],blob=null;
+
+/* ── 進度：server-truth（換裝置/清快取仍讀得回，localStorage 只當快取） ── */
+async function loadProgress(){
+  var name=document.getElementById('name').value.trim();
+  if(!name||!lessonId){ renderProgress(); return; }
+  try{
+    var r=await fetch(API+'/api/testset/progress?name='+encodeURIComponent(name)+'&lesson='+encodeURIComponent(lessonId));
+    if(r.ok){
+      var d=await r.json();
+      if(d&&d.ok){
+        done={correct:!!d.correct,error:!!d.error};
+        localStorage.setItem('testset_done_v2_'+lessonId,JSON.stringify(done));
+      }
+    }
+  }catch(e){ /* 離線/失敗 → 沿用 localStorage 快取 */ }
+  renderProgress();
+}
 
 /* ── load story ── */
 async function loadStory(){
@@ -223,30 +233,30 @@ async function toggleRec(){
 
 async function upload(){
   var name=document.getElementById('name').value.trim();
-  var grade=document.getElementById('grade').value;
-  if(!name||!grade){
-    document.getElementById('status').innerHTML='<span class="err">請先填①的名字和年級</span>';
+  if(!name){
+    document.getElementById('status').innerHTML='<span class="err">請先填①的名字</span>';
     window.scrollTo(0,0); return;
   }
   if(!blob) return;
   if(!lessonId){
     document.getElementById('status').innerHTML='<span class="err">缺少 lesson ID，無法上傳</span>'; return;
   }
+  localStorage.setItem(NAME_KEY,name);
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='<span style="color:var(--muted)">上傳中…</span>';
   var fd=new FormData();
   fd.append('contributor_name',name);
-  fd.append('grade',grade);
   fd.append('lesson_id',lessonId);
   fd.append('version',cur.version);
   fd.append('audio',blob,lessonId+'_'+cur.version+'.webm');
   try{
     var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
     if(!r.ok){ throw new Error('HTTP '+r.status); }
-    done[cur.version]=true;
+    done[cur.version]=true;  // 樂觀更新（即時回饋）
     localStorage.setItem('testset_done_v2_'+lessonId,JSON.stringify(done));
     document.getElementById('status').innerHTML='<span class="ok">✓ 已上傳！可以繼續錄另一個版本。</span>';
     renderProgress();
+    loadProgress();  // 再從 server 對齊真實進度
   }catch(e){
     document.getElementById('upBtn').disabled=false;
     document.getElementById('status').innerHTML='<span class="err">上傳失敗，請再試一次（'+e.message+'）</span>';
@@ -266,8 +276,19 @@ function renderProgress(){
   document.getElementById('doneBanner').style.display=allDone?'block':'none';
 }
 
+// 自動帶回上次名字 → 從 server 讀真實進度（下次進來/換裝置都看得到）
+(function initName(){
+  var saved=localStorage.getItem(NAME_KEY);
+  if(saved) document.getElementById('name').value=saved;
+})();
+document.getElementById('name').addEventListener('change',function(){
+  var n=document.getElementById('name').value.trim();
+  if(n) localStorage.setItem(NAME_KEY,n);
+  loadProgress();
+});
+
 loadStory();
-renderProgress();
+loadProgress();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## What（Young 2026-06-21 回饋）
1. record.html 拿掉「← 返回」連結
2. ① 你是誰拿掉「年級」欄（backend grade 改選填）
3. **進度改 server-truth** — 原本「正確版/錯誤版」進度只存 localStorage（device-local，換裝置/清快取/換名字就消失）。新增公開 `GET /testset/progress?name=&lesson=`（只回布林，無 PII），record.html 自動帶回上次名字 + 從 server 讀真實進度 → **下次進來/換裝置都看得到**；localStorage 降為快取/離線 fallback

## CRUD 驗證（staging 實測）
- **Create**：POST /api/testset/upload 回 `{"ok":true,"path":"test-dataset/qa_crud/5/correct-...webm"}`，gcloud 確認 GCS 真的有 `.webm` + `.json` 兩個物件（測試檔已清）✅
- **Read（進度）**：本 PR 把它從 localStorage 升級成 server-truth
- backend py_compile OK；無 testset 契約測試（無契約破壞）
- 前端 file:// browse：返回/年級已移除、名字欄在、進度 grid 2 項、無 JS 例外（只有 file:// 對 staging API 的預期 CORS）

Refs #2335

> 🤖 由 Claude AI 代發（非 Young 本人）