### PR TITLE
feat(testset): 朗讀語音批次測試 API POST /testset/batch-eval (#2340)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -14,6 +14,12 @@
 安全:
 - 公開 endpoint → IP rate-limit + size cap + content-type 檢查 + fail-closed。
 - v1 list 也公開（owner 資料低敏感、URL 隱蔽）；v2 再加 auth。已向 owner 標註此 tradeoff。
+
+批次評估 (Issue #2340):
+- POST /api/testset/batch-eval — 登入後才可用（get_current_user）
+- 讀 GCS meta → transcribe → evaluate pipeline，每筆 fail-safe
+- 硬上限 _BATCH_EVAL_LIMIT 筆，超過截斷並回 truncated:true + log
+- 無 DB migration（GCS-only）
 """
 
 from __future__ import annotations
@@ -24,7 +30,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 
 from ..auth.dependencies import get_current_user
 from ..models.user import User
@@ -45,6 +51,10 @@ _ALLOWED_VERSION = {"correct", "error"}
 _LESSON_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,20}$")
 _LIST_CAP = 500  # list_blobs hard cap，避免 unbounded read/signBlob
 
+# 批次評估單次硬上限：每次最多評 N 筆（cost guard，#2340）
+# Gemini transcribe 每筆約 2-5s，30 筆 = ~150s；超過截斷並回 truncated:true
+_BATCH_EVAL_LIMIT = 30
+
 # Rate-limiting 靠全域 GlobalRateLimitMiddleware（讀 X-Forwarded-For，真 per-IP）。
 # 不在 endpoint 用 request.client.host limiter — Cloud Run LB 後面那只會讓所有人共用
 # 一個 bucket → self-DoS（security 複查 #2304）。
@@ -54,6 +64,25 @@ def _slug(name: str) -> str:
     """Stable, path-safe slug from contributor name (keeps CJK, strips separators)."""
     s = re.sub(r"[^\w一-鿿]+", "_", (name or "").strip())
     return (s.strip("_") or "anon")[:40]
+
+
+def _resolve_target_text(lesson_id: str) -> str | None:
+    """Return full_text for lesson_id (numeric int or code string like 'G6-L22').
+
+    Priority: int lookup → code lookup. Returns None if not found.
+    """
+    from ..services.lesson_loader import get_lesson_by_code, get_lesson_by_id  # noqa: PLC0415
+
+    lesson = None
+    try:
+        lesson = get_lesson_by_id(int(lesson_id))
+    except (ValueError, TypeError):
+        pass
+    if lesson is None:
+        lesson = get_lesson_by_code(lesson_id)
+    if lesson is None:
+        return None
+    return lesson.get("full_text") or None
 
 
 @router.post("/testset/upload")
@@ -202,3 +231,217 @@ def testset_recordings(current_user: User = Depends(get_current_user)):
 
     out.sort(key=lambda m: m.get("created_at", ""), reverse=True)
     return {"ok": True, "count": len(out), "recordings": out}
+
+
+@router.post("/testset/batch-eval")
+async def testset_batch_eval(
+    current_user: User = Depends(get_current_user),
+    name: str | None = Query(default=None, description="過濾貢獻者名字（slug 比對）"),
+    lesson: str | None = Query(default=None, description="過濾課文 lesson_id（字串精確比對）"),
+) -> dict:
+    """批次跑 STT + 評分 pipeline，驗測試集準度（Issue #2340）。
+
+    Auth: 登入使用者才可呼叫（get_current_user），不需 teacher/admin role。
+
+    Query params:
+        name   — 過濾 contributor slug（局部比對，例如 '王小明' → slug '王小明'）
+        lesson — 過濾 lesson_id（例如 '1' 或 'G6-L22'）
+
+    Returns:
+        {
+          ok: bool,
+          n: int,
+          truncated: bool,
+          results: [{
+            name, lesson, version,
+            match_rate, adjusted_match_rate, cpm,
+            transcript_method,  // "gemini" | "fallback"
+            transcript_reason,  // fallback 原因，非 fallback 時 null
+            expected,           // "high" (correct) | "low" (error)
+            flag,               // true = 不符期望（異常）
+            error,              // 該筆例外訊息，正常時 null
+          }],
+          summary: {
+            correct_avg,    // correct 版的 adjusted_match_rate 平均（無資料時 null）
+            error_avg,      // error 版的 adjusted_match_rate 平均（無資料時 null）
+            anomaly_count,  // flag=true 的筆數
+          }
+        }
+
+    Cost guard: 單次最多評 _BATCH_EVAL_LIMIT（30）筆，超過截斷並標 truncated:true。
+    Fail-safe: 單筆 exception 不中斷整批，標 error 欄位並繼續。
+    """
+    from ..services.reading_evaluation_service import evaluate_reading_with_ai  # noqa: PLC0415
+    from ..services.reading_transcription_service import transcribe_reading_audio  # noqa: PLC0415
+
+    # ── 1. GCS availability check (fail-closed) ────────────────────────────
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        logger.warning("testset batch-eval: GCS unavailable")
+        return {
+            "ok": False,
+            "n": 0,
+            "truncated": False,
+            "results": [],
+            "summary": {"correct_avg": None, "error_avg": None, "anomaly_count": 0},
+        }
+
+    # ── 2. Collect meta entries from GCS ──────────────────────────────────
+    name_slug = _slug(name) if name else None
+    metas: list[dict] = []
+    try:
+        for blob in bucket.list_blobs(prefix=f"{_PREFIX}/", max_results=_LIST_CAP):
+            if not blob.name.endswith(".json"):
+                continue
+            # Apply contributor filter (slug-based path component match)
+            if name_slug and f"/{name_slug}/" not in blob.name:
+                continue
+            try:
+                meta = json.loads(blob.download_as_text())
+            except Exception:
+                continue
+            # Apply lesson filter
+            if lesson and meta.get("lesson_id", "") != lesson:
+                continue
+            metas.append(meta)
+    except Exception as exc:
+        logger.warning("testset batch-eval list failed: %s", exc)
+        return {
+            "ok": False,
+            "n": 0,
+            "truncated": False,
+            "results": [],
+            "summary": {"correct_avg": None, "error_avg": None, "anomaly_count": 0},
+        }
+
+    # ── 3. Hard limit — cost guard ─────────────────────────────────────────
+    truncated = len(metas) > _BATCH_EVAL_LIMIT
+    if truncated:
+        logger.info(
+            "testset batch-eval truncated: total=%d limit=%d name=%s lesson=%s",
+            len(metas), _BATCH_EVAL_LIMIT, name, lesson,
+        )
+        metas = metas[:_BATCH_EVAL_LIMIT]
+
+    # ── 4. Per-entry pipeline (fail-safe) ──────────────────────────────────
+    results: list[dict] = []
+    for meta in metas:
+        entry_name = meta.get("contributor_name", "")
+        entry_lesson = meta.get("lesson_id", "")
+        entry_version = meta.get("version", "")
+        audio_path = meta.get("audio_path", "")
+
+        base_result: dict = {
+            "name": entry_name,
+            "lesson": entry_lesson,
+            "version": entry_version,
+            "match_rate": None,
+            "adjusted_match_rate": None,
+            "cpm": None,
+            "transcript_method": None,
+            "transcript_reason": None,
+            "expected": "high" if entry_version == "correct" else "low",
+            "flag": False,
+            "error": None,
+        }
+
+        try:
+            # 4a. Resolve target_text for this lesson
+            target_text = _resolve_target_text(entry_lesson)
+            if not target_text:
+                base_result["error"] = f"lesson '{entry_lesson}' not found in catalog"
+                results.append(base_result)
+                logger.info("batch-eval skip: lesson not found path=%s", audio_path)
+                continue
+
+            # 4b. Download audio bytes
+            audio_blob = bucket.blob(audio_path)
+            audio_bytes = audio_blob.download_as_bytes()
+
+            # 4c. Transcribe
+            transcribe_result = await transcribe_reading_audio(
+                audio_bytes=audio_bytes,
+                mime_type="audio/webm",
+                target_text=target_text,
+                duration_ms=None,
+            )
+            transcript = transcribe_result.get("transcript")
+            transcript_method = transcribe_result.get("method", "fallback")
+            transcript_reason = transcribe_result.get("reason")
+
+            base_result["transcript_method"] = transcript_method
+            base_result["transcript_reason"] = transcript_reason
+
+            # 4d. Skip scoring if transcription failed (fallback with no transcript)
+            if not transcript:
+                base_result["error"] = f"transcription fallback: {transcript_reason or 'unknown'}"
+                results.append(base_result)
+                logger.info(
+                    "batch-eval transcribe fallback: path=%s reason=%s",
+                    audio_path, transcript_reason,
+                )
+                continue
+
+            # 4e. Evaluate
+            eval_result = await evaluate_reading_with_ai(
+                spoken_text=transcript,
+                target_text=target_text,
+                duration_ms=None,
+            )
+            match_rate = eval_result.get("match_rate")
+            adjusted = eval_result.get("adjusted_match_rate")
+            cpm = eval_result.get("cpm")
+
+            base_result["match_rate"] = match_rate
+            base_result["adjusted_match_rate"] = adjusted
+            base_result["cpm"] = cpm
+
+            # 4f. Flag anomalies vs expected score direction
+            # correct → expect adjusted >= 0.8; error → expect adjusted < 0.8
+            if adjusted is not None:
+                if entry_version == "correct" and adjusted < 0.8:
+                    base_result["flag"] = True
+                elif entry_version == "error" and adjusted >= 0.8:
+                    base_result["flag"] = True
+
+        except Exception as exc:
+            # Fail-safe: single entry exception must not abort the batch
+            base_result["error"] = type(exc).__name__
+            logger.warning(
+                "batch-eval entry error: path=%s err=%s", audio_path, exc, exc_info=True
+            )
+
+        results.append(base_result)
+
+    # ── 5. Summary statistics ───────────────────────────────────────────────
+    correct_scores = [
+        r["adjusted_match_rate"]
+        for r in results
+        if r["version"] == "correct" and r["adjusted_match_rate"] is not None
+    ]
+    error_scores = [
+        r["adjusted_match_rate"]
+        for r in results
+        if r["version"] == "error" and r["adjusted_match_rate"] is not None
+    ]
+    anomaly_count = sum(1 for r in results if r["flag"])
+
+    correct_avg = round(sum(correct_scores) / len(correct_scores), 4) if correct_scores else None
+    error_avg = round(sum(error_scores) / len(error_scores), 4) if error_scores else None
+
+    logger.info(
+        "testset batch-eval done: n=%d truncated=%s anomaly=%d correct_avg=%s error_avg=%s",
+        len(results), truncated, anomaly_count, correct_avg, error_avg,
+    )
+
+    return {
+        "ok": True,
+        "n": len(results),
+        "truncated": truncated,
+        "results": results,
+        "summary": {
+            "correct_avg": correct_avg,
+            "error_avg": error_avg,
+            "anomaly_count": anomaly_count,
+        },
+    }

--- a/backend/tests/test_testset_batch_eval.py
+++ b/backend/tests/test_testset_batch_eval.py
@@ -1,0 +1,537 @@
+"""Tests for POST /api/testset/batch-eval (Issue #2340).
+
+Coverage:
+  (a) Empty test set → empty results, no error
+  (b) correct high score → flag=False; error high score → flag=True
+  (c) Single transcription fallback → does not abort batch, marks error field
+  (d) Truncation at _BATCH_EVAL_LIMIT
+  (e) GCS unavailable → ok=False, graceful degradation
+  (f) Unauthenticated → 401
+
+Run:
+    cd backend && python -m pytest tests/test_testset_batch_eval.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User
+from app.auth.dependencies import get_current_user
+from app.auth.rate_limiter import ai_rate_limiter, general_rate_limiter
+
+
+# ---------------------------------------------------------------------------
+# SQLite in-memory test DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+_fake_user = User(
+    id=99,
+    username="test_evaluator",
+    name="Test Evaluator",
+    email="eval@example.com",
+    password_hash="fake",
+)
+
+
+def _override_get_current_user():
+    return _fake_user
+
+
+# ---------------------------------------------------------------------------
+# Helpers: mock GCS bucket factory
+# ---------------------------------------------------------------------------
+
+def _make_bucket_with_metas(metas: list[dict]) -> MagicMock:
+    """Return a mock GCS bucket whose list_blobs yields json blobs for each meta."""
+    import json as _json
+
+    bucket = MagicMock()
+    blobs = []
+    for meta in metas:
+        blob = MagicMock()
+        blob.name = meta["audio_path"].replace(".webm", ".json")
+        blob.download_as_text.return_value = _json.dumps(meta)
+        blob.download_as_bytes.return_value = b"dummy_audio"
+        blobs.append(blob)
+    bucket.list_blobs.return_value = iter(blobs)
+
+    def _get_blob(path):
+        b = MagicMock()
+        b.download_as_bytes.return_value = b"dummy_audio"
+        return b
+
+    bucket.blob.side_effect = _get_blob
+    return bucket
+
+
+def _sample_meta(version: str = "correct", lesson_id: str = "1", uid: str = "abc12345") -> dict:
+    return {
+        "contributor_name": "王小明",
+        "grade": "5",
+        "lesson_id": lesson_id,
+        "version": version,
+        "audio_path": f"test-dataset/王小明/{lesson_id}/{version}-{uid}.webm",
+        "created_at": "2026-06-20T10:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    # seed roles (display_name + scope_level required by Role model)
+    _role_defs = [
+        {"name": "student", "display_name": "Student", "scope_level": "school"},
+        {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+        {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    ]
+    for rd in _role_defs:
+        if not db.query(Role).filter(Role.name == rd["name"]).first():
+            db.add(Role(name=rd["name"], display_name=rd["display_name"], scope_level=rd["scope_level"]))
+    db.commit()
+    student_role = db.query(Role).filter(Role.name == "student").first()
+    _fake_user.role_id = student_role.id if student_role else None
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_limiters():
+    ai_rate_limiter.reset()
+    general_rate_limiter.reset()
+    try:
+        from app.routes.auth import rate_limiter
+        rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+
+
+@pytest.fixture(scope="module")
+def authed_client():
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def unauthed_client():
+    """Client with NO auth override (get_current_user raises 401)."""
+    app.dependency_overrides[get_db] = _override_get_db
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# (a) Empty test set → ok=True, n=0, empty results
+# ---------------------------------------------------------------------------
+
+class TestEmptyTestset:
+    def test_empty_gcs_returns_empty_results(self, authed_client):
+        """GCS has zero json metas → response ok=True, n=0, empty results."""
+        empty_bucket = MagicMock()
+        empty_bucket.list_blobs.return_value = iter([])
+
+        with patch(
+            "app.routes.testset._get_gcs_bucket", return_value=empty_bucket
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["n"] == 0
+        assert data["truncated"] is False
+        assert data["results"] == []
+        assert data["summary"]["anomaly_count"] == 0
+        assert data["summary"]["correct_avg"] is None
+        assert data["summary"]["error_avg"] is None
+
+
+# ---------------------------------------------------------------------------
+# (b) Scoring flag logic
+# ---------------------------------------------------------------------------
+
+class TestFlagLogic:
+    """correct high score → flag=False; error high score → flag=True."""
+
+    def _run_with_metas(self, authed_client, metas, transcribe_ret, eval_ret):
+        bucket = _make_bucket_with_metas(metas)
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.routes.testset.testset_batch_eval.__wrapped__"
+                if hasattr(authed_client, "__wrapped__")
+                else "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=transcribe_ret,
+            ) as _t,
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ) as _e,
+        ):
+            # Patch inside the route module directly
+            with (
+                patch(
+                    "app.services.reading_transcription_service.transcribe_reading_audio",
+                    new_callable=AsyncMock,
+                    return_value=transcribe_ret,
+                ),
+                patch(
+                    "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                    new_callable=AsyncMock,
+                    return_value=eval_ret,
+                ),
+            ):
+                resp = authed_client.post("/api/testset/batch-eval")
+        return resp
+
+    def test_correct_high_score_no_flag(self, authed_client):
+        """correct version + adjusted>=0.8 → flag=False."""
+        metas = [_sample_meta(version="correct", uid="aaa00001")]
+        transcribe_ret = {"transcript": "課文內容", "method": "gemini", "reason": None}
+        eval_ret = {
+            "match_rate": 0.95,
+            "adjusted_match_rate": 0.95,
+            "cpm": 120.0,
+            "tier": 1,
+        }
+        bucket = _make_bucket_with_metas(metas)
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=transcribe_ret,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["n"] == 1
+        r = data["results"][0]
+        assert r["version"] == "correct"
+        assert r["adjusted_match_rate"] == pytest.approx(0.95)
+        assert r["flag"] is False
+        assert r["expected"] == "high"
+        assert data["summary"]["correct_avg"] == pytest.approx(0.95)
+        assert data["summary"]["anomaly_count"] == 0
+
+    def test_error_version_high_score_flags_anomaly(self, authed_client):
+        """error version + adjusted>=0.8 → flag=True (異常：expected low but scored high)."""
+        metas = [_sample_meta(version="error", uid="bbb00002")]
+        transcribe_ret = {"transcript": "課文內容", "method": "gemini", "reason": None}
+        eval_ret = {
+            "match_rate": 0.9,
+            "adjusted_match_rate": 0.9,
+            "cpm": 100.0,
+            "tier": 1,
+        }
+        bucket = _make_bucket_with_metas(metas)
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=transcribe_ret,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        r = data["results"][0]
+        assert r["version"] == "error"
+        assert r["flag"] is True
+        assert data["summary"]["anomaly_count"] == 1
+
+    def test_correct_low_score_flags_anomaly(self, authed_client):
+        """correct version + adjusted<0.8 → flag=True."""
+        metas = [_sample_meta(version="correct", uid="ccc00003")]
+        transcribe_ret = {"transcript": "wrong text", "method": "gemini", "reason": None}
+        eval_ret = {
+            "match_rate": 0.3,
+            "adjusted_match_rate": 0.3,
+            "cpm": 50.0,
+            "tier": 3,
+        }
+        bucket = _make_bucket_with_metas(metas)
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=transcribe_ret,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        data = resp.json()
+        assert data["results"][0]["flag"] is True
+        assert data["summary"]["anomaly_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# (c) Transcription fallback — does not abort batch
+# ---------------------------------------------------------------------------
+
+class TestTranscribeFallback:
+    def test_fallback_entry_does_not_abort_batch(self, authed_client):
+        """If entry[0] transcribe→fallback and entry[1] succeeds, both entries returned."""
+        metas = [
+            _sample_meta(version="correct", uid="fall0001"),
+            _sample_meta(version="correct", uid="ok000002"),
+        ]
+        # First call returns fallback (no transcript), second returns gemini
+        fallback_ret = {"transcript": None, "method": "fallback", "reason": "timeout"}
+        success_ret = {"transcript": "課文內容", "method": "gemini", "reason": None}
+        eval_ret = {
+            "match_rate": 0.9,
+            "adjusted_match_rate": 0.9,
+            "cpm": 110.0,
+            "tier": 1,
+        }
+        bucket = _make_bucket_with_metas(metas)
+
+        side_effects = [fallback_ret, success_ret]
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                side_effect=side_effects,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["n"] == 2  # Both entries processed
+
+        # First entry: fallback recorded as error, no score
+        r0 = data["results"][0]
+        assert r0["transcript_method"] == "fallback"
+        assert r0["adjusted_match_rate"] is None
+        assert "transcription fallback" in (r0["error"] or "")
+
+        # Second entry: scored normally
+        r1 = data["results"][1]
+        assert r1["adjusted_match_rate"] == pytest.approx(0.9)
+        assert r1["error"] is None
+
+    def test_exception_in_single_entry_does_not_abort(self, authed_client):
+        """RuntimeError in one entry → that entry gets error field, rest continue."""
+        metas = [
+            _sample_meta(version="correct", uid="exc00001"),
+            _sample_meta(version="correct", uid="ok000003"),
+        ]
+        success_ret = {"transcript": "課文", "method": "gemini", "reason": None}
+        eval_ret = {"match_rate": 0.85, "adjusted_match_rate": 0.85, "cpm": 90.0, "tier": 1}
+        bucket = _make_bucket_with_metas(metas)
+
+        call_count = [0]
+
+        async def transcribe_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("simulated GCS download error")
+            return success_ret
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                side_effect=transcribe_side_effect,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["n"] == 2
+        assert data["results"][0]["error"] == "RuntimeError"
+        assert data["results"][1]["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# (d) Truncation at _BATCH_EVAL_LIMIT
+# ---------------------------------------------------------------------------
+
+class TestTruncation:
+    def test_truncates_at_limit(self, authed_client):
+        """More than _BATCH_EVAL_LIMIT metas → truncated=True, n <= limit."""
+        from app.routes.testset import _BATCH_EVAL_LIMIT
+
+        # Build _BATCH_EVAL_LIMIT + 5 metas
+        metas = [
+            _sample_meta(version="correct", uid=f"{i:08d}")
+            for i in range(_BATCH_EVAL_LIMIT + 5)
+        ]
+        success_ret = {"transcript": "課文", "method": "gemini", "reason": None}
+        eval_ret = {"match_rate": 0.9, "adjusted_match_rate": 0.9, "cpm": 100.0, "tier": 1}
+        bucket = _make_bucket_with_metas(metas)
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=success_ret,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["truncated"] is True
+        assert data["n"] == _BATCH_EVAL_LIMIT
+
+    def test_no_truncation_at_exactly_limit(self, authed_client):
+        """Exactly _BATCH_EVAL_LIMIT metas → truncated=False."""
+        from app.routes.testset import _BATCH_EVAL_LIMIT
+
+        metas = [
+            _sample_meta(version="correct", uid=f"{i:08d}")
+            for i in range(_BATCH_EVAL_LIMIT)
+        ]
+        success_ret = {"transcript": "課文", "method": "gemini", "reason": None}
+        eval_ret = {"match_rate": 0.9, "adjusted_match_rate": 0.9, "cpm": 100.0, "tier": 1}
+        bucket = _make_bucket_with_metas(metas)
+
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                new_callable=AsyncMock,
+                return_value=success_ret,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        data = resp.json()
+        assert data["truncated"] is False
+        assert data["n"] == _BATCH_EVAL_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# (e) GCS unavailable → graceful ok=False
+# ---------------------------------------------------------------------------
+
+class TestGCSUnavailable:
+    def test_gcs_none_returns_ok_false(self, authed_client):
+        """_get_gcs_bucket returns None → ok=False, empty results, no 5xx."""
+        with patch("app.routes.testset._get_gcs_bucket", return_value=None):
+            resp = authed_client.post("/api/testset/batch-eval")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["n"] == 0
+        assert data["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# (f) Unauthenticated → 401
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def test_unauthenticated_returns_401(self):
+        """No auth header → 401, endpoint is not public."""
+        # Clear all overrides for this test to test real auth guard
+        saved = dict(app.dependency_overrides)
+        app.dependency_overrides.clear()
+        try:
+            with TestClient(app, raise_server_exceptions=False) as c:
+                resp = c.post("/api/testset/batch-eval")
+            assert resp.status_code == 401
+        finally:
+            app.dependency_overrides.update(saved)


### PR DESCRIPTION
## What（6/18 週會 Young-owned action item）
新增 `POST /api/testset/batch-eval`：把已收集的測試集音檔整批跑 transcribe→評分 pipeline，輸出每檔評分 + 與期望比對（correct 版期望高分、error 版期望低分），驗 STT/評分準度。

## 驗證（已實測）
- `backend/tests/test_testset_batch_eval.py` **10 passed**（空集合 / correct flag / error flag / transcribe fallback 不中斷 / 截斷上限 等）
- target 解析用 lesson dict 的 `full_text` key — **實際 load `get_lesson_by_id(1)` 確認 dict 有此 key**（非看 YAML 猜）
- `specs/run-ci.sh --quick` registry OK；rebased onto staging 無衝突
- LLM hardening：登入才可（get_current_user）/ 單次上限 30 筆 cost guard / 單筆 fail-safe 不中斷 / GCS fail-closed / 每筆帶 transcript_method+reason 可稽核

## Refs
#2340 · 6/18 週會 docs/meetings/2026-06-18-record.md §2-§3

> 🤖 由 Claude AI 代發（非 Young 本人）