### PR TITLE
release: dashboard 每課跑分鈕 + QA 表白話化（含很差）(staging→main)

### DIFF
--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -345,18 +345,18 @@
     <table>
       <thead><tr><th>QA 細目</th><th>flow 階段</th><th>驗證方式</th><th>現況</th><th>證據</th><th>需測試集?</th></tr></thead>
       <tbody>
-        <tr><td>逐段朗讀頁 render（mount 不白屏）</td><td>①錄音/⑤顯示</td><td>vitest smoke + /qa console</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2284">#2284</a></td><td>—</td></tr>
-        <tr><td>全文朗讀頁 render</td><td>①錄音/⑤顯示</td><td>vitest smoke + /qa console</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a></td><td>—</td></tr>
-        <tr><td>評分正確率（deterministic 對齊）</td><td>③評分</td><td>方大哥真錄音 staging 重算</td><td>✅ 98.1%</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2274">#2274</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2266">#2266</a></td><td>—</td></tr>
-        <tr><td>同音/近音字寬容</td><td>④優化</td><td>spec 契約測試</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2266">#2266</a></td><td>—</td></tr>
-        <tr><td>後送儲存（評估=存、取消/重錄不存）</td><td>⑥儲存</td><td>spec + curl /reading/save-audio</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">#2299</a></td><td>—</td></tr>
-        <tr><td>回放（學生/老師 signed URL + IDOR）</td><td>回放</td><td>curl 401/403/200 + 老師端鈕</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2283">#2283</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2286">#2286</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2327">#2327</a></td><td>—</td></tr>
-        <tr><td>靜音偽陽性 gate（不出聲不送評分）</td><td>②辨識前</td><td>能量門檻 + duration gate；行為需真機</td><td>🟡 待真機</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2321">#2321</a></td><td>—</td></tr>
-        <tr><td>STT 字準率（真實童音）</td><td>②辨識</td><td>真人朗讀樣本 × 課文 diff CER</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
-        <tr><td>評分準度（真實童音 across 課文）</td><td>③評分</td><td>真人樣本 × 正確/錯誤版 對照</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
+        <tr><td>逐段朗讀頁 render（mount 不白屏）</td><td>①錄音/⑤顯示</td><td><b>原則</b>：頁面一定要畫得出來、不白屏。<br><b>方法</b>：vitest 自動 mount 每個元件不報錯 + /qa 開實際頁看 console 乾淨。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2284">#2284</a></td><td>—</td></tr>
+        <tr><td>全文朗讀頁 render</td><td>①錄音/⑤顯示</td><td><b>原則</b>：同上，全文朗讀頁也要正常 render。<br><b>方法</b>：vitest smoke + /qa console。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a></td><td>—</td></tr>
+        <tr><td>評分正確率（deterministic 對齊）</td><td>③評分</td><td><b>原則</b>：機器算的分數要跟人工核對一致，<b>且涵蓋全範圍——念得好、普通、很差都要對齊</b>（好的接近高分、很差的接近 0）。<br><b>方法</b>：拿真人錄音（含刻意念很差的）在 staging 重算，比對「該得的比例」，太高太低都算 fail。</td><td>✅ 98.1%</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2274">#2274</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2266">#2266</a></td><td>—</td></tr>
+        <tr><td>同音/近音字寬容</td><td>④優化</td><td><b>原則</b>：發音對但字不同（同音/近音字）不該扣分。<br><b>方法</b>：spec 契約測試用固定案例驗，確保寬容規則不退化。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2266">#2266</a></td><td>—</td></tr>
+        <tr><td>後送儲存（評估=存、取消/重錄不存）</td><td>⑥儲存</td><td><b>原則</b>：只存學生按了「評估」且接受的那段，分數先顯示才後送上傳。<br><b>方法</b>：spec + curl 打 /reading/save-audio 看行為與守門。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">#2299</a></td><td>—</td></tr>
+        <tr><td>回放（學生/老師 signed URL + IDOR）</td><td>回放</td><td><b>原則</b>：只有本人/老師能聽，連結 10 分鐘過期。<br><b>方法</b>：curl 帶不同身分看 401/403/200 + 老師端鈕；簽名改走 IAM SignBlob 後 prod 實證 HTTP 200。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2283">#2283</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2327">#2327</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2344">#2344</a></td><td>—</td></tr>
+        <tr><td>靜音偽陽性 gate（不出聲不送評分）</td><td>②辨識前</td><td><b>原則</b>：沒出聲就不該送評分、更不該假性通過（最危險的沉默失敗）。<br><b>方法</b>：音量能量 + 錄音時長門檻先擋；轉錄端再擋幻覺前綴；完整行為需真機麥克風測。</td><td>🟡 待真機</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a></td><td>—</td></tr>
+        <tr><td>STT 字準率（真實童音）</td><td>②辨識</td><td><b>原則</b>：機器聽寫要跟學生實際念的吻合，尤其真實童音（口齒不清/方言腔）。<br><b>方法</b>：收真人朗讀樣本，逐字跟課文比對算「字錯率 CER」。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
+        <tr><td>評分準度（真實童音 across 課文）</td><td>③評分</td><td><b>原則</b>：好的高分、普通中等、<b>很差的接近 0</b>，分數要拉得開、跨課文都穩。<br><b>方法</b>：真人多版本（正確版 / 錯誤版 / <b>很差版</b>）跑批次評分，比對各自該落的分數帶。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
       </tbody>
     </table>
-    <p style="font-size:.82rem;color:var(--muted);margin-top:10px">⏳ 兩列「真實童音」的量化驗證靠<b>人聲測試集</b>：<a href="../testset/index.html">貢獻者收集頁</a> · <a href="../testset/list.html">owner 現況表</a>。每位貢獻者讀 3 篇×(正確版+錯誤版)，存 GCS <code>test-dataset/</code>。樣本足夠後這兩列填入 per-課 CER/正確率。</p>
+    <p style="font-size:.82rem;color:var(--muted);margin-top:10px">⏳ 兩列「真實童音」量化驗證靠<b>人聲測試集</b>（見上方④測試集 tab，內嵌現況表）：每課收正確版 + 錯誤版（含念很差的），按貢獻者暱稱分組存 GCS <code>test-dataset/</code>；在現況表點各課「跑分」即跑批次評分對照期望。樣本足夠後這兩列填入 per-課 CER / 正確率。</p>
   </div>
 
   <!-- TESTSET -->

--- a/frontend/public/testset/list.html
+++ b/frontend/public/testset/list.html
@@ -48,6 +48,11 @@
   .ai-tools{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:10px 0}
   .ai-run-btn{background:var(--purple,#5B4FC4);color:#fff;border:none;border-radius:8px;padding:8px 16px;font:inherit;font-weight:700;cursor:pointer}
   .ai-run-btn:disabled{opacity:.5;cursor:not-allowed}
+  .ai-row-btn{background:#fff;border:1px solid var(--purple,#5B4FC4);color:var(--purple,#5B4FC4);border-radius:6px;padding:3px 10px;font:inherit;font-size:.78rem;font-weight:700;cursor:pointer;white-space:nowrap;margin-top:4px}
+  .ai-row-btn:hover{background:var(--chip,#efe9ff)}
+  .ai-score .ok{color:#15803d}
+  .ai-score .lo{color:#b45309}
+  .ai-score .anom{color:#dc2626}
   .ai-status{font-size:.85rem;font-weight:600}
   .ai-score{display:inline-block;font-size:.78rem;line-height:1.5;white-space:nowrap}
   .ai-score .ok{color:#15803d;font-weight:700}
@@ -89,14 +94,20 @@ var aiResults={};  // lesson_id → {correct:adj|null, error:adj|null, anomaly:b
 
 function pct(v){ return v==null?'—':(Math.round(v*1000)/10)+'%'; }
 
-function aiCell(id){
+function aiCell(id, hasRec){
   var r=aiResults[id];
-  if(!r) return '<span class="ai-badge">待對應</span>';
-  var parts=[];
-  if(r.correct!=null) parts.push('<span class="'+(r.correct>=0.8?'ok':'anom')+'">正 '+pct(r.correct)+'</span>');
-  if(r.error!=null)   parts.push('<span class="'+(r.error<0.8?'lo':'anom')+'">誤 '+pct(r.error)+'</span>');
-  if(!parts.length) return '<span class="ai-badge">待對應</span>';
-  return '<span class="ai-score">'+parts.join('<br>')+(r.anomaly?' ⚠':'')+'</span>';
+  if(r&&r.running) return '<span class="muted">跑分中…</span>';
+  if(r&&(r.correct!=null||r.error!=null)){
+    var parts=[];
+    if(r.correct!=null) parts.push('<div class="'+(r.correctFlag?'anom':'ok')+'">正確版 '+pct(r.correct)+(r.correctFlag?' ⚠':' ✓')+'</div>');
+    if(r.error!=null)   parts.push('<div class="'+(r.errorFlag?'anom':'lo')+'">錯誤版 '+pct(r.error)+(r.errorFlag?' ⚠':' ✓')+'</div>');
+    var both=(r.correct!=null&&!r.correctFlag)&&(r.error!=null&&!r.errorFlag);
+    var verdict=(r.correct!=null&&r.error!=null)?('<div style="font-weight:700;margin-top:2px" class="'+(both?'ok':'anom')+'">'+(both?'✅ 兩版都 pass':'⚠ 有異常')+'</div>'):'';
+    return '<div class="ai-score">'+parts.join('')+verdict+'<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重跑</button></div>';
+  }
+  if(r&&r.err) return '<span class="anom">失敗</span> <button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重試</button>';
+  if(hasRec) return '<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">▶ 跑分</button>';
+  return '<span class="ai-badge">待對應</span>';
 }
 
 function recordUrl(lessonId){
@@ -218,7 +229,7 @@ async function load(){
     h+='<td><span class="pill '+(correctList.length?'some':'zero')+'">'+correctList.length+'</span></td>';
     h+='<td><span class="pill '+(errorList.length?'some':'zero')+'">'+errorList.length+'</span></td>';
     h+='<td>'+(contribs.length?('<span title="'+esc(contribs.join('、'))+'">'+esc(contribs.join('、'))+'</span>'):'<span class="muted">—</span>')+'</td>';
-    h+='<td>'+aiCell(id)+'</td>';
+    h+='<td id="aicell-'+esc(id)+'">'+aiCell(id, allRecs.length>0)+'</td>';
     h+='<td><div class="action-cell">'+
       '<button class="copy-btn" onclick="copyLink(this,\''+esc(url)+'\')">複製連結</button>'+
       '<a class="open-btn" href="'+esc(url)+'" target="_blank">開啟</a>'+
@@ -270,12 +281,7 @@ async function runAiEval(){
     if(!r.ok) throw new Error('HTTP '+r.status);
     var d=await r.json();
     aiResults={};
-    (d.results||[]).forEach(function(x){
-      var e=aiResults[x.lesson]=aiResults[x.lesson]||{correct:null,error:null,anomaly:false};
-      if(x.version==='correct') e.correct=x.adjusted_match_rate;
-      else if(x.version==='error') e.error=x.adjusted_match_rate;
-      if(x.flag) e.anomaly=true;
-    });
+    (d.results||[]).forEach(function(x){ applyAiResult(x); });
     var sm=d.summary||{};
     st.textContent='完成：'+(d.n||0)+' 筆 · 異常 '+(sm.anomaly_count||0)+(d.truncated?'（達單次上限 30，僅評前 30）':'');
     await load();
@@ -284,6 +290,34 @@ async function runAiEval(){
   }finally{
     btn.disabled=false;
   }
+}
+
+// 把一筆 batch-eval result 套進 aiResults（correct/error 各自分數 + 是否符合期望 flag）
+function applyAiResult(x){
+  var e=aiResults[x.lesson]=aiResults[x.lesson]||{correct:null,error:null,correctFlag:false,errorFlag:false};
+  if(x.version==='correct'){ e.correct=x.adjusted_match_rate; e.correctFlag=!!x.flag; }
+  else if(x.version==='error'){ e.error=x.adjusted_match_rate; e.errorFlag=!!x.flag; }
+  delete e.running; delete e.err;
+}
+
+// 單課跑分（Image #8：點某課 → 跑該課正確/錯誤版 → 顯示分數 + 兩版是否都 pass）
+async function runAiEvalForLesson(id){
+  var token=localStorage.getItem('lingoleap_token');
+  aiResults[id]={running:true}; rerenderAiCell(id);
+  try{
+    var headers=token?{'Authorization':'Bearer '+token}:{};
+    var r=await fetch(API+'/api/testset/batch-eval?lesson='+encodeURIComponent(id),{method:'POST',headers:headers});
+    if(!r.ok) throw new Error('HTTP '+r.status);
+    var d=await r.json();
+    aiResults[id]={correct:null,error:null,correctFlag:false,errorFlag:false};
+    (d.results||[]).forEach(function(x){ if(String(x.lesson)===String(id)) applyAiResult(x); });
+  }catch(e){ aiResults[id]={err:true}; }
+  rerenderAiCell(id);
+}
+
+function rerenderAiCell(id){
+  var td=document.getElementById('aicell-'+id);
+  if(td) td.innerHTML=aiCell(id, true);
 }
 
 load();


### PR DESCRIPTION
## Release staging → main（1 commit）
- #2360 dashboard AI判斷 per-row「▶ 跑分」鈕（點該課 → 正確版分/錯誤版分/兩版是否都 pass，可重跑）+ QA 表驗證方式白話化（原則+方法）+ 評分列涵蓋「很差的」

## Verify（staging 實證）
- 點 L1 跑分 → 正確版 96% ✓ / 錯誤版 35.3% ✓ / ✅ 兩版都 pass（Young 真人聲）
- QA tab：每列原則+方法 + 很差；0 SyntaxError；E2E/audits 綠
- 無 CI/deploy 變動

> 🤖 由 Claude AI 代發（非 Young 本人）