### PR TITLE
fix(eval-ux): 統一逐段+全文朗讀評估進度 — duration 動態緩動,去假掃描 (#2396)

### DIFF
--- a/frontend/src/components/reading-steps/EvalProgress.tsx
+++ b/frontend/src/components/reading-steps/EvalProgress.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * EvalProgress — 共用評估進度指示器（逐段朗讀 + 全文朗讀共用，#2396）
+ *
+ * 解掉舊版假掃描進度（EVAL_STEPS 固定 minMs 步驟）的兩個毛病：
+ *   - 快完成 → 動畫沒播完被硬中斷（尷尬）
+ *   - >20s → 卡死在最後一步發呆
+ *
+ * 機制：
+ *   1. duration 動態 — 用實際錄音長度估預期評估時間 expectedMs = BASE + K×recordingMs
+ *      （短錄音→快、長錄音→慢，自動貼合）
+ *   2. 緩動漸近 — 進度條用 1-e^(-t/τ) 逼近 TARGET(92%)，自己永遠跑不完 → 不卡死、永遠在動
+ *   3. snap — active 轉 false（真結果到）→ 衝 100% + 閃「完成」再收掉 → 不管快慢都平滑收尾
+ *
+ * K / BASE 是第一版估值，可從真實 telemetry（評估秒數 / 錄音秒數）再校準；
+ * 漸近 + snap 設計讓估錯也不尷尬，故 K 不需精準。
+ */
+
+const BASE_MS = 2500; // 固定開銷（冷啟動 + setup）
+const K = 0.6; // 評估時間 ≈ K × 錄音長度（tunable）
+const TARGET = 0.92; // 結果到之前的漸近上限
+
+interface EvalProgressProps {
+  /** 是否正在評估（true = 顯示進度；轉 false = 真結果到，觸發 snap 收尾） */
+  active: boolean;
+  /** 實際錄音長度（ms），用來動態配節奏 */
+  recordingMs: number;
+  /** 評估中主文案（預設「AI 評估中…」） */
+  label?: string;
+}
+
+export function EvalProgress({ active, recordingMs, label = 'AI 評估中…' }: EvalProgressProps) {
+  const [pct, setPct] = useState(0);
+  const [finishing, setFinishing] = useState(false);
+  const [elapsedSecs, setElapsedSecs] = useState(0);
+  const startRef = useRef(0);
+
+  useEffect(() => {
+    if (active) {
+      setFinishing(false);
+      setPct(0);
+      setElapsedSecs(0);
+      startRef.current = Date.now();
+      const expectedMs = BASE_MS + K * Math.max(0, recordingMs);
+      const tau = Math.max(1500, expectedMs * 0.55); // 時間常數：~TARGET 落在 expectedMs 附近
+      const id = setInterval(() => {
+        const t = Date.now() - startRef.current;
+        setPct(TARGET * (1 - Math.exp(-t / tau)));
+        setElapsedSecs(Math.floor(t / 1000));
+      }, 120);
+      return () => clearInterval(id);
+    }
+    // active 轉 false：若有跑過 → snap 100% + 閃「完成」再收
+    if (pct > 0) {
+      setFinishing(true);
+      setPct(1);
+      const id = setTimeout(() => {
+        setFinishing(false);
+        setPct(0);
+      }, 450);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, recordingMs]);
+
+  if (!active && !finishing) return null;
+
+  const widthPct = Math.round(pct * 100);
+
+  return (
+    <div className="w-full flex flex-col items-center gap-3">
+      <div className="w-full rounded-2xl overflow-hidden shadow-[0_12px_48px_rgba(0,105,71,0.2)] bg-gradient-to-br from-[#006947] to-[#34d399]">
+        {/* 進度條（緩動寬度 + 掃描光點） */}
+        <div className="relative h-1.5 bg-white/20">
+          <div
+            className="absolute inset-y-0 left-0 bg-white/80 rounded-full"
+            style={{ width: `${widthPct}%`, transition: 'width 0.3s ease-out' }}
+          />
+          <div
+            className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-white shadow-[0_0_8px_4px_rgba(255,255,255,0.5)]"
+            style={{ left: `calc(${widthPct}% - 4px)`, transition: 'left 0.3s ease-out' }}
+          />
+        </div>
+        {/* 單一誠實文案 + elapsed（不再假裝後端在跑哪一步） */}
+        <div className="px-5 py-4 flex items-center gap-3">
+          <span className="text-lg leading-none select-none">{finishing ? '✅' : '🤖'}</span>
+          <span className="flex-1 text-sm font-bold text-white">
+            {finishing ? '完成' : label}
+          </span>
+          {!finishing && (
+            <span className="text-xs font-medium text-white/70 tabular-nums">{elapsedSecs}s</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EvalProgress;

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -8,6 +8,7 @@ import { useFullReadingSession, type SavedResult } from '../../hooks/useFullRead
 import { useFullReadingTtsQueue } from '../../hooks/useFullReadingTtsQueue';
 import { useFullReadingResultPersistence } from '../../hooks/useFullReadingResultPersistence';
 import ReadingMetricsCard from './full-reading/ReadingMetricsCard';
+import { EvalProgress } from './EvalProgress';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import { useAuth } from '../../contexts/AuthContext';
 import { splitZhuyinChars } from '../../utils/zhuyinUtils';
@@ -301,9 +302,17 @@ const FullReading: React.FC<FullReadingProps> = ({
 
   /* ── Recording timer (Issue #2175) ──────────────────────────────────── */
   const [recordingSecs, setRecordingSecs] = useState(0);
+  // 錄音長度（ms）保留到 transcribe 後 — recordingSecs 在 stop 時歸 0，故用 ref 留住
+  // 給共用 <EvalProgress> 動態配評估進度節奏（#2396）。
+  const lastRecordingMsRef = useRef(0);
   useEffect(() => {
     if (!isSessionActive) { setRecordingSecs(0); return; }
-    const id = setInterval(() => setRecordingSecs(s => s + 1), 1000);
+    lastRecordingMsRef.current = 0;
+    const id = setInterval(() => setRecordingSecs(s => {
+      const next = s + 1;
+      lastRecordingMsRef.current = next * 1000;
+      return next;
+    }), 1000);
     return () => clearInterval(id);
   }, [isSessionActive]);
 
@@ -332,13 +341,12 @@ const FullReading: React.FC<FullReadingProps> = ({
         fontFamily: fontForZhuyin(isZhuyinAny),
       }}
     >
-      {/* ── Gemini transcription loading overlay (Issue #2131) ─────────── */}
+      {/* ── 評估進度：共用 EvalProgress（與逐段朗讀同款 duration 動態+緩動+snap，#2396）
+            取代舊版乾轉圈 spinner（#2131）；置中 overlay 保留 ── */}
       {isTranscribing && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="bg-surface rounded-2xl px-8 py-6 flex flex-col items-center gap-3 shadow-xl">
-            <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
-            <p className="text-on-surface font-medium text-base">分析中…</p>
-            <p className="text-on-surface-variant text-sm">AI 正在分析您的朗讀，請稍候</p>
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm px-6">
+          <div className="w-full max-w-md">
+            <EvalProgress active={isTranscribing} recordingMs={lastRecordingMsRef.current} />
           </div>
         </div>
       )}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -1,14 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { DiffToken } from '../../../types';
 import { formatTime } from '../../../utils/formatTime';
-
-/** Eval progress steps — defined outside component to avoid per-render allocation. */
-const EVAL_STEPS = [
-  { icon: '📖', label: '掃描課文中…',    minMs: 0     },
-  { icon: '🎙️', label: '辨識你的朗讀…', minMs: 2500  },
-  { icon: '🔍', label: '逐字比對對錯…', minMs: 10000 },
-  { icon: '📊', label: '計算正確率…',   minMs: 15000 },
-] as const;
+import { EvalProgress } from '../EvalProgress';
 
 interface LiveTutorControlsProps {
   // Session state
@@ -174,33 +167,8 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
     setIsPlayingBack(true);
   }, [recordingAudioUrl, isPlayingBack, stopPlaybackSync]);
 
-  /* ── Eval progress animation: step sequence + elapsed counter ── */
-  const [awaitingSecs, setAwaitingSecs] = useState(0);
-  const [evalStepIdx, setEvalStepIdx] = useState(0);
-
-  useEffect(() => {
-    if (!isSubmittingSentence) {
-      setAwaitingSecs(0);
-      setEvalStepIdx(0);
-      return;
-    }
-    const start = Date.now();
-    const id = setInterval(() => {
-      const elapsedMs = Date.now() - start;
-      const secs = Math.floor(elapsedMs / 1000);
-      setAwaitingSecs(secs);
-      // Advance to the highest step whose minMs has been reached;
-      // cap at last step (stays there until result arrives).
-      let nextIdx = 0;
-      for (let i = EVAL_STEPS.length - 1; i >= 0; i--) {
-        if (elapsedMs >= EVAL_STEPS[i].minMs) { nextIdx = i; break; }
-      }
-      setEvalStepIdx(nextIdx);
-    }, 300);
-    return () => clearInterval(id);
-  }, [isSubmittingSentence]);
-
-  const evalElapsedSecs = isSubmittingSentence ? awaitingSecs : 0;
+  /* 評估進度改用共用 <EvalProgress>（duration 動態 + 緩動漸近 + snap，#2396）—
+     舊版假掃描步驟（EVAL_STEPS 固定 minMs）已移除。 */
 
   return (
     <div
@@ -315,80 +283,8 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                 </div>
               </>
             ) : isSubmittingSentence ? (
-              /* Eval progress animation — step-by-step with scanning line */
-              <div className="w-full flex flex-col items-center gap-3">
-                {/* Main card */}
-                <div className="w-full rounded-2xl overflow-hidden shadow-[0_12px_48px_rgba(0,105,71,0.2)] bg-gradient-to-br from-[#006947] to-[#34d399]">
-                  {/* Scanning progress bar */}
-                  <div className="relative h-1.5 bg-white/20">
-                    <div
-                      className="absolute inset-y-0 left-0 bg-white/80 rounded-full"
-                      style={{
-                        width: `${Math.min(95, (evalStepIdx / (EVAL_STEPS.length - 1)) * 100)}%`,
-                        transition: 'width 0.6s ease-in-out',
-                      }}
-                    />
-                    {/* Glowing scanner dot */}
-                    <div
-                      className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-white shadow-[0_0_8px_4px_rgba(255,255,255,0.5)]"
-                      style={{
-                        left: `calc(${Math.min(95, (evalStepIdx / (EVAL_STEPS.length - 1)) * 100)}% - 4px)`,
-                        transition: 'left 0.6s ease-in-out',
-                      }}
-                    />
-                  </div>
-
-                  {/* Step messages */}
-                  <div className="px-5 py-4 flex flex-col gap-2.5">
-                    {EVAL_STEPS.map((step, idx) => {
-                      const isActive = idx === evalStepIdx;
-                      const isDone = idx < evalStepIdx;
-                      return (
-                        <div
-                          key={step.label}
-                          className="flex items-center gap-3 transition-opacity duration-500"
-                          style={{ opacity: isDone ? 0.45 : isActive ? 1 : 0.25 }}
-                        >
-                          <span
-                            className="text-lg leading-none select-none"
-                            style={{ filter: isActive ? 'none' : 'grayscale(0.5)' }}
-                          >
-                            {step.icon}
-                          </span>
-                          <span
-                            className={`text-sm font-bold transition-colors duration-300 ${
-                              isActive ? 'text-white' : isDone ? 'text-white/60 line-through decoration-white/40' : 'text-white/40'
-                            }`}
-                          >
-                            {step.label}
-                          </span>
-                          {isActive && (
-                            <div className="ml-auto flex items-end gap-1 h-4">
-                              {[0, 1, 2].map(i => (
-                                <div
-                                  key={i}
-                                  className="w-1.5 h-1.5 rounded-full bg-white animate-bounce"
-                                  style={{ animationDelay: `${i * 0.15}s` }}
-                                />
-                              ))}
-                            </div>
-                          )}
-                          {isDone && (
-                            <span className="ml-auto text-sm text-white/60">✓</span>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                {/* Elapsed time hint */}
-                <p className="text-xs text-on-surface-variant tabular-nums">
-                  {evalElapsedSecs > 0
-                    ? `已等待 ${evalElapsedSecs} 秒，AI 正在分析中…`
-                    : 'AI 正在分析朗讀音訊，約需 10–20 秒'}
-                </p>
-              </div>
+              /* 評估進度：共用 EvalProgress（duration 動態 + 緩動漸近 + snap，#2396） */
+              <EvalProgress active={isSubmittingSentence} recordingMs={recordingSecs * 1000} />
             ) : (
               <button
                 type="button"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

舊逐段朗讀評估進度是假固定計時掃描(EVAL_STEPS 0/2.5/10/15s)→ 快完成被硬中斷、>20s 卡死發呆;全文朗讀是乾轉圈 spinner。

新增共用 `EvalProgress.tsx`(兩處共用):
- **duration 動態** expectedMs = BASE + K×錄音長度(短快長慢自動貼合)
- **緩動漸近** 1-e^(-t/τ) 逼近 92%,永遠跑不完 → 不卡死
- **snap** 真結果到 → 衝 100%+「完成」→ 快慢都平滑收尾
- 誠實單一文案,不再假裝後端步驟

全文朗讀保留 history + 自我評估。render-smoke 13 passed、tsc clean。
驗證:preview 上實際錄音→評估,看新進度(快/慢都不尷尬)。