### PR TITLE
release: 聚光燈 icon 統一 + 測試集嵌入 + 進度 UIUX + G4-L2 標題校正 (staging→main)

### DIFF
--- a/backend/data/lessons/spotlight/catalog/G4-L2.spotlight.yml
+++ b/backend/data/lessons/spotlight/catalog/G4-L2.spotlight.yml
@@ -12,7 +12,7 @@ spotlight:
     asset: fig1.png
     bind_paragraph: null
   - type: free_text
-    prompt: ２.<𪹚1龍慶元宵>　彭仁星
+    prompt: ２.〈𪹚龍慶元宵〉　彭仁星
   - type: figure
     referent: table
     asset: fig10.png

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -361,13 +361,8 @@
 
   <!-- TESTSET -->
   <div class="pane" id="testset">
-    <div class="card" style="border-left:4px solid var(--green)">
-      <h3>測試集 — 已建立 <span class="ok">✅ 可用</span></h3>
-      <p>人聲測試集 crowdsource 頁（<a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2287">issue #2287</a>）— 已建好且 live。</p>
-      <div style="display:flex;gap:12px;flex-wrap:wrap;margin-top:10px">
-        <a href="../testset/index.html" style="display:inline-block;padding:10px 18px;background:var(--purple);color:#fff;border-radius:8px;font-weight:600;text-decoration:none">貢獻者收集頁</a>
-        <a href="../testset/list.html" style="display:inline-block;padding:10px 18px;background:var(--chip);color:var(--purple);border-radius:8px;font-weight:600;text-decoration:none;border:1px solid var(--purple)">owner 現況表</a>
-      </div>
+    <div class="card" style="border-left:4px solid var(--green);padding:0;overflow:hidden">
+      <iframe src="../testset/list.html" title="測試集現況表" style="width:100%;height:820px;border:0;display:block;background:#fff"></iframe>
     </div>
     <div class="card">
       <h3>收集 SOP（陌生人視角，每人 ~30 分）</h3>

--- a/frontend/public/testset/record.html
+++ b/frontend/public/testset/record.html
@@ -44,8 +44,8 @@
   .ok{color:var(--green);font-weight:700}
   .err{color:var(--red)}
   .done-banner{background:#dcfce7;border:1px solid var(--green);border-radius:10px;padding:16px;text-align:center;color:var(--green);font-weight:700;font-size:1.05rem;display:none}
-  .progress-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
-  .prog-item{display:flex;align-items:center;gap:8px;font-size:.88rem}
+  .progress-grid{display:flex;flex-direction:column;gap:8px;margin-top:8px}
+  .prog-item{display:flex;align-items:center;gap:10px;font-size:.95rem;padding:10px 14px;background:#faf7f0;border:1px solid var(--line);border-radius:8px}
   .dot{width:14px;height:14px;border-radius:50%;background:#ddd;flex-shrink:0}
   .dot.done{background:var(--green)}
   .prog-play{margin-left:auto;background:#fff;border:1px solid var(--purple);color:var(--purple);border-radius:6px;padding:2px 9px;font-size:.74rem;font-weight:600;cursor:pointer;white-space:nowrap}

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -194,8 +194,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     needsStory: true,
     enabled: true,
     category: 'comprehension',
-    navEmphasis: true,
-    navShortLabel: '聚光燈',
+    // navEmphasis 移除（Young 2026-06-21）：原本 #2192 讓聚光燈用 💡+放大+紫框，
+    // 跟其他步單字灰圈不一致 → 統一成 displayChar '光' 灰圈。findability 若要再加用顏色非換 icon。
   },
   'sentence-practice': {
     id: 'sentence-practice',


### PR DESCRIPTION
## Release staging → main（4 commits）
- #2349 聚光燈 stepper icon 統一（💡→「光」灰圈，跟其他步一致）
- #2350 測試集 tab 直接嵌入 list.html 現況表（取代外連按鈕）
- #2351 record「我的進度」改 1 欄整齊卡片行（取代 2 欄擠壓）
- #2352 G4-L2 聚光燈第二練習文標題正規化 〈𪹚龍慶元宵〉

## Verify（各 PR 已 staging 驗）
- icon：lightbulb DOM 數=0、改後截圖「光」灰圈
- embed：iframe 內 h1=測試集收集現況、165 課 row
- UIUX：flex column 1 欄卡片行截圖
- G4-L2：yaml 有效、無 < 殘留、run-ci registry OK
- 全 frontend/data，無 CI/deploy 變動

> 🤖 由 Claude AI 代發（非 Young 本人）