### PR TITLE
feat(testset): 跑分結果持久化 + 跑分時間戳 → prod (#2392)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -85,6 +85,32 @@ def _resolve_target_text(lesson_id: str) -> str | None:
     return lesson.get("full_text") or None
 
 
+def _eval_blob_path(audio_path: str) -> str:
+    """跑分結果持久化的 sibling 路徑：
+    .../{version}-{uid}.webm → .../{version}-{uid}.eval.json（#2392）。"""
+    if not audio_path:
+        return ""
+    return audio_path.rsplit(".", 1)[0] + ".eval.json"
+
+
+def _stamp_persist_append(bucket, audio_path: str, result: dict, results: list) -> None:
+    """蓋 scored_at 時間戳 → 持久化 eval 結果到 GCS（fail-safe，寫失敗不中斷批次）→ append。
+
+    讓 dashboard reload 不丟分數 + 標跑分時間（#2392）。重跑會覆寫同一 eval.json。
+    """
+    result["scored_at"] = datetime.now(timezone.utc).isoformat()
+    eval_path = _eval_blob_path(audio_path)
+    if eval_path:
+        try:
+            bucket.blob(eval_path).upload_from_string(
+                json.dumps(result, ensure_ascii=False),
+                content_type="application/json",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("batch-eval persist failed: path=%s err=%s", eval_path, exc)
+    results.append(result)
+
+
 @router.post("/testset/upload")
 async def testset_upload(
     contributor_name: str = Form(...),
@@ -214,15 +240,29 @@ def testset_recordings():
 
     out = []
     try:
+        # 單趟掃描同時收 meta + 持久化的 eval 結果（#2392），用 base path join，
+        # 避免每筆再打一次 GCS exists/download（N 次額外呼叫會拖慢清單）。
+        metas_by_base: dict[str, dict] = {}
+        evals_by_base: dict[str, dict] = {}
         for blob in bucket.list_blobs(prefix=f"{_PREFIX}/", max_results=_LIST_CAP):
-            if not blob.name.endswith(".json"):
-                continue
-            try:
-                meta = json.loads(blob.download_as_text())
-            except Exception:
-                continue
+            if blob.name.endswith(".eval.json"):
+                base = blob.name[: -len(".eval.json")]
+                try:
+                    evals_by_base[base] = json.loads(blob.download_as_text())
+                except Exception:
+                    continue
+            elif blob.name.endswith(".json"):
+                base = blob.name[: -len(".json")]
+                try:
+                    metas_by_base[base] = json.loads(blob.download_as_text())
+                except Exception:
+                    continue
+        for base, meta in metas_by_base.items():
             signed = generate_audio_signed_url(meta.get("audio_path", ""), expiration_seconds=600)
             meta["play_url"] = signed
+            ev = evals_by_base.get(base)
+            if ev is not None:
+                meta["eval"] = ev  # 含 adjusted_match_rate / flag / scored_at 等
             out.append(meta)
     except Exception as exc:
         logger.warning("testset list failed: %s", exc)
@@ -292,6 +332,9 @@ async def testset_batch_eval(
         for blob in bucket.list_blobs(prefix=f"{_PREFIX}/", max_results=_LIST_CAP):
             if not blob.name.endswith(".json"):
                 continue
+            # 跳過跑分結果檔（#2392）—— 它也以 .json 結尾，當 meta 解析會污染清單
+            if blob.name.endswith(".eval.json"):
+                continue
             # Apply contributor filter (slug-based path component match)
             if name_slug and f"/{name_slug}/" not in blob.name:
                 continue
@@ -349,7 +392,7 @@ async def testset_batch_eval(
             target_text = _resolve_target_text(entry_lesson)
             if not target_text:
                 base_result["error"] = f"lesson '{entry_lesson}' not found in catalog"
-                results.append(base_result)
+                _stamp_persist_append(bucket, audio_path, base_result, results)
                 logger.info("batch-eval skip: lesson not found path=%s", audio_path)
                 continue
 
@@ -374,7 +417,7 @@ async def testset_batch_eval(
             # 4d. Skip scoring if transcription failed (fallback with no transcript)
             if not transcript:
                 base_result["error"] = f"transcription fallback: {transcript_reason or 'unknown'}"
-                results.append(base_result)
+                _stamp_persist_append(bucket, audio_path, base_result, results)
                 logger.info(
                     "batch-eval transcribe fallback: path=%s reason=%s",
                     audio_path, transcript_reason,
@@ -410,7 +453,7 @@ async def testset_batch_eval(
                 "batch-eval entry error: path=%s err=%s", audio_path, exc, exc_info=True
             )
 
-        results.append(base_result)
+        _stamp_persist_append(bucket, audio_path, base_result, results)
 
     # ── 5. Summary statistics ───────────────────────────────────────────────
     correct_scores = [

--- a/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
+++ b/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
@@ -94,6 +94,14 @@ var aiResults={};  // lesson_id → {correct:adj|null, error:adj|null, anomaly:b
 
 function pct(v){ return v==null?'—':(Math.round(v*1000)/10)+'%'; }
 
+// 跑分時間戳格式化（#2392）：ISO → MM/DD HH:MM（本地時區）
+function fmtTs(iso){
+  try{ var d=new Date(iso); if(isNaN(d.getTime())) return '';
+    var p=function(n){return (n<10?'0':'')+n;};
+    return p(d.getMonth()+1)+'/'+p(d.getDate())+' '+p(d.getHours())+':'+p(d.getMinutes());
+  }catch(e){ return ''; }
+}
+
 function aiCell(id, hasRec){
   var r=aiResults[id];
   if(r&&r.running) return '<span class="muted">跑分中…（約 30 秒）</span>';
@@ -103,7 +111,8 @@ function aiCell(id, hasRec){
     if(r.error!=null)   parts.push('<div class="'+(r.errorFlag?'anom':'lo')+'">錯誤版 '+pct(r.error)+(r.errorFlag?' ⚠':' ✓')+'</div>');
     var both=(r.correct!=null&&!r.correctFlag)&&(r.error!=null&&!r.errorFlag);
     var verdict=(r.correct!=null&&r.error!=null)?('<div style="font-weight:700;margin-top:2px" class="'+(both?'ok':'anom')+'">'+(both?'✅ 兩版都 pass':'⚠ 有異常')+'</div>'):'';
-    return '<div class="ai-score">'+parts.join('')+verdict+'<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重跑</button></div>';
+    var ts=r.scoredAt?('<div class="muted" style="font-size:.72rem;margin-top:2px">跑分 '+fmtTs(r.scoredAt)+'</div>'):'';
+    return '<div class="ai-score">'+parts.join('')+verdict+ts+'<button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重跑</button></div>';
   }
   if(r&&r.authErr) return '<span class="anom">登入已過期</span> <a class="ai-row-btn" href="/login" target="_blank" rel="noopener" style="text-decoration:none">重新登入</a>';
   if(r&&r.err) return '<span class="anom">失敗</span> <button class="ai-row-btn" onclick="runAiEvalForLesson(\''+esc(id)+'\')">重試</button>';
@@ -184,6 +193,7 @@ async function load(){
     var k=m.lesson_id+'||'+m.version;
     (idx[k]=idx[k]||[]).push(m);
     if(m.contributor_name) contribSet[m.contributor_name]=true;
+    if(m.eval) applyAiResult(m.eval);  // 持久化跑分結果 → reload 直接顯示分數+時間，免重跑（#2392）
   });
 
   // 4. stats
@@ -320,7 +330,8 @@ function applyAiResult(x){
   var e=aiResults[x.lesson]=aiResults[x.lesson]||{correct:null,error:null,correctFlag:false,errorFlag:false};
   if(x.version==='correct'){ e.correct=x.adjusted_match_rate; e.correctFlag=!!x.flag; }
   else if(x.version==='error'){ e.error=x.adjusted_match_rate; e.errorFlag=!!x.flag; }
-  delete e.running; delete e.err;
+  if(x.scored_at && (!e.scoredAt || x.scored_at>e.scoredAt)) e.scoredAt=x.scored_at;  // 取最新跑分時間（#2392）
+  delete e.running; delete e.err; delete e.authErr;
 }
 
 // 單課跑分（Image #8：點某課 → 跑該課正確/錯誤版 → 顯示分數 + 兩版是否都 pass）


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

staging 實測通過 → prod（cherry-pick #2393）。

- 跑分結果持久化 GCS（reload 不丟）+ 標跑分時間 + 單點重跑
- staging 驗：reload 直接顯示 95.9%/35% + 「跑分 06/22 12:51」，API eval 帶 scored_at

Closes #2392.