### PR TITLE
fix(frontend): testset 跑分 401 re-login + /presentation 301 redirect (#2389)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,8 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 # SPA fallback: all routes → index.html
-RUN echo 'server { listen 8080; location / { root /usr/share/nginx/html; try_files $uri $uri/ /index.html; } }' > /etc/nginx/conf.d/default.conf
+# absolute_redirect off: dir 尾斜線 301（如 /presentation → /presentation/）改送相對 Location，
+# 否則 nginx 用內部 listen 8080 + http 拼絕對 URL → http://host:8080/... 對外連不到（Cloud Run 只開 443）
+RUN echo 'server { listen 8080; absolute_redirect off; location / { root /usr/share/nginx/html; try_files $uri $uri/ /index.html; } }' > /etc/nginx/conf.d/default.conf
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
+++ b/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
@@ -105,6 +105,7 @@ function aiCell(id, hasRec){
     var verdict=(r.correct!=null&&r.error!=null)?('<div style="font-weight:700;margin-top:2px" class="'+(both?'ok':'anom')+'">'+(both?'✅ 兩版都 pass':'⚠ 有異常')+'</div>'):'';
     return '<div class="ai-score">'+parts.join('')+verdict+'<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重跑</button></div>';
   }
+  if(r&&r.authErr) return '<span class="anom">登入已過期</span> <a class="ai-row-btn" href="/login" target="_blank" rel="noopener" style="text-decoration:none">重新登入</a>';
   if(r&&r.err) return '<span class="anom">失敗</span> <button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重試</button>';
   if(hasRec) return '<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">▶ 跑分</button>';
   return '<span class="ai-badge">待對應</span>';
@@ -278,10 +279,13 @@ async function evalFetch(url, headers){
     try{
       var r=await fetch(url,{method:'POST',headers:headers,signal:ctrl.signal});
       clearTimeout(timer);
+      // 401 = token 過期/失效（JWT 8h TTL）。重試同一個死 token 永遠還是 401 → 不重試，直接拋給 caller 導重新登入（#2379 只修冷啟動，沒處理這個）
+      if(r.status===401){ var ae=new Error('登入已過期'); ae.authExpired=true; throw ae; }
       if(!r.ok) throw new Error('HTTP '+r.status);
       return await r.json();
     }catch(e){
       clearTimeout(timer);
+      if(e&&e.authExpired) throw e;  // 過期不重試
       lastErr=e;
       if(attempt<2){ await new Promise(function(res){ setTimeout(res,2000); }); }  // 等 2s，冷啟動已暖
     }
@@ -293,7 +297,7 @@ async function evalFetch(url, headers){
 async function runAiEval(){
   var btn=document.getElementById('aiRunBtn'), st=document.getElementById('aiStatus');
   var token=localStorage.getItem('lingoleap_token');
-  if(!token){ st.textContent='需先登入'; return; }
+  if(!token){ st.innerHTML='請先<a href="/login" target="_blank" rel="noopener">登入</a>'; return; }
   btn.disabled=true;
   st.textContent='AI 評分中…（真人聲辨識較久，約每筆 20-30 秒，請稍候）';
   try{
@@ -304,7 +308,8 @@ async function runAiEval(){
     st.textContent='完成：'+(d.n||0)+' 筆 · 異常 '+(sm.anomaly_count||0)+(d.truncated?'（達單次上限 30，僅評前 30）':'');
     await load();
   }catch(e){
-    st.textContent='失敗：'+e.message;
+    if(e&&e.authExpired){ st.innerHTML='登入已過期，<a href="/login" target="_blank" rel="noopener">請重新登入</a>後重跑'; }
+    else { st.textContent='失敗：'+e.message; }
   }finally{
     btn.disabled=false;
   }
@@ -327,7 +332,7 @@ async function runAiEvalForLesson(id){
     var d=await evalFetch(API+'/api/testset/batch-eval?lesson='+encodeURIComponent(id), headers);
     aiResults[id]={correct:null,error:null,correctFlag:false,errorFlag:false};
     (d.results||[]).forEach(function(x){ if(String(x.lesson)===String(id)) applyAiResult(x); });
-  }catch(e){ aiResults[id]={err:true}; }
+  }catch(e){ aiResults[id]=(e&&e.authExpired)?{authErr:true}:{err:true}; }
   rerenderAiCell(id);
 }
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2389 — 兩個 staging 前端 bug（Young QA 發現）：

## 1. testset 跑分一直「失敗 重試」(6f206fba)
真因 **HTTP 401**（JWT 8h TTL 過期），非 #2379 冷啟動。過期 token 重試還是 401。
修：evalFetch 認 401 → 不重試、拋 authExpired；UI「登入已過期 → 重新登入」(/login target=_blank，同 origin token 刷新可直接重跑)。

## 2. /presentation 進不去 (b20cf3d2)
`/presentation` 301 → `http://host:8080/...`（nginx 內部 port+http 洩漏），Cloud Run 對外只 443。
修：Dockerfile nginx `absolute_redirect off` → 相對 Location。

## 驗證
- testset HTML：browse 0 JS 語法錯、render 正常
- 待 staging deploy 後實測：401 情境顯示重新登入 + curl /presentation 不再洩漏 :8080