### PR TITLE
release: 錄音驗證 layer ①.5（逐段也擋靜音）(staging→main)

### DIFF
--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -209,6 +209,16 @@
 
       <div class="arrow">▼</div>
 
+      <!-- ①.5 錄音驗證 (Issue #2362) -->
+      <div class="node-row">
+        <div class="node-text">
+          <div class="t">①.5 錄音驗證 <span class="side">前端</span></div>
+          <div class="s">validateRecording() — 能量(peak &lt; 0.05) / 時長(&lt; 1500 ms) 驗證，沒語音不進 STT；逐段(LiveTutor) + 全文(FullReading) 共用同一函式（recordingValidation.ts）</div>
+        </div>
+      </div>
+
+      <div class="arrow">▼</div>
+
       <!-- ② 辨識STT -->
       <div class="node-row">
         <div class="node-text">

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -8,6 +8,7 @@ import { useLiveTutorSpeech } from '../../../hooks/useLiveTutorSpeech';
 import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 import { useAudioRecorder } from '../../../hooks/useAudioRecorder';
 import { transcribeReading, saveReadingAudio } from '../../../services/learning/session';
+import { validateRecording } from '../../../utils/recordingValidation';
 import { useAuth } from '../../../contexts/AuthContext';
 import { splitIntoSentences } from '../../../utils/localEval';
 import { normalizePunctuationToChinese } from '../../../utils/textDiff';
@@ -420,6 +421,18 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         let transcriptSource: 'gemini' | 'webspeech' = 'webspeech';
 
         if (audioBlob && token) {
+          /* Issue #2362 — Silence gate (①.5, frontend): shared with FullReading.
+           * Validate peak volume + duration before sending to STT.
+           * ok:false → show banner via existing micError path, skip transcribeReading. */
+          const silenceCheck = validateRecording({
+            peakVolume: paragraphRecorder.getPeakVolume(),
+            durationMs,
+          });
+          if (!silenceCheck.ok) {
+            setMicError('未偵測到語音，請重試。');
+            return;   // finally{} resets isSubmittingSentenceRef + state
+          }
+
           const targetText = story.content[currentLineIndex] || '';
           try {
             const result = await transcribeReading(audioBlob, targetText, durationMs, token);
@@ -467,6 +480,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     story.content,
     clearParagraphFallback,
     setParagraphFallbackReason,
+    paragraphRecorder.getPeakVolume,
+    setMicError,
   ]);
 
   // ── handleRetryParagraph ─────────────────────────────────────────────────

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -20,23 +20,10 @@ import { useAudioRecorder } from './useAudioRecorder';
 import { cancelTts } from '../services/ttsApi';
 import { saveReadingHistory } from '../services/readingHistoryApi';
 import { transcribeReading, saveReadingAudio } from '../services/learning/session';
+import { validateRecording } from '../utils/recordingValidation';
 
-/**
- * Issue #2321 — Silence gate constants.
- *
- * SILENT_PEAK_THRESHOLD: peak volume (0-1) below which we consider the recording
- * silent.  The AnalyserNode returns average byte frequency; 0.05 corresponds to
- * ~6.4/128 — well below conversational speech (~0.15-0.4) but above true silence.
- * Conservative: a very soft whisper may still exceed this threshold, which is
- * intentional — we prefer the occasional STT hallucination over blocking a
- * real-but-quiet reader.
- *
- * SILENT_MIN_DURATION_MS: minimum recording duration below which we skip STT.
- * 1 500 ms is comfortably longer than an accidental tap but shorter than even
- * a single Chinese syllable at slow reading speed (~300-400 ms).
- */
-const SILENT_PEAK_THRESHOLD = 0.05;   // gate: peak volume must exceed this
-const SILENT_MIN_DURATION_MS = 1500;  // gate: recording must be at least 1.5 s
+// Issue #2362: SILENT_PEAK_THRESHOLD and SILENT_MIN_DURATION_MS are now the
+// single source of truth in recordingValidation.ts — imported via validateRecording().
 
 /**
  * Issue #2321 — Hallucination sanity gate for FullReading scoring.
@@ -200,15 +187,17 @@ export function useFullReadingSession({
       return;
     }
 
-    /* Issue #2321 — Silence gate (Gate 1, frontend):
+    /* Issue #2321 / #2362 — Silence gate (Gate 1, frontend):
+     * Shared validateRecording() — same constants as LiveTutor.
      * If the recording was too short OR entirely silent, skip STT to prevent
      * Gemini from hallucinating the lesson text back when given a blank audio.
      * Uses peakVolume tracked by useAudioRecorder's AnalyserNode loop.
      * Reuses the existing micError path — no new UI component needed. */
-    const peakVolume = audioRecorder.getPeakVolume();
-    const isSilentByVolume = peakVolume < SILENT_PEAK_THRESHOLD;
-    const isTooShort = durationMs < SILENT_MIN_DURATION_MS;
-    if (isSilentByVolume || isTooShort) {
+    const silenceCheck = validateRecording({
+      peakVolume: audioRecorder.getPeakVolume(),
+      durationMs,
+    });
+    if (!silenceCheck.ok) {
       setMicError('未偵測到語音，請重試。');
       return;
     }

--- a/frontend/src/utils/recordingValidation.ts
+++ b/frontend/src/utils/recordingValidation.ts
@@ -1,0 +1,57 @@
+/**
+ * recordingValidation.ts — Issue #2362
+ *
+ * Shared "①.5 Recording Validation" layer that sits between ① Recording and
+ * ② STT Transcription for BOTH LiveTutor (per-paragraph) and FullReading
+ * (full text).
+ *
+ * Previously the silence gate existed only in useFullReadingSession.ts (#2321).
+ * LiveTutor had no front-end guard and sent silent audio straight to Gemini,
+ * allowing hallucinations to pass the hallucination-prefix backend gate
+ * (which only fires when transcript ≥ 35% length of target).
+ *
+ * Constants are the single source of truth; both hooks import from here.
+ */
+
+/** Peak volume (0–1) from AnalyserNode below which we consider the recording silent.
+ *  0.05 ≈ 6.4 / 128 byte value — well below conversational speech (~0.15–0.4)
+ *  but above true digital silence.  Conservative so we do not block soft readers. */
+export const SILENT_PEAK_THRESHOLD = 0.05;
+
+/** Minimum recording duration (ms) below which we skip STT.
+ *  1 500 ms is longer than an accidental tap but shorter than a single Chinese
+ *  syllable at slow reading pace (~300–400 ms per character × 1 character). */
+export const SILENT_MIN_DURATION_MS = 1500;
+
+export type ValidationFailReason = 'silent' | 'too_short';
+
+export interface RecordingValidationResult {
+  ok: boolean;
+  reason: ValidationFailReason | null;
+}
+
+/**
+ * Validate a completed recording before sending it to STT.
+ *
+ * Returns { ok: true, reason: null } if the recording appears to contain speech.
+ * Returns { ok: false, reason: 'silent' | 'too_short' } otherwise.
+ *
+ * @param opts.peakVolume  - peak volume (0–1) from audioRecorder.getPeakVolume()
+ * @param opts.durationMs  - actual recording duration in milliseconds
+ */
+export function validateRecording(opts: {
+  peakVolume: number;
+  durationMs: number;
+}): RecordingValidationResult {
+  const { peakVolume, durationMs } = opts;
+
+  if (durationMs < SILENT_MIN_DURATION_MS) {
+    return { ok: false, reason: 'too_short' };
+  }
+
+  if (peakVolume < SILENT_PEAK_THRESHOLD) {
+    return { ok: false, reason: 'silent' };
+  }
+
+  return { ok: true, reason: null };
+}


### PR DESCRIPTION
## Release staging → main（1 commit）
- #2363（Fixes #2362）共用「錄音驗證」layer ①.5：抽 validateRecording（peak<0.05 / 時長<1500 擋）；逐段(LiveTutor)送 STT 前也驗（補前端 gap）；全文 refactor 共用；架構圖加 ①.5 node。從源頭擋 #2321 靜音幻覺。

## Verify（staging 已驗）
- lint 0 / vitest 13/13 / E2E pass；①.5 node staging live
- 真機靜音行為交啟翔；無 CI/deploy 變動

> 🤖 由 Claude AI 代發（非 Young 本人）