### PR TITLE
fix(reading-audio): Cloud Run 簽名 URL 改走 IAM SignBlob — 修好所有回放 (#2343)

### DIFF
--- a/backend/app/services/audio_upload_service.py
+++ b/backend/app/services/audio_upload_service.py
@@ -310,6 +310,49 @@ def delete_gcs_blobs_for_paths(blob_paths: list[str]) -> tuple[int, int]:
     return deleted, failed
 
 
+_signing_creds = None
+_signing_creds_lock = threading.Lock()
+_signing_email: str | None = None
+
+
+def _signing_identity() -> tuple[str | None, str | None]:
+    """Return (service_account_email, access_token) for IAM-based v4 signing.
+
+    On Cloud Run/GCE the default credentials hold only an OAuth token, so v4
+    signing must go through the IAM SignBlob API — which needs the runtime SA's
+    email + a fresh access token. Returns (None, None) if unavailable (caller
+    then falls back to library default, e.g. a private key in local dev).
+    """
+    global _signing_creds, _signing_email
+    try:
+        from google.auth import default as _ga_default  # noqa: PLC0415
+        from google.auth.transport.requests import Request as _GaRequest  # noqa: PLC0415
+
+        with _signing_creds_lock:
+            if _signing_creds is None:
+                _signing_creds, _ = _ga_default()
+            creds = _signing_creds
+        if not getattr(creds, "valid", False):
+            creds.refresh(_GaRequest())
+
+        email = _signing_email or getattr(creds, "service_account_email", None)
+        if not email or email == "default":
+            # compute_engine creds may report "default" → resolve real email
+            import urllib.request  # noqa: PLC0415
+
+            req = urllib.request.Request(
+                "http://metadata.google.internal/computeMetadata/v1/instance/"
+                "service-accounts/default/email",
+                headers={"Metadata-Flavor": "Google"},
+            )
+            email = urllib.request.urlopen(req, timeout=2).read().decode().strip()  # noqa: S310
+        _signing_email = email
+        return email, getattr(creds, "token", None)
+    except Exception as exc:  # never block signing setup; fall back to default
+        logger.debug("signing identity unavailable, using library default: %s", exc)
+        return None, None
+
+
 def generate_audio_signed_url(
     blob_path: str,
     expiration_seconds: int = 600,
@@ -338,15 +381,27 @@ def generate_audio_signed_url(
 
     try:
         blob = bucket.blob(blob_path)
-        url = blob.generate_signed_url(
-            expiration=timedelta(seconds=expiration_seconds),
-            method="GET",
-            version="v4",
-        )
+        kwargs = {
+            "expiration": timedelta(seconds=expiration_seconds),
+            "method": "GET",
+            "version": "v4",
+        }
+        # Cloud Run / GCE default credentials only carry an OAuth token (no
+        # private key) → blob.generate_signed_url() would raise "you need a
+        # private key to sign credentials". Passing service_account_email +
+        # access_token makes the client sign via the IAM SignBlob API instead
+        # (requires the runtime SA to have roles/iam.serviceAccountTokenCreator
+        # on itself — already granted to the compute SA).
+        email, token = _signing_identity()
+        if email and token:
+            kwargs["service_account_email"] = email
+            kwargs["access_token"] = token
+        url = blob.generate_signed_url(**kwargs)
         logger.debug(
-            "reading-audio signed URL generated: path=%s expiry=%ds",
+            "reading-audio signed URL generated: path=%s expiry=%ds via_iam=%s",
             blob_path,
             expiration_seconds,
+            bool(email and token),
         )
         return url
     except Exception as exc:


### PR DESCRIPTION
## What
修 `generate_audio_signed_url`：Cloud Run compute 憑證無私鑰，v4 簽名一直失敗（`you need a private key to sign credentials`，staging log 實證）→ **所有回放/聽錄音 signed URL 永遠 null、播不出來**（學生 #2283、老師 #2326/#2327、testset 聽取 #2341 全受影響，之前只 code-verified 沒真播）。

新增 `_signing_identity()` 取 runtime SA email + access token，傳給 `generate_signed_url` 走 IAM SignBlob API（compute SA 已有 `serviceAccountTokenCreator` 自我授權）。無 GCE 時 fall back，本地/測試不受影響。

## Verify
- py_compile OK；本地測試無新增失敗（pre-existing GCS/TTS local-env 失敗 baseline 也有）
- **真實簽名效果需 Cloud Run SA** → merge + deploy 後驗：`GET /testset/progress` 的 correct_url 非 null + 該 URL HTTP 200 取得音檔（會在 PR 後補證據）

Fixes #2343

> 🤖 由 Claude AI 代發（非 Young 本人）