### PR TITLE
feat(testset): recordings 公開顯示貢獻者暱稱 + 刪收集 SOP

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -201,13 +201,12 @@ def testset_progress(name: str = "", lesson: str = ""):
 
 
 @router.get("/testset/recordings")
-def testset_recordings(current_user: User = Depends(get_current_user)):
+def testset_recordings():
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
 
-    任何登入者可看（Young 2026-06-21：先不限 admin/teacher）。仍需登入，
-    擋匿名公開抓取貢獻者 PII（名字/年級/可播放錄音）。list.html 讀 localStorage
-    `lingoleap_token` 帶 Bearer；未登入 → 401。
-    （v2 若要全公開或收回 admin-only 再調；codex #2304 的 role gate 暫移除。）
+    公開（Young 2026-06-21：不需登入即顯示貢獻者暱稱/數量）。暱稱為自選暱稱、
+    朗讀公開課文，非敏感 PII；list.html 現況表不登入就能看到誰貢獻了哪幾課。
+    （此前曾 admin/teacher → 任何登入者 → 現全公開。）
     """
     bucket = _get_gcs_bucket()
     if bucket is None:

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -364,20 +364,6 @@
     <div class="card" style="border-left:4px solid var(--green);padding:0;overflow:hidden">
       <iframe src="../testset/list.html" title="測試集現況表" style="width:100%;height:820px;border:0;display:block;background:#fff"></iframe>
     </div>
-    <div class="card">
-      <h3>收集 SOP（陌生人視角，每人 ~30 分）</h3>
-      <ol>
-        <li>落地頁：為什麼錄、要做什麼、多久</li>
-        <li>輸入名字（輕量、無登入；列為貢獻者留名）</li>
-        <li>看指派課文：依年級難度分級（國小只看國小）</li>
-        <li>點開一篇 → 課文全文顯示，照念</li>
-        <li>錄 2 版本：正確 + 刻意錯漏（每人 3 篇×2=6 段）</li>
-        <li>上傳 → 可回放確認</li>
-        <li>進度 grid：哪些課文×(正確/錯誤)已上傳打勾</li>
-        <li>全部完成 → 致謝 + 留名</li>
-      </ol>
-      <p class="legend">存放：GCS <code>lingoleap-reading-audio</code> prefix <code>test-dataset/{貢獻者}/{課文}/{correct|error}.webm</code>（不跟學生 attempt 混）。第一批靖杭/方大哥開箱。</p>
-    </div>
   </div>
 
   <!-- DEBT -->

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -149,22 +149,17 @@ async function load(){
     return;
   }
 
-  // 2. recordings — requires teacher/admin Bearer token
+  // 2. recordings — 公開端點（Young 2026-06-21：不登入也顯示貢獻者暱稱/數量）
   var recs=[];
   var authOk=false;
   try{
     var token=localStorage.getItem('lingoleap_token');
-    if(token){
-      var r2=await fetch(API+'/api/testset/recordings',{headers:{'Authorization':'Bearer '+token}});
-      if(r2.status===401||r2.status===403){
-        document.getElementById('authBanner').style.display='block';
-      } else if(r2.ok){
-        var j2=await r2.json();
-        recs=j2.recordings||[];
-        authOk=true;
-      }
-    } else {
-      document.getElementById('authBanner').style.display='block';
+    var headers=token?{'Authorization':'Bearer '+token}:{};
+    var r2=await fetch(API+'/api/testset/recordings',{headers:headers});
+    if(r2.ok){
+      var j2=await r2.json();
+      recs=j2.recordings||[];
+      authOk=true;
     }
   }catch(e){
     // recordings optional
@@ -222,7 +217,7 @@ async function load(){
     h+='<td><div class="lesson-title">'+esc(s.title)+'</div><div class="lesson-id">'+esc(id)+'</div></td>';
     h+='<td><span class="pill '+(correctList.length?'some':'zero')+'">'+correctList.length+'</span></td>';
     h+='<td><span class="pill '+(errorList.length?'some':'zero')+'">'+errorList.length+'</span></td>';
-    h+='<td>'+(authOk?(contribs.length?('<span title="'+esc(contribs.join('、'))+'">'+esc(contribs.length+' 人')+'</span>'):'<span class="muted">—</span>'):'<span class="muted">需登入</span>')+'</td>';
+    h+='<td>'+(contribs.length?('<span title="'+esc(contribs.join('、'))+'">'+esc(contribs.join('、'))+'</span>'):'<span class="muted">—</span>')+'</td>';
     h+='<td>'+aiCell(id)+'</td>';
     h+='<td><div class="action-cell">'+
       '<button class="copy-btn" onclick="copyLink(this,\''+esc(url)+'\')">複製連結</button>'+


### PR DESCRIPTION
Young 回饋（貢獻者欄顯示「需登入」、自己貢獻看不到）：
- `/testset/recordings` 改公開（移除登入）→ 不登入即顯示貢獻者暱稱/數量/聽取
- list.html 永遠抓 recordings + 貢獻者欄直接顯示暱稱
- reading-pipeline 測試集 tab 刪「收集 SOP」card
py_compile OK；無 recordings auth 測試。
Related to #2287
> 🤖 由 Claude AI 代發（非 Young 本人）