### PR TITLE
feat(testset): record 重錄防誤觸 + 進度可聽取 (#2335)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -125,10 +125,13 @@ async def testset_upload(
 def testset_progress(name: str = "", lesson: str = ""):
     """錄音頁進度查詢（公開，server-truth）：某貢獻者某課是否已上傳 correct/error。
 
-    只回布林（不回名字/年級/play URL 等 PII），讓匿名 record.html 換裝置/清快取後
-    仍能讀回真實進度（取代純 localStorage 的 device-local 標記）。
+    回布林 + 各版本最新一筆的 10 分鐘簽名播放 URL（correct_url/error_url），讓匿名
+    record.html 換裝置/清快取後仍能讀回真實進度（取代純 localStorage 的 device-local
+    標記），且可在「我的進度」直接聽取自己上傳的錄音。
+    隱私 tradeoff：URL 以「名字 + 課」查得，知道名字者可聽該人錄音；符合 #2287
+    「公開上傳、隱私只做標配」設計，且 URL 10 分鐘過期。
     """
-    empty = {"ok": False, "correct": False, "error": False}
+    empty = {"ok": False, "correct": False, "error": False, "correct_url": None, "error_url": None}
     if not name.strip() or not _LESSON_ID_RE.match(lesson.strip()):
         return empty
     bucket = _get_gcs_bucket()
@@ -137,20 +140,35 @@ def testset_progress(name: str = "", lesson: str = ""):
 
     slug = _slug(name)
     lid = lesson.strip()
-    done = {"correct": False, "error": False}
+    latest = {"correct": None, "error": None}  # 各版本最新（lexical 末筆）webm blob path
     try:
         for blob in bucket.list_blobs(prefix=f"{_PREFIX}/{slug}/{lid}/", max_results=50):
             fname = blob.name.rsplit("/", 1)[-1]
             if not fname.endswith(".webm"):
                 continue
             if fname.startswith("correct"):
-                done["correct"] = True
+                latest["correct"] = blob.name
             elif fname.startswith("error"):
-                done["error"] = True
+                latest["error"] = blob.name
     except Exception as exc:
         logger.warning("testset progress failed: %s", exc)
         return empty
-    return {"ok": True, **done}
+
+    def _url(path: str | None) -> str | None:
+        if not path:
+            return None
+        try:
+            return generate_audio_signed_url(path, expiration_seconds=600)
+        except Exception:
+            return None
+
+    return {
+        "ok": True,
+        "correct": latest["correct"] is not None,
+        "error": latest["error"] is not None,
+        "correct_url": _url(latest["correct"]),
+        "error_url": _url(latest["error"]),
+    }
 
 
 @router.get("/testset/recordings")

--- a/frontend/public/testset/record.html
+++ b/frontend/public/testset/record.html
@@ -34,7 +34,12 @@
   .btn-rec.recording{background:#7f1d1d}
   .btn-up{background:var(--purple);color:#fff;width:100%}
   .btn:disabled{opacity:.4;cursor:not-allowed}
-  audio{width:100%;margin-top:10px}
+  audio{width:100%}
+  /* 播放器 + 右側小重錄鈕同列（重錄縮小、不被誤觸）*/
+  .player-row{display:flex;align-items:center;gap:8px;margin-top:10px}
+  .player-row audio{flex:1;min-width:0;margin:0}
+  .btn-rerec{flex:0 0 auto;background:#fff;border:1px solid var(--red);color:var(--red);border-radius:8px;padding:8px 10px;font-size:.78rem;font-weight:600;cursor:pointer;white-space:nowrap;line-height:1.2}
+  .btn-rerec:hover{background:#fee2e2}
   .status{font-size:.85rem;margin-top:8px}
   .ok{color:var(--green);font-weight:700}
   .err{color:var(--red)}
@@ -43,6 +48,9 @@
   .prog-item{display:flex;align-items:center;gap:8px;font-size:.88rem}
   .dot{width:14px;height:14px;border-radius:50%;background:#ddd;flex-shrink:0}
   .dot.done{background:var(--green)}
+  .prog-play{margin-left:auto;background:#fff;border:1px solid var(--purple);color:var(--purple);border-radius:6px;padding:2px 9px;font-size:.74rem;font-weight:600;cursor:pointer;white-space:nowrap}
+  .prog-play:hover{background:var(--chip)}
+  .prog-play.playing{background:var(--purple);color:#fff}
   .back{display:inline-block;margin-bottom:16px;color:var(--purple);text-decoration:none;font-size:.88rem;font-weight:600}
   .back:hover{text-decoration:underline}
   .err-banner{background:#fee2e2;border:1px solid var(--red);border-radius:10px;padding:16px;text-align:center;color:var(--red);font-weight:600}
@@ -88,7 +96,10 @@
           <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
         </div>
         <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
-        <audio id="player" controls style="display:none"></audio>
+        <div class="player-row" id="playerRow" style="display:none">
+          <audio id="player" controls></audio>
+          <button class="btn-rerec" id="reRecBtn" onclick="reRecord()" title="重新錄音">↻ 重錄</button>
+        </div>
         <button class="btn btn-up" id="upBtn" onclick="upload()" disabled style="margin-top:10px">上傳這段</button>
         <div class="status" id="status"></div>
       </div>
@@ -124,6 +135,7 @@ var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
 var NAME_KEY='testset_name';
 var done=JSON.parse(localStorage.getItem('testset_done_v2_'+lessonId)||'{}');
+var doneUrls={correct:null,error:null};  // server 簽名播放 URL（聽取用，10 分鐘有效）
 var mediaRec=null,chunks=[],blob=null;
 
 /* ── 進度：server-truth（換裝置/清快取仍讀得回，localStorage 只當快取） ── */
@@ -136,6 +148,7 @@ async function loadProgress(){
       var d=await r.json();
       if(d&&d.ok){
         done={correct:!!d.correct,error:!!d.error};
+        doneUrls={correct:d.correct_url||null,error:d.error_url||null};
         localStorage.setItem('testset_done_v2_'+lessonId,JSON.stringify(done));
       }
     }
@@ -204,10 +217,11 @@ function selVersion(v){
 
 function resetRec(){
   blob=null;
-  var p=document.getElementById('player'); p.style.display='none'; p.src='';
+  var p=document.getElementById('player'); p.src='';
+  document.getElementById('playerRow').style.display='none';
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='';
-  var b=document.getElementById('recBtn'); b.classList.remove('recording'); b.textContent='● 開始錄音';
+  var b=document.getElementById('recBtn'); b.style.display=''; b.classList.remove('recording'); b.textContent='● 開始錄音';
 }
 
 async function toggleRec(){
@@ -219,16 +233,29 @@ async function toggleRec(){
     mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
     mediaRec.onstop=function(){
       blob=new Blob(chunks,{type:'audio/webm'});
-      var p=document.getElementById('player'); p.src=URL.createObjectURL(blob); p.style.display='block';
+      var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
+      // 完成：收起大錄音鈕，改顯示「播放器 + 右側小重錄鈕」（避免誤觸重錄）
+      document.getElementById('playerRow').style.display='flex';
+      b.style.display='none';
       document.getElementById('upBtn').disabled=false;
       stream.getTracks().forEach(function(t){t.stop()});
-      b.classList.remove('recording'); b.textContent='● 重新錄音';
+      b.classList.remove('recording');
+      document.getElementById('status').innerHTML='';
     };
+    // 進入錄音中：收起播放器列、顯示停止鈕
+    document.getElementById('playerRow').style.display='none';
+    b.style.display='';
     mediaRec.start(); b.classList.add('recording'); b.textContent='■ 停止錄音';
     document.getElementById('status').innerHTML='<span style="color:var(--muted)">錄音中…照著上面的課文念</span>';
   }catch(e){
     document.getElementById('status').innerHTML='<span class="err">無法存取麥克風，請允許瀏覽器麥克風權限後再試。</span>';
   }
+}
+
+// 重錄：先確認再捨棄目前這段（小鈕在播放器右邊，避免誤觸）
+function reRecord(){
+  if(!confirm('確定要重錄嗎？目前這段會被捨棄。')) return;
+  toggleRec();
 }
 
 async function upload(){
@@ -270,10 +297,28 @@ function renderProgress(){
     var ok=!!done[V.k];
     if(!ok) allDone=false;
     var div=document.createElement('div'); div.className='prog-item';
-    div.innerHTML='<span class="dot'+(ok?' done':'')+'"></span><span>'+(ok?'✓ ':'')+V.n+'</span>';
+    var html='<span class="dot'+(ok?' done':'')+'"></span><span>'+(ok?'✓ ':'')+V.n+'</span>';
+    if(ok && doneUrls[V.k]){
+      html+='<button class="prog-play" data-v="'+V.k+'" onclick="playVersion(\''+V.k+'\')">▶ 聽取</button>';
+    }
+    div.innerHTML=html;
     el.appendChild(div);
   });
   document.getElementById('doneBanner').style.display=allDone?'block':'none';
+}
+
+// 聽取已上傳的某版本錄音（server 簽名 URL）；再點一次停止
+var progAudio=null;
+function playVersion(v){
+  var url=doneUrls[v];
+  if(!url) return;
+  if(!progAudio) progAudio=new Audio();
+  var btn=document.querySelector('.prog-play[data-v="'+v+'"]');
+  if(progAudio.src===url && !progAudio.paused){ progAudio.pause(); if(btn) btn.classList.remove('playing'); return; }
+  document.querySelectorAll('.prog-play').forEach(function(b){b.classList.remove('playing')});
+  progAudio.src=url; progAudio.play();
+  if(btn) btn.classList.add('playing');
+  progAudio.onended=function(){ if(btn) btn.classList.remove('playing'); };
 }
 
 // 自動帶回上次名字 → 從 server 讀真實進度（下次進來/換裝置都看得到）


### PR DESCRIPTION
## What（Young 2026-06-21 回饋）
1. **重錄防誤觸**：重錄鈕從整條大紅鈕 → 移到播放器右側的小鈕（縮小），點擊先 `confirm("確定要重錄嗎？")` 才捨棄重錄
2. **進度可聽取**：③ 我的進度的正確版/錯誤版加「▶ 聽取」鈕，直接播放已上傳錄音（再點停止）
3. backend `GET /testset/progress` 回傳各版本 10 分鐘簽名播放 URL（`correct_url`/`error_url`）

## Verify（file:// browse）
- review 狀態截圖：大錄音鈕隱藏、播放器 + 右側小「↻ 重錄」鈕、上傳鈕 ✅
- 小重錄鈕 onclick=reRecord() → confirm 才重錄 ✅
- 進度 ▶ 聽取鈕渲染（done + 有 URL 時）✅
- backend py_compile OK；console 僅 file:// 對 staging API 的預期 CORS（served 同源不會有）
- 完整聽取/重錄互動（需真麥克風 + API）→ merge 後 served staging 實測

## 隱私 tradeoff
progress 端點回簽名播放 URL，知道「名字」者可聽該人錄音；符合 #2287「公開上傳、隱私只做標配」+ URL 10 分過期

Refs #2335

> 🤖 由 Claude AI 代發（非 Young 本人）