### PR TITLE
fix(reading): opaque mic-error banner + larger font (Fixes #2357)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -392,8 +392,8 @@ const FullReading: React.FC<FullReadingProps> = ({
             <div className="mt-6 flex items-start gap-3 px-5 py-4 rounded-2xl bg-amber-50 border border-amber-300 shadow-sm">
               <span className="material-symbols-outlined text-amber-600 shrink-0 mt-0.5">warning</span>
               <div className="flex-1">
-                <p className="text-sm font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
-                <p className="text-xs text-amber-700 mt-0.5">
+                <p className="text-base font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
+                <p className="text-sm text-amber-700 mt-0.5">
                   AI 音訊分析未能完成（{fallbackReason}），評分僅依瀏覽器語音辨識，準確度較低。建議重試以獲得精準評分。
                 </p>
               </div>
@@ -475,10 +475,13 @@ const FullReading: React.FC<FullReadingProps> = ({
         </div>
       </div>
 
-      {/* Mic error */}
+      {/* Mic error — Issue #2357: opaque banner, not transparent pill overlapping passage */}
       {micError && (
-        <div className="absolute bottom-52 left-1/2 -translate-x-1/2 px-5 py-2 bg-tertiary-container/20 rounded-full z-20">
-          <span className="text-sm text-tertiary">{micError}</span>
+        <div className="mt-4 flex items-start gap-3 px-5 py-4 rounded-2xl bg-rose-50 border border-rose-300 shadow-sm">
+          <span className="material-symbols-outlined text-rose-600 shrink-0 mt-0.5">mic_off</span>
+          <div className="flex-1">
+            <p className="text-base font-bold text-rose-800">{micError}</p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -759,8 +759,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           <div className="flex items-start gap-3 px-4 py-3 rounded-2xl bg-amber-50 border border-amber-300 shadow-md">
             <span className="material-symbols-outlined text-amber-600 shrink-0">warning</span>
             <div className="flex-1">
-              <p className="text-sm font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
-              <p className="text-xs text-amber-700 mt-0.5">
+              <p className="text-base font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
+              <p className="text-sm text-amber-700 mt-0.5">
                 AI 音訊分析未能完成（{paragraphFallbackReason}），評分依瀏覽器語音辨識，準確度較低。建議重試此段。
               </p>
             </div>

--- a/frontend/src/components/reading-steps/live-tutor/TutorFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/TutorFeedbackPanel.tsx
@@ -106,10 +106,11 @@ const TutorFeedbackPanel: React.FC<TutorFeedbackPanelProps> = ({
 
       </div>
 
-      {/* Mic error */}
+      {/* Mic error — Issue #2357: promote to opaque banner with icon */}
       {micError && (
-        <div className="flex-shrink-0 px-4 py-2 bg-rose-50 border-t border-rose-100">
-          <span className="text-xs text-rose-500">{micError}</span>
+        <div className="flex-shrink-0 mx-4 mb-3 flex items-center gap-3 px-4 py-3 rounded-2xl bg-rose-50 border border-rose-300 shadow-sm">
+          <span className="material-symbols-outlined text-rose-600 shrink-0">mic_off</span>
+          <p className="text-base font-bold text-rose-800">{micError}</p>
         </div>
       )}
     </div>


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2357

## Summary

- **FullReading.tsx** — remove absolute-positioned semi-transparent pill (`bg-tertiary-container/20`) that overlapped passage text; replace with in-flow rose banner matching the amber fallback banner style (opaque background, icon, bold text-base)
- **TutorFeedbackPanel.tsx** — replace `text-xs text-rose-500` inline text with rose opaque banner, same structure
- **FullReading.tsx + LiveTutor.tsx** — amber fallback banner title `text-sm` → `text-base`, body `text-xs` → `text-sm` (字要大一點)

## Test plan

- [ ] `npm run lint` — 0 errors (21 pre-existing warnings, unchanged)
- [ ] `npm run test` (render-smoke) — 13/13 passed
- [ ] Preview deploy: check full-reading page and tutor page with mic error state