### PR TITLE
release: staging→main — 靜音/噪音 STT 幻覺修復 (#2368) + 看板

### DIFF
--- a/backend/app/services/reading_transcription_service.py
+++ b/backend/app/services/reading_transcription_service.py
@@ -85,6 +85,18 @@ _REASON_SAFETY    = "safety"
 _REASON_EMPTY     = "empty"
 _REASON_ERROR     = "error"
 _REASON_HALLUCINATION = "hallucination"  # Issue #2321 — Gemini hallucinated hint text
+_REASON_SILENT = "silent"                # Issue #2368 — deterministic no-speech energy gate
+
+# Issue #2368 — server-side silence / energy gate.
+# Gemini parrots the FULL reference text on silent / no-speech audio (it is given
+# target_text as a homophone hint), and the length-based hallucination gate below
+# only catches SHORT prefixes — a full-text parrot slips through as a false ~100%.
+# Measured peak (ffmpeg volumedetect max_volume):
+#   digital silence ≈ -inf   ·  440 Hz tone ≈ -18 dB
+#   white noise     ≈ -3.5 dB·  child speech ≈ -10 … -30 dB
+# -45 dB is well below the softest real reading but above true / near silence,
+# so it rejects silence without blocking soft readers.
+_SILENT_MAX_VOLUME_DB = -45.0
 
 
 def _normalise_mime(raw: str) -> str:
@@ -139,6 +151,59 @@ def _needs_transcode(mime_type: str) -> bool:
     """Return True if the MIME type is NOT natively accepted by Gemini."""
     base = _normalise_mime(mime_type)
     return base not in _GEMINI_NATIVE_AUDIO_MIMES
+
+
+def _max_volume_db(audio_bytes: bytes, source_mime: str) -> float | None:
+    """Return peak (max) volume in dBFS via ffmpeg `volumedetect`.
+
+    Issue #2368 — deterministic silence gate run BEFORE STT.  ffmpeg can decode
+    every browser MediaRecorder container directly, so we measure the raw bytes
+    without transcoding first.
+
+    Returns:
+        - a negative float (e.g. -3.5) for audio with sound
+        - float('-inf') for true digital silence
+        - None if ffmpeg fails or the level cannot be parsed (caller fails open —
+          STT + the downstream hallucination gate still apply).
+    """
+    import re
+
+    base = _normalise_mime(source_mime)
+    ext = {
+        "audio/webm": ".webm",
+        "audio/ogg":  ".ogg",
+        "audio/mp4":  ".mp4",
+        "audio/mpeg": ".mp3",
+        "audio/wav":  ".wav",
+    }.get(base, ".audio")
+
+    in_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as in_f:
+            in_f.write(audio_bytes)
+            in_path = in_f.name
+
+        result = subprocess.run(
+            ["ffmpeg", "-i", in_path, "-af", "volumedetect", "-f", "null", "-"],
+            capture_output=True,
+            timeout=20,
+        )
+        stderr = result.stderr or b""
+        m = re.search(rb"max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB", stderr)
+        if m:
+            return float(m.group(1))
+        # ffmpeg emits no max_volume line for empty/-inf audio streams.
+        if b"-inf dB" in stderr or b"mean_volume" in stderr:
+            return float("-inf")
+        return None
+    except Exception:  # noqa: BLE001 — fail open; downstream gates still apply
+        return None
+    finally:
+        if in_path and os.path.exists(in_path):
+            try:
+                os.unlink(in_path)
+            except OSError:
+                pass
 
 
 def _transcode_to_ogg(audio_bytes: bytes, source_mime: str) -> bytes | None:
@@ -244,6 +309,28 @@ async def transcribe_reading_audio(
     from .ai.gemini_client import GEMINI_TIMEOUT
     from .llm_models import get_model_for_task
 
+    # ── 0. Deterministic silence gate (Issue #2368) ───────────────────────────
+    # Gemini parrots the FULL reference text on silent audio (it gets target_text
+    # as a hint); the length-based hallucination gate below only catches SHORT
+    # prefixes, so a full parrot would pass as a false ~100%.  Reject effectively
+    # silent audio here — before transcode + STT — independent of Gemini.
+    max_db = await asyncio.to_thread(_max_volume_db, audio_bytes, mime_type)
+    if max_db is not None and max_db < _SILENT_MAX_VOLUME_DB:
+        logger.warning(
+            "Reading transcription fallback — silent audio: max_volume=%.1f dB "
+            "(< %.1f) duration_ms=%s",
+            max_db,
+            _SILENT_MAX_VOLUME_DB,
+            duration_ms,
+            extra={
+                "event": "reading_transcribe_fallback",
+                "reason": _REASON_SILENT,
+                "max_volume_db": max_db,
+                "duration_ms": duration_ms,
+            },
+        )
+        return {"transcript": None, "method": "fallback", "reason": _REASON_SILENT}
+
     # ── 1. Transcode if Gemini doesn't natively support the input MIME ─────────
     gemini_audio_bytes = audio_bytes
     gemini_mime = "audio/ogg"  # default after transcode
@@ -276,11 +363,16 @@ async def transcribe_reading_audio(
         "你是一個繁體中文語音轉錄系統，專門轉錄台灣國小至國中學生的朗讀音檔。\n"
         "任務：將學生朗讀的音檔逐字轉錄成繁體中文文字，並加入正確標點符號。\n"
         "規則：\n"
-        "1. 以提供的課文原文（reference text）為基準，校正同音字、近音字。\n"
-        "2. 輸出必須忠實反映學生實際唸出的字（不要補字或修正未唸出的字）。\n"
-        "3. 在 transcript 中加入中文標點（。，！？……），以課文原文為準。\n"
+        "1. 課文原文（reference text）只用於校正同音字、近音字——"
+        "嚴禁直接把課文原文當成轉錄結果輸出。\n"
+        "2. 輸出必須忠實反映學生實際唸出的字（不要補字、不要修正未唸出的字、"
+        "不要把沒聽到的句子補進來）。\n"
+        "3. 在 transcript 中加入中文標點（。，！？……）。\n"
         "4. reasoning 欄位寫 1-2 句說明你如何處理難以辨認的部分（供教師稽核）。\n"
-        "5. 若完全無法辨認（靜音或雜音），transcript 回傳空字串 ''。\n"
+        "5. 若音檔中沒有清晰可辨的人聲朗讀（靜音、環境雜音、白噪音、音樂、"
+        "只有單一音調或喇叭聲），transcript 必須回傳空字串 ''，"
+        "且 reasoning 註明「未偵測到人聲朗讀」——此時絕對不可輸出任何課文原文內容。\n"
+        "6. 只在你真的聽到學生唸出對應字句時，才把那些字寫進 transcript。\n"
         "回傳格式：JSON {\"transcript\": \"...\", \"reasoning\": \"...\"}"
     )
 

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -320,8 +320,8 @@
         </tr>
         <tr>
           <td class="nowrap">② 錄音驗證</td><td><span class="pill fe">前端</span></td>
-          <td>能量+時長 VAD 守門，沒語音不送 STT；逐段+全文共用<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/frontend/src/utils/recordingValidation.ts">recordingValidation.ts</a></td>
-          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a> · 🟡 行為待真機麥克風</td><td>🟡</td>
+          <td>前端能量+時長 VAD 守門 + 後端 ffmpeg 能量 gate(−45dB) 擋靜音 + 轉錄 prompt 硬化禁鸚鵡學舌<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/frontend/src/utils/recordingValidation.ts">recordingValidation.ts</a></td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2368">#2368</a> · vitest 9/9 + 合成音檔 staging 真 Gemini 複驗</td><td class="ok">✅</td>
         </tr>
         <tr>
           <td class="nowrap">③ 辨識 STT</td><td><span class="pill llm">後端·LLM</span></td>
@@ -366,7 +366,7 @@
         <tr><td>同音/近音字寬容</td><td>④優化</td><td><b>原則</b>：發音對但字不同（同音/近音字）不該扣分。<br><b>方法</b>：spec 契約測試用固定案例驗，確保寬容規則不退化。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2266">#2266</a></td><td>—</td></tr>
         <tr><td>後送儲存（評估=存、取消/重錄不存）</td><td>⑥儲存</td><td><b>原則</b>：只存學生按了「評估」且接受的那段，分數先顯示才後送上傳。<br><b>方法</b>：spec + curl 打 /reading/save-audio 看行為與守門。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">#2299</a></td><td>—</td></tr>
         <tr><td>回放（學生/老師 signed URL + IDOR）</td><td>回放</td><td><b>原則</b>：只有本人/老師能聽，連結 10 分鐘過期。<br><b>方法</b>：curl 帶不同身分看 401/403/200 + 老師端鈕；簽名改走 IAM SignBlob 後 prod 實證 HTTP 200。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2283">#2283</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2327">#2327</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2344">#2344</a></td><td>—</td></tr>
-        <tr><td>靜音偽陽性 gate（不出聲不送評分）</td><td>②錄音驗證</td><td><b>原則</b>：沒出聲就不該送評分、更不該假性通過（最危險的沉默失敗）。<br><b>方法</b>：音量能量 + 錄音時長門檻先擋；轉錄端再擋幻覺前綴；完整行為需真機麥克風測。</td><td>🟡 待真機</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a></td><td>—</td></tr>
+        <tr><td>靜音/噪音偽陽性 gate（不出聲不送評分）</td><td>②錄音驗證</td><td><b>原則</b>：沒出聲就不該送評分、更不該假性通過（最危險的沉默失敗）。<br><b>方法</b>：前端能量+時長門檻擋靜音；後端 ffmpeg 能量 gate(−45dB)再擋一層；轉錄 prompt 硬化禁把課文當輸出、沒人聲回空；<b>合成音檔（靜音/白噪音/純音）+ 真人朗讀跑 staging 真 Gemini 複驗</b>。</td><td>✅ 合成音檔驗證<br>靜音/噪音 0 假passed · 真朗讀 pass</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2368">#2368</a></td><td>—</td></tr>
         <tr><td>STT 字準率（真實童音）</td><td>③辨識</td><td><b>原則</b>：機器聽寫要跟學生實際念的吻合，尤其真實童音（口齒不清/方言腔）。<br><b>方法</b>：收真人朗讀樣本，逐字跟課文比對算「字錯率 CER」。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
         <tr><td>評分準度（真實童音 across 課文）</td><td>④評分</td><td><b>原則</b>：好的高分、普通中等、<b>很差的接近 0</b>，分數要拉得開、跨課文都穩。<br><b>方法</b>：真人多版本（正確版 / 錯誤版 / <b>很差版</b>）跑批次評分，比對各自該落的分數帶。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
       </tbody>
@@ -392,7 +392,7 @@
         <li><b>CI 測 staging-not-PR-code</b> — <code>e2e-tests.yml</code> 跑 staging baseURL（測舊 code 非 PR 自己的），render-smoke 才跑 PR build</li>
         <li><b>reconcile orphan 未排程</b> — <code>reconcile_reading_audio_orphans.py</code> 預設 dry-run、未排 cron（#2299 後送後新 orphan 應大減）</li>
       </ul>
-      <p class="legend">近期已解：回放簽名 URL Cloud Run 修復（#2344，原本所有回放都播不出）· 老師端「▶聽錄音」鈕（#2327）· 測試集收集＋server-truth 進度＋聽取＋批次評分閉環 · 靜音偽陽性 3 層防線（#2338）· 聚光燈 icon 統一（#2349）</p>
+      <p class="legend">近期已解：靜音/噪音 STT 整段幻覺假passed 修復（#2368，合成音檔實測抓到→後端能量 gate＋prompt 硬化→staging 真 Gemini 複驗 0 假passed）· 回放簽名 URL Cloud Run 修復（#2344）· 老師端「▶聽錄音」鈕（#2327）· 測試集收集＋server-truth 進度＋聽取＋批次評分閉環 · 聚光燈 icon 統一（#2349）</p>
     </div>
     <div class="card rule">
       <h3>設計鐵律</h3>

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -209,20 +209,20 @@
 
       <div class="arrow">▼</div>
 
-      <!-- ①.5 錄音驗證 (Issue #2362) -->
+      <!-- ② 錄音驗證 (Issue #2362) -->
       <div class="node-row">
         <div class="node-text">
-          <div class="t">①.5 錄音驗證 <span class="side">前端</span></div>
+          <div class="t">② 錄音驗證 <span class="side">前端</span></div>
           <div class="s">validateRecording() — 能量(peak &lt; 0.05) / 時長(&lt; 1500 ms) 驗證，沒語音不進 STT；逐段(LiveTutor) + 全文(FullReading) 共用同一函式（recordingValidation.ts）</div>
         </div>
       </div>
 
       <div class="arrow">▼</div>
 
-      <!-- ② 辨識STT -->
+      <!-- ③ 辨識STT -->
       <div class="node-row">
         <div class="node-text">
-          <div class="t">② 辨識 STT <span class="side">後端 · LLM</span></div>
+          <div class="t">③ 辨識 STT <span class="side">後端 · LLM</span></div>
           <div class="s">POST /reading/transcribe → gemini-2.5-flash@us-central1（只做辨識，#2299 後已不在此上傳）</div>
         </div>
         <div class="node-demo stt-demo">
@@ -237,10 +237,10 @@
 
       <div class="arrow">▼</div>
 
-      <!-- ③ 優化+評分 -->
+      <!-- ④ 優化+評分 -->
       <div class="node-row">
         <div class="node-text">
-          <div class="t">③ 優化 + 評分 <span class="side">前端 local + 後端</span></div>
+          <div class="t">④ 優化 + 評分 <span class="side">前端 local + 後端</span></div>
           <div class="s">normalize(去標點/注音/全形)+同音校正 → DP/Levenshtein deterministic（local 先算；tier3 才 Gemini）→ match_rate + diff + CPM</div>
         </div>
         <div class="node-demo">
@@ -254,10 +254,10 @@
 
       <div class="arrow">▼</div>
 
-      <!-- ④ 分數回傳UI -->
+      <!-- ⑤ 分數回傳UI -->
       <div class="node-row">
         <div class="node-text">
-          <div class="t">④ 分數回傳 UI <span class="side">前端</span></div>
+          <div class="t">⑤ 分數回傳 UI <span class="side">前端</span></div>
           <div class="s">ParagraphCard 顯示正確率（學生立刻看到，不等儲存）</div>
         </div>
         <div class="node-demo">
@@ -273,10 +273,10 @@
 
       <div class="arrow">▼ （學生按評估—一定存放；取消/重錄不存）</div>
 
-      <!-- ⑤ 儲存後送 -->
+      <!-- ⑥ 儲存後送 -->
       <div class="node-row branch">
         <div class="node-text">
-          <div class="t">⑤ 儲存（後送·async） <span class="side">前端→後端+GCS</span></div>
+          <div class="t">⑥ 儲存（後送·async） <span class="side">前端→後端+GCS</span></div>
           <div class="s">saveReadingAudio → POST /reading/save-audio → IDOR(session.student_id==user) → GCS lingoleap-reading-audio → 寫 audio_gcs_path（fail-safe，不擋分數；取消/重錄不存放；▶播放錄音可先回放（已實作））</div>
         </div>
         <div class="node-demo upload-demo">
@@ -305,7 +305,7 @@
       </div>
 
     </div>
-    <p class="legend">關鍵：LLM 只在②辨識；③④全確定性（分數穩定可稽核）。<b>儲存在④之後（後送）</b>——舊版把儲存放在 transcribe（評分前），#2299 已改正。</p>
+    <p class="legend">關鍵：LLM 只在③辨識；④⑤全確定性（分數穩定可稽核）。<b>儲存在⑤之後（後送）</b>——舊版把儲存放在 transcribe（評分前），#2299 已改正。</p>
   </div>
 
   <!-- DEV -->
@@ -319,22 +319,27 @@
           <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">/qa render OK</a></td><td class="ok">✅</td>
         </tr>
         <tr>
-          <td class="nowrap">② 辨識 STT</td><td><span class="pill llm">後端·LLM</span></td>
+          <td class="nowrap">② 錄音驗證</td><td><span class="pill fe">前端</span></td>
+          <td>能量+時長 VAD 守門，沒語音不送 STT；逐段+全文共用<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/frontend/src/utils/recordingValidation.ts">recordingValidation.ts</a></td>
+          <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a> · 🟡 行為待真機麥克風</td><td>🟡</td>
+        </tr>
+        <tr>
+          <td class="nowrap">③ 辨識 STT</td><td><span class="pill llm">後端·LLM</span></td>
           <td>gemini-2.5-flash @us-central1<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/services/reading_transcription_service.py">reading_transcription_service.py</a></td>
           <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/docs/ai/reading-stt-scorer-ab-2026-06.md">A/B doc</a></td><td class="ok">✅</td>
         </tr>
         <tr>
-          <td class="nowrap">③ 優化+評分</td><td><span class="pill fe">前</span><span class="pill be">後</span></td>
+          <td class="nowrap">④ 優化+評分</td><td><span class="pill fe">前</span><span class="pill be">後</span></td>
           <td>normalize+同音校正 → deterministic DP 對齊<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/services/reading_evaluation_service.py">reading_evaluation_service.py</a></td>
           <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2266">#2266</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2274">#2274</a> · <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2266">staging 98.1%</a></td><td class="ok">✅</td>
         </tr>
         <tr>
-          <td class="nowrap">④ 顯示</td><td><span class="pill fe">前端</span></td>
+          <td class="nowrap">⑤ 顯示</td><td><span class="pill fe">前端</span></td>
           <td>ParagraphCard 正確率+diff<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts">useParagraphEvaluation.ts</a></td>
           <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2279">#2279</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2284">#2284</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a> · /qa console 乾淨</td><td class="ok">✅</td>
         </tr>
         <tr>
-          <td class="nowrap">⑤ 儲存(後送)</td><td><span class="pill fe">前</span><span class="pill be">後+GCS</span></td>
+          <td class="nowrap">⑥ 儲存(後送)</td><td><span class="pill fe">前</span><span class="pill be">後+GCS</span></td>
           <td>分數後 async 上傳+綁定（只存接受的 take）<br><a href="https://github.com/Youngger9765/chinese-literacy-platform/blob/staging/backend/app/routes/learning/learning_save_audio.py">learning_save_audio.py</a></td>
           <td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2278">#2278</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2283">#2283</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2286">#2286</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">#2299</a> · <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">Backend Tests 綠</a></td><td class="ok">✅</td>
         </tr>
@@ -357,13 +362,13 @@
       <tbody>
         <tr><td>逐段朗讀頁 render（mount 不白屏）</td><td>①錄音/⑤顯示</td><td><b>原則</b>：頁面一定要畫得出來、不白屏。<br><b>方法</b>：vitest 自動 mount 每個元件不報錯 + /qa 開實際頁看 console 乾淨。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2284">#2284</a></td><td>—</td></tr>
         <tr><td>全文朗讀頁 render</td><td>①錄音/⑤顯示</td><td><b>原則</b>：同上，全文朗讀頁也要正常 render。<br><b>方法</b>：vitest smoke + /qa console。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2292">#2292</a></td><td>—</td></tr>
-        <tr><td>評分正確率（deterministic 對齊）</td><td>③評分</td><td><b>原則</b>：機器算的分數要跟人工核對一致，<b>且涵蓋全範圍——念得好、普通、很差都要對齊</b>（好的接近高分、很差的接近 0）。<br><b>方法</b>：拿真人錄音（含刻意念很差的）在 staging 重算，比對「該得的比例」，太高太低都算 fail。</td><td>✅ 98.1%</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2274">#2274</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2266">#2266</a></td><td>—</td></tr>
+        <tr><td>評分正確率（deterministic 對齊）</td><td>④評分</td><td><b>原則</b>：機器算的分數要跟人工核對一致，<b>且涵蓋全範圍——念得好、普通、很差都要對齊</b>（好的接近高分、很差的接近 0）。<br><b>方法</b>：拿真人錄音（含刻意念很差的）在 staging 重算，比對「該得的比例」，太高太低都算 fail。</td><td>✅ 98.1%</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2274">#2274</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/issues/2266">#2266</a></td><td>—</td></tr>
         <tr><td>同音/近音字寬容</td><td>④優化</td><td><b>原則</b>：發音對但字不同（同音/近音字）不該扣分。<br><b>方法</b>：spec 契約測試用固定案例驗，確保寬容規則不退化。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2266">#2266</a></td><td>—</td></tr>
         <tr><td>後送儲存（評估=存、取消/重錄不存）</td><td>⑥儲存</td><td><b>原則</b>：只存學生按了「評估」且接受的那段，分數先顯示才後送上傳。<br><b>方法</b>：spec + curl 打 /reading/save-audio 看行為與守門。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2299">#2299</a></td><td>—</td></tr>
         <tr><td>回放（學生/老師 signed URL + IDOR）</td><td>回放</td><td><b>原則</b>：只有本人/老師能聽，連結 10 分鐘過期。<br><b>方法</b>：curl 帶不同身分看 401/403/200 + 老師端鈕；簽名改走 IAM SignBlob 後 prod 實證 HTTP 200。</td><td>✅</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2283">#2283</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2327">#2327</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2344">#2344</a></td><td>—</td></tr>
-        <tr><td>靜音偽陽性 gate（不出聲不送評分）</td><td>②辨識前</td><td><b>原則</b>：沒出聲就不該送評分、更不該假性通過（最危險的沉默失敗）。<br><b>方法</b>：音量能量 + 錄音時長門檻先擋；轉錄端再擋幻覺前綴；完整行為需真機麥克風測。</td><td>🟡 待真機</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a></td><td>—</td></tr>
-        <tr><td>STT 字準率（真實童音）</td><td>②辨識</td><td><b>原則</b>：機器聽寫要跟學生實際念的吻合，尤其真實童音（口齒不清/方言腔）。<br><b>方法</b>：收真人朗讀樣本，逐字跟課文比對算「字錯率 CER」。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
-        <tr><td>評分準度（真實童音 across 課文）</td><td>③評分</td><td><b>原則</b>：好的高分、普通中等、<b>很差的接近 0</b>，分數要拉得開、跨課文都穩。<br><b>方法</b>：真人多版本（正確版 / 錯誤版 / <b>很差版</b>）跑批次評分，比對各自該落的分數帶。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
+        <tr><td>靜音偽陽性 gate（不出聲不送評分）</td><td>②錄音驗證</td><td><b>原則</b>：沒出聲就不該送評分、更不該假性通過（最危險的沉默失敗）。<br><b>方法</b>：音量能量 + 錄音時長門檻先擋；轉錄端再擋幻覺前綴；完整行為需真機麥克風測。</td><td>🟡 待真機</td><td><a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2324">#2324</a> <a href="https://github.com/Youngger9765/chinese-literacy-platform/pull/2338">#2338</a></td><td>—</td></tr>
+        <tr><td>STT 字準率（真實童音）</td><td>③辨識</td><td><b>原則</b>：機器聽寫要跟學生實際念的吻合，尤其真實童音（口齒不清/方言腔）。<br><b>方法</b>：收真人朗讀樣本，逐字跟課文比對算「字錯率 CER」。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
+        <tr><td>評分準度（真實童音 across 課文）</td><td>④評分</td><td><b>原則</b>：好的高分、普通中等、<b>很差的接近 0</b>，分數要拉得開、跨課文都穩。<br><b>方法</b>：真人多版本（正確版 / 錯誤版 / <b>很差版</b>）跑批次評分，比對各自該落的分數帶。</td><td>⏳ 待樣本</td><td>—</td><td>✅ 需</td></tr>
       </tbody>
     </table>
     <p style="font-size:.82rem;color:var(--muted);margin-top:10px">⏳ 兩列「真實童音」量化驗證靠<b>人聲測試集</b>（見上方④測試集 tab，內嵌現況表）：每課收正確版 + 錯誤版（含念很差的），按貢獻者暱稱分組存 GCS <code>test-dataset/</code>；在現況表點各課「跑分」即跑批次評分對照期望。樣本足夠後這兩列填入 per-課 CER / 正確率。</p>

--- a/frontend/src/utils/__tests__/recordingValidation.test.ts
+++ b/frontend/src/utils/__tests__/recordingValidation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateRecording,
+  SILENT_PEAK_THRESHOLD,
+  SILENT_MIN_DURATION_MS,
+} from '../recordingValidation';
+
+/**
+ * #2362 — 錄音驗證（VAD）gate 行為驗證（合成音檔，免真人麥克風）
+ *
+ * peakVolume 取自 ffmpeg 合成音檔的實測 astats Max level：
+ *   silence.webm    (anullsrc)            → 0.000   數位靜音
+ *   tone.webm       (sine 440Hz)          → 0.125   有能量的純音
+ *   whitenoise.webm (anoisesrc white a=.5)→ 0.668   大聲但無語音
+ *
+ * 前端 gate 只看「能量 + 時長」：
+ *   - 靜音(0.0) → 擋（reason=silent）
+ *   - 純音/語音/白噪音(>0.05) → 過能量關（白噪音故意過，留給後端 STT 幻覺 gate 擋）
+ *   - <1500ms → 擋（reason=too_short），即使很大聲
+ */
+describe('validateRecording — VAD 靜音 gate（合成音檔實測值）', () => {
+  it('擋數位靜音 peak=0.0（silence.webm）', () => {
+    expect(validateRecording({ peakVolume: 0.0, durationMs: 3000 })).toEqual({
+      ok: false,
+      reason: 'silent',
+    });
+  });
+
+  it('擋接近靜音的背景 peak=0.02（< 0.05）', () => {
+    expect(validateRecording({ peakVolume: 0.02, durationMs: 3000 })).toEqual({
+      ok: false,
+      reason: 'silent',
+    });
+  });
+
+  it('恰在門檻下界 peak=0.049 → 擋', () => {
+    expect(validateRecording({ peakVolume: 0.049, durationMs: 3000 })).toEqual({
+      ok: false,
+      reason: 'silent',
+    });
+  });
+
+  it('放行純音 peak=0.125（tone.webm，有能量）', () => {
+    expect(validateRecording({ peakVolume: 0.125, durationMs: 3000 })).toEqual({
+      ok: true,
+      reason: null,
+    });
+  });
+
+  it('放行典型朗讀語音 peak=0.2', () => {
+    expect(validateRecording({ peakVolume: 0.2, durationMs: 3000 })).toEqual({
+      ok: true,
+      reason: null,
+    });
+  });
+
+  it('白噪音 peak=0.668 過能量關（whitenoise.webm）→ 交後端 STT 幻覺 gate 擋', () => {
+    expect(validateRecording({ peakVolume: 0.668, durationMs: 3000 })).toEqual({
+      ok: true,
+      reason: null,
+    });
+  });
+
+  it('擋誤觸短錄音 <1500ms，即使大聲（peak=0.668, 800ms）', () => {
+    expect(validateRecording({ peakVolume: 0.668, durationMs: 800 })).toEqual({
+      ok: false,
+      reason: 'too_short',
+    });
+  });
+
+  it('時長關優先於能量關：靜音又太短 → too_short', () => {
+    expect(validateRecording({ peakVolume: 0.0, durationMs: 500 })).toEqual({
+      ok: false,
+      reason: 'too_short',
+    });
+  });
+
+  it('門檻常數鎖定（避免日後誤改）', () => {
+    expect(SILENT_PEAK_THRESHOLD).toBe(0.05);
+    expect(SILENT_MIN_DURATION_MS).toBe(1500);
+  });
+});


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

真 student-facing 計分 bug 修復推 prod：
- #2369 後端 silence/noise STT 整段幻覺 gate（能量 gate −45dB + prompt 硬化）
- #2370 看板 ② 錄音驗證 / 靜音 gate → ✅
合成音檔 + 真人朗讀 staging 真 Gemini 複驗通過（靜音/噪音 0 假passed、真朗讀 pass）。