### PR TITLE
fix(spotlight): G4-L2 第二練習文標題正規化 〈𪹚龍慶元宵〉

### DIFF
--- a/backend/data/lessons/spotlight/catalog/G4-L2.spotlight.yml
+++ b/backend/data/lessons/spotlight/catalog/G4-L2.spotlight.yml
@@ -12,7 +12,7 @@ spotlight:
     asset: fig1.png
     bind_paragraph: null
   - type: free_text
-    prompt: ２.<𪹚1龍慶元宵>　彭仁星
+    prompt: ２.〈𪹚龍慶元宵〉　彭仁星
   - type: figure
     referent: table
     asset: fig10.png


### PR DESCRIPTION
Young 看到聚光燈標題「２.<𪹚1龍慶元宵>」很亂。查證後：元宵詩是十秒的背後 DOCX 的合法第二練習文，`<𪹚1龍慶元宵>` 是源檔原樣（老師用 <> + 註腳號攤平）。校正成 `〈𪹚龍慶元宵〉`（書名號 + 去攤平註腳數字 + 保留 𪹚）。
yaml 有效、run-ci registry OK、無 `<` 殘留。
Related to #2083
> 🤖 由 Claude AI 代發（非 Young 本人）