### PR TITLE
fix(stepper): 聚光燈 step icon 與其他步統一 (#2348)

### DIFF
--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -194,8 +194,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     needsStory: true,
     enabled: true,
     category: 'comprehension',
-    navEmphasis: true,
-    navShortLabel: '聚光燈',
+    // navEmphasis 移除（Young 2026-06-21）：原本 #2192 讓聚光燈用 💡+放大+紫框，
+    // 跟其他步單字灰圈不一致 → 統一成 displayChar '光' 灰圈。findability 若要再加用顏色非換 icon。
   },
   'sentence-practice': {
     id: 'sentence-practice',


### PR DESCRIPTION
## What
聚光燈（reading-strategy）在 stepper 原本是 lightbulb + 放大 pill + 紫框（早期為了讓學生找得到聚光燈），跟其他步「單字灰圈」不一致。移除 `navEmphasis` → 改用 displayChar「光」灰圈跟大家一樣。一改同時修好 StepperNav.tsx + AppShell.tsx 兩個 renderer。

## Verify
- 改前截圖：聚光燈紫圈燈泡放大、其他灰圈單字
- config-only 2 行（navEmphasis optional 欄位移除），render 風險極低
- lint + render-smoke → CI frontend-checks gate；改後視覺 merge+deploy 後 staging 驗

Fixes #2348

> 🤖 由 Claude AI 代發（非 Young 本人）