### PR TITLE
feat(qa): keypoints ② text-fidelity + ③ intent drift-lock (Related to #2397)

### DIFF
--- a/scripts/eval_keypoints_text_fidelity.py
+++ b/scripts/eval_keypoints_text_fidelity.py
@@ -45,6 +45,10 @@ def normalize_text(text: str) -> str:
 
 BLANK_RE = re.compile(r"【(.*?)】")
 
+# Markers that indicate inline checkbox option lists in schema templates.
+# These make positional DOCX↔schema alignment unreliable — skip fidelity check.
+CHECKBOX_MARKER_RE = re.compile(r"□|勾選")
+
 
 def extract_blanks_from_docx_text(text: str) -> list:
     """Extract answer strings from 【...】 patterns in a DOCX cell."""
@@ -88,6 +92,30 @@ def _skip_header_rows(rows_raw: list) -> int:
         if _re.search(r"提示|元素|重點|段落", cell_texts):
             skip += 1
     return skip
+
+
+def _has_checkbox_structure(rows_out: list) -> bool:
+    """
+    Return True if any schema row or sub_row template/value contains inline
+    checkbox markers (□ or 勾選).
+
+    These layouts interleave fill-in blanks with multiple-choice checkbox options
+    on extra lines inside the same DOCX cell. Positional DOCX↔schema alignment
+    breaks for these tables — classifying them as structure_unsupported avoids
+    false-positive mismatches.
+
+    Real example: G5-L20 template =
+      "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜 \n惱怒 煩躁"
+    """
+    for row in rows_out:
+        for text_field in (row.get("value", ""), row.get("template", "")):
+            if CHECKBOX_MARKER_RE.search(text_field):
+                return True
+        for sr in row.get("sub_rows", []):
+            for text_field in (sr.get("value", ""), sr.get("template", "")):
+                if CHECKBOX_MARKER_RE.search(text_field):
+                    return True
+    return False
 
 
 def _flatten_schema_rows(rows_out: list, structure: str) -> list:
@@ -192,6 +220,22 @@ def eval_keypoints_text_fidelity(
             "available": False,
             "note": "schema has no rows",
             "text_fidelity": 1.0,
+            "mismatches": [],
+            "pass": True,
+        }
+
+    # ── Structure guard: checkbox/勾選 inline layouts ─────────────────────────
+    # These tables mix fill-in blanks with checkbox option lists on extra lines
+    # inside the same cell. Positional alignment between schema rows and DOCX rows
+    # is unreliable → classify as structure_unsupported, skip (not FAIL).
+    if _has_checkbox_structure(rows_out):
+        return {
+            "available": True,
+            "structure_unsupported": True,
+            "note": "checkbox/勾選 inline layout — positional alignment unreliable, skipped",
+            "text_fidelity": 1.0,
+            "total_cells_checked": 0,
+            "matched_cells": 0,
             "mismatches": [],
             "pass": True,
         }

--- a/scripts/eval_keypoints_text_fidelity.py
+++ b/scripts/eval_keypoints_text_fidelity.py
@@ -340,10 +340,23 @@ def eval_keypoints_text_fidelity(
                     "diff": "blank not found in DOCX",
                 })
 
-    # ── Row cardinality: unmatched schema rows → mismatch ────────────────────
-    # Schema rows beyond n_pairs had no DOCX counterpart. Silently dropping them
-    # would produce a false pass (BLOCKING 1). Each unmatched row produces a
-    # mismatch with docx_text="<row missing from DOCX>".
+    # ── Row cardinality: unmatched rows on both sides → mismatch ─────────────
+    # n_pairs = min(schema, docx) silently drops trailing rows on the longer side.
+    # Both directions must produce mismatches to prevent false-pass:
+    #
+    # (A) schema > docx: extra schema rows have no DOCX counterpart.
+    #     → mismatch per row (docx_text="<row missing from DOCX>")
+    #
+    # (B) docx > schema: extra DOCX rows have no schema counterpart.
+    #     _flatten_docx_rows already skips title/header via _skip_header_rows,
+    #     so every remaining row is a content row.
+    #     → mismatch per row (schema_text="<row missing from schema>")
+    #
+    # Checkbox cells in unmatched schema rows are skipped (counted as skipped_cells),
+    # since their positional alignment is already unreliable.
+    # No analogous filter for unmatched DOCX rows: they're content by definition.
+
+    # (A) Unmatched schema rows
     for idx in range(n_pairs, n_schema):
         s = schema_flat[idx]
         if _is_checkbox_only_cell(s):
@@ -378,6 +391,24 @@ def eval_keypoints_text_fidelity(
                 "diff": "blank not found in DOCX (row missing)",
             })
 
+    # (B) Unmatched DOCX rows (docx > schema)
+    # _flatten_docx_rows already strips title/header via _skip_header_rows,
+    # so every entry here is a real content row.
+    n_docx = len(docx_flat)
+    for idx in range(n_pairs, n_docx):
+        d = docx_flat[idx]
+        docx_value_text = normalize_text(docx_text_to_template(d["value_text"]))
+        total_cells += 1
+        mismatches.append({
+            "row": f"docx_{idx}",
+            "label": "<extra DOCX row>",
+            "field": "value",
+            "match": False,
+            "schema_text": "<row missing from schema>",
+            "docx_text": docx_value_text,
+            "diff": "DOCX row has no schema counterpart",
+        })
+
     # ── Whole-lesson checkbox guard ───────────────────────────────────────────
     # If every paired cell was checkbox-only (nothing to check), mark as
     # structure_unsupported to avoid a trivially "passing" 0/0 result.
@@ -395,10 +426,16 @@ def eval_keypoints_text_fidelity(
         }
 
     # ── Extraction empty guard (BLOCKING 2) ──────────────────────────────────
-    # Non-checkbox schema with zero comparable cells extracted: DOCX provided no
-    # data rows. This is not "all checkbox-only" (skipped_cells==0) — it means the
-    # DOCX extraction returned nothing for a non-empty schema.
-    # Zero comparison ≠ passing → flag as extraction_empty and fail.
+    # Originally added when DOCX returned 0 rows → total_cells=0 → silent pass.
+    # After adding the symmetric cardinality loops (A) and (B), this guard is now
+    # unreachable in practice:
+    #   - If DOCX is empty AND schema_flat is non-empty AND no checkbox cells:
+    #     loop (A) adds every schema row to total_cells (as "<row missing from DOCX>")
+    #     → total_cells > 0 before we reach this guard.
+    #   - If DOCX is empty AND all schema cells are checkbox-only:
+    #     skipped_cells > 0 → the checkbox guard above fires first.
+    # Kept as a defensive belt-and-suspenders against future code changes that might
+    # skip the cardinality loops (e.g., early returns added above them).
     if total_cells == 0 and skipped_cells == 0 and schema_flat:
         return {
             "available": True,

--- a/scripts/eval_keypoints_text_fidelity.py
+++ b/scripts/eval_keypoints_text_fidelity.py
@@ -267,6 +267,7 @@ def eval_keypoints_text_fidelity(
     skipped_cells = 0  # cells skipped due to checkbox-only structure
 
     n_pairs = min(len(schema_flat), len(docx_flat))
+    n_schema = len(schema_flat)
 
     for idx in range(n_pairs):
         s = schema_flat[idx]
@@ -339,6 +340,44 @@ def eval_keypoints_text_fidelity(
                     "diff": "blank not found in DOCX",
                 })
 
+    # ── Row cardinality: unmatched schema rows → mismatch ────────────────────
+    # Schema rows beyond n_pairs had no DOCX counterpart. Silently dropping them
+    # would produce a false pass (BLOCKING 1). Each unmatched row produces a
+    # mismatch with docx_text="<row missing from DOCX>".
+    for idx in range(n_pairs, n_schema):
+        s = schema_flat[idx]
+        if _is_checkbox_only_cell(s):
+            skipped_cells += 1
+            continue
+        row_idx = s["row_idx"]
+        label = s["label"]
+        field = s["field"]
+        schema_normalized = normalize_text(s["schema_text"])
+        total_cells += 1
+        mismatches.append({
+            "row": row_idx,
+            "label": label,
+            "field": field,
+            "match": False,
+            "schema_text": schema_normalized,
+            "docx_text": "<row missing from DOCX>",
+            "diff": "schema row has no DOCX counterpart",
+        })
+        # Also count each blank as missing
+        for b_idx, blank_spec in enumerate(s["blanks"]):
+            schema_answer = blank_spec.get("answer") or ""
+            schema_answer_norm = normalize_text(str(schema_answer))
+            total_cells += 1
+            mismatches.append({
+                "row": row_idx,
+                "label": label,
+                "field": f"answer[{b_idx}]",
+                "match": False,
+                "schema_text": schema_answer_norm,
+                "docx_text": "<missing>",
+                "diff": "blank not found in DOCX (row missing)",
+            })
+
     # ── Whole-lesson checkbox guard ───────────────────────────────────────────
     # If every paired cell was checkbox-only (nothing to check), mark as
     # structure_unsupported to avoid a trivially "passing" 0/0 result.
@@ -353,6 +392,23 @@ def eval_keypoints_text_fidelity(
             "skipped_cells": skipped_cells,
             "mismatches": [],
             "pass": True,
+        }
+
+    # ── Extraction empty guard (BLOCKING 2) ──────────────────────────────────
+    # Non-checkbox schema with zero comparable cells extracted: DOCX provided no
+    # data rows. This is not "all checkbox-only" (skipped_cells==0) — it means the
+    # DOCX extraction returned nothing for a non-empty schema.
+    # Zero comparison ≠ passing → flag as extraction_empty and fail.
+    if total_cells == 0 and skipped_cells == 0 and schema_flat:
+        return {
+            "available": True,
+            "extraction_empty": True,
+            "note": "DOCX returned no comparable rows for non-empty schema — possible extraction failure",
+            "text_fidelity": 0.0,
+            "total_cells_checked": 0,
+            "matched_cells": 0,
+            "mismatches": [],
+            "pass": False,
         }
 
     text_fidelity = matched_cells / total_cells if total_cells > 0 else 1.0

--- a/scripts/eval_keypoints_text_fidelity.py
+++ b/scripts/eval_keypoints_text_fidelity.py
@@ -31,13 +31,17 @@ def normalize_text(text: str) -> str:
     """
     Normalize text for comparison:
     1. NFKC (full-width ← ASCII, combines compatibility chars)
-    2. Strip surrounding whitespace
-    3. Collapse internal consecutive whitespace to single space
-    4. Normalize full-width/half-width punctuation via NFKC (covered by step 1)
+    2. Normalize empty blank markers 【 】/【　】/【】 → __ (semantically identical to __)
+       NOTE: only EMPTY brackets — 【answer】 (non-empty) is left intact so real
+       answer comparisons are not swallowed.
+    3. Strip surrounding whitespace
+    4. Collapse internal consecutive whitespace to single space
     """
     if not text:
         return ""
     text = unicodedata.normalize("NFKC", text)
+    # Replace empty blank markers with __ BEFORE stripping (NFKC already normalised spaces)
+    text = EMPTY_BLANK_MARKER_RE.sub("__", text)
     text = text.strip()
     text = re.sub(r"\s+", " ", text)
     return text
@@ -46,8 +50,14 @@ def normalize_text(text: str) -> str:
 BLANK_RE = re.compile(r"【(.*?)】")
 
 # Markers that indicate inline checkbox option lists in schema templates.
-# These make positional DOCX↔schema alignment unreliable — skip fidelity check.
-CHECKBOX_MARKER_RE = re.compile(r"□|勾選")
+# Cell-level: a cell is "checkbox-only" if its template/value contains □/勾選/單選/複選
+# AND has no real fill-in blanks (blanks list is empty).
+CHECKBOX_MARKER_RE = re.compile(r"□|勾選|單選|複選")
+
+# Empty blank markers: 【 】/【　】/【】 (only whitespace/ideographic-space inside brackets).
+# These are instruction markers meaning "fill in here" — semantically identical to __.
+# Normalize them to __ before text comparison.
+EMPTY_BLANK_MARKER_RE = re.compile(r"【[\s　]*】")
 
 
 def extract_blanks_from_docx_text(text: str) -> list:
@@ -94,28 +104,33 @@ def _skip_header_rows(rows_raw: list) -> int:
     return skip
 
 
-def _has_checkbox_structure(rows_out: list) -> bool:
+def _is_checkbox_only_cell(schema_cell: dict) -> bool:
     """
-    Return True if any schema row or sub_row template/value contains inline
-    checkbox markers (□ or 勾選).
+    Return True if this schema cell (a flat row or sub_row dict) is a checkbox-only
+    cell that should be SKIPPED in fidelity comparison.
 
-    These layouts interleave fill-in blanks with multiple-choice checkbox options
-    on extra lines inside the same DOCX cell. Positional DOCX↔schema alignment
-    breaks for these tables — classifying them as structure_unsupported avoids
-    false-positive mismatches.
+    A cell is checkbox-only when ALL of:
+    1. Its template/value text contains checkbox markers (□/勾選/單選/複選)
+    2. It has NO real fill-in blanks (blanks list is empty)
 
-    Real example: G5-L20 template =
-      "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜 \n惱怒 煩躁"
+    Rationale: checkbox-only cells interleave option lists with the fill-in text
+    in a layout that doesn't align positionally to DOCX rows. Cells WITH blanks
+    (even if also containing checkbox text) are real fill-in rows — verify them.
+
+    Real example of checkbox-only: G4-L2 sub_row =
+      template = "（單選）\n□驕傲地奪得銀牌\n不甘心以微小的差距奪得銀牌"
+      blanks = []   ← no real fill-in → skip
+
+    Real example of real fill-in (must NOT skip): G5-L20 sub_row =
+      template = "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜..."
+      blanks = [{"answer": "如何回應"}, {"answer": "尷尬"}]  ← has real blanks
+      (These are genuinely hard to align → caught by positional drift, reported)
     """
-    for row in rows_out:
-        for text_field in (row.get("value", ""), row.get("template", "")):
-            if CHECKBOX_MARKER_RE.search(text_field):
-                return True
-        for sr in row.get("sub_rows", []):
-            for text_field in (sr.get("value", ""), sr.get("template", "")):
-                if CHECKBOX_MARKER_RE.search(text_field):
-                    return True
-    return False
+    # schema_cell is a flat cell from _flatten_schema_rows() — text is in "schema_text"
+    text = schema_cell.get("schema_text") or ""
+    has_checkbox_text = bool(CHECKBOX_MARKER_RE.search(text))
+    has_real_blanks = bool(schema_cell.get("blanks"))
+    return has_checkbox_text and not has_real_blanks
 
 
 def _flatten_schema_rows(rows_out: list, structure: str) -> list:
@@ -224,22 +239,6 @@ def eval_keypoints_text_fidelity(
             "pass": True,
         }
 
-    # ── Structure guard: checkbox/勾選 inline layouts ─────────────────────────
-    # These tables mix fill-in blanks with checkbox option lists on extra lines
-    # inside the same cell. Positional alignment between schema rows and DOCX rows
-    # is unreliable → classify as structure_unsupported, skip (not FAIL).
-    if _has_checkbox_structure(rows_out):
-        return {
-            "available": True,
-            "structure_unsupported": True,
-            "note": "checkbox/勾選 inline layout — positional alignment unreliable, skipped",
-            "text_fidelity": 1.0,
-            "total_cells_checked": 0,
-            "matched_cells": 0,
-            "mismatches": [],
-            "pass": True,
-        }
-
     # ── Load DOCX rows ────────────────────────────────────────────────────────
     if _docx_rows_override is not None:
         docx_raw_rows = _docx_rows_override
@@ -265,6 +264,7 @@ def eval_keypoints_text_fidelity(
     mismatches = []
     total_cells = 0
     matched_cells = 0
+    skipped_cells = 0  # cells skipped due to checkbox-only structure
 
     n_pairs = min(len(schema_flat), len(docx_flat))
 
@@ -278,6 +278,14 @@ def eval_keypoints_text_fidelity(
         field = s["field"]
         row_idx = s["row_idx"]
         label = s["label"]
+
+        # ── Cell-level checkbox guard ─────────────────────────────────────────
+        # Skip cells where schema template/value has checkbox markers AND no real
+        # fill-in blanks. These cells are checkbox-only (option lists) and cannot
+        # be aligned positionally. Real fill-in cells (has blanks) are always checked.
+        if _is_checkbox_only_cell(s):
+            skipped_cells += 1
+            continue
 
         # ── Compare template/value text (blanks replaced with __) ────────────
         docx_as_template = normalize_text(docx_text_to_template(docx_value_text))
@@ -331,9 +339,25 @@ def eval_keypoints_text_fidelity(
                     "diff": "blank not found in DOCX",
                 })
 
+    # ── Whole-lesson checkbox guard ───────────────────────────────────────────
+    # If every paired cell was checkbox-only (nothing to check), mark as
+    # structure_unsupported to avoid a trivially "passing" 0/0 result.
+    if total_cells == 0 and skipped_cells > 0:
+        return {
+            "available": True,
+            "structure_unsupported": True,
+            "note": "all cells are checkbox-only — positional alignment unreliable, skipped",
+            "text_fidelity": 1.0,
+            "total_cells_checked": 0,
+            "matched_cells": 0,
+            "skipped_cells": skipped_cells,
+            "mismatches": [],
+            "pass": True,
+        }
+
     text_fidelity = matched_cells / total_cells if total_cells > 0 else 1.0
 
-    return {
+    result = {
         "available": True,
         "text_fidelity": round(text_fidelity, 4),
         "total_cells_checked": total_cells,
@@ -341,6 +365,9 @@ def eval_keypoints_text_fidelity(
         "mismatches": mismatches,
         "pass": len(mismatches) == 0,
     }
+    if skipped_cells > 0:
+        result["skipped_cells"] = skipped_cells
+    return result
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/scripts/eval_keypoints_text_fidelity.py
+++ b/scripts/eval_keypoints_text_fidelity.py
@@ -1,0 +1,336 @@
+"""
+eval_keypoints_text_fidelity.py — Slice ②: text fidelity check for keypoints schema.
+
+Detects false-pass cases where row/blank COUNT metrics pass but the actual
+text content of individual cells is garbled, merged, or wrong.
+
+Usage (as a module):
+    from eval_keypoints_text_fidelity import eval_keypoints_text_fidelity
+
+    result = eval_keypoints_text_fidelity(
+        lesson_id="G6-L22",
+        docx_path=Path("...G6-L22.docx"),
+        schema_dir=Path("private/curriculum-source/_online-schema/"),
+        bls=bls_module,
+    )
+
+For testing without a real DOCX, supply _schema_override and _docx_rows_override.
+"""
+
+import re
+import unicodedata
+from pathlib import Path
+from typing import Optional, Any
+
+import yaml
+
+
+# ─── Normalization ────────────────────────────────────────────────────────────
+
+def normalize_text(text: str) -> str:
+    """
+    Normalize text for comparison:
+    1. NFKC (full-width ← ASCII, combines compatibility chars)
+    2. Strip surrounding whitespace
+    3. Collapse internal consecutive whitespace to single space
+    4. Normalize full-width/half-width punctuation via NFKC (covered by step 1)
+    """
+    if not text:
+        return ""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.strip()
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+BLANK_RE = re.compile(r"【(.*?)】")
+
+
+def extract_blanks_from_docx_text(text: str) -> list:
+    """Extract answer strings from 【...】 patterns in a DOCX cell."""
+    blanks = []
+    for m in BLANK_RE.finditer(text):
+        raw = m.group(1).strip()
+        answer = re.sub(r"\s+", "", raw).replace("　", "")  # remove ideographic spaces
+        blanks.append(answer)
+    return blanks
+
+
+def docx_text_to_template(text: str) -> str:
+    """Replace 【...】 with __ to match schema template format."""
+    return BLANK_RE.sub("__", text).strip()
+
+
+# ─── Row matching helpers ─────────────────────────────────────────────────────
+
+def _skip_header_rows(rows_raw: list) -> int:
+    """
+    Return the number of rows to skip (title + header rows), same logic as eval_keypoints.
+    """
+    import re as _re
+    skip = 0
+    if not rows_raw:
+        return 0
+    # Title row: single non-dup cell, no blanks
+    first_non_dup = [c for c in rows_raw[0]["cells"] if not c.get("dup")]
+    if len(first_non_dup) == 1 and not BLANK_RE.search(first_non_dup[0]["text"]):
+        skip += 1
+    elif (len(first_non_dup) >= 2 and
+          not first_non_dup[0]["text"].strip() and
+          not first_non_dup[0].get("has_blank") and
+          not BLANK_RE.search(first_non_dup[1]["text"])):
+        skip += 1  # empty-label header variant
+    # Header row: contains 提示/元素/重點/段落 keywords
+    if skip < len(rows_raw):
+        next_row = rows_raw[skip]
+        next_cells = [c for c in next_row["cells"] if not c.get("dup")]
+        cell_texts = " ".join(c["text"] for c in next_cells)
+        if _re.search(r"提示|元素|重點|段落", cell_texts):
+            skip += 1
+    return skip
+
+
+def _flatten_schema_rows(rows_out: list, structure: str) -> list:
+    """
+    Flatten schema rows (including sub_rows) into a list of cell comparison specs.
+    Each spec: {"row_idx": str, "field": str, "schema_text": str, "blanks": list}
+    row_idx is like "0", "1_0", "1_1" (parent_subrow).
+    """
+    flat = []
+    for i, row in enumerate(rows_out):
+        if row.get("sub_rows"):
+            for j, sr in enumerate(row["sub_rows"]):
+                template = sr.get("template", "")
+                blanks = sr.get("blanks", [])
+                flat.append({
+                    "row_idx": f"{i}_{j}",
+                    "label": row.get("label", ""),
+                    "sub_label": sr.get("sub_label", ""),
+                    "field": "template",
+                    "schema_text": template,
+                    "blanks": blanks,
+                })
+        else:
+            value = row.get("value", "")
+            blanks = row.get("blanks", [])
+            flat.append({
+                "row_idx": str(i),
+                "label": row.get("label", ""),
+                "sub_label": "",
+                "field": "value",
+                "schema_text": value,
+                "blanks": blanks,
+            })
+    return flat
+
+
+def _flatten_docx_rows(rows_raw: list, skip: int) -> list:
+    """
+    Flatten DOCX rows (after skipping title/header) into a list of value-column texts.
+    Each entry: {"value_text": str, "raw_row": dict}
+    For nested tables, the value column is the last non-dup cell.
+    For flat tables, it's cells[1].
+    """
+    flat = []
+    for row in rows_raw[skip:]:
+        cells = [c for c in row["cells"] if not c.get("dup")]
+        if not cells:
+            continue
+        # Value column: last cell (works for both 2-col flat and 3-col nested)
+        value_text = cells[-1]["text"] if cells else ""
+        flat.append({"value_text": value_text, "cells": cells})
+    return flat
+
+
+# ─── Main fidelity function ───────────────────────────────────────────────────
+
+def eval_keypoints_text_fidelity(
+    lesson_id: str,
+    docx_path,
+    schema_dir,
+    bls,
+    *,
+    _schema_override: Optional[dict] = None,
+    _docx_rows_override: Optional[list] = None,
+) -> dict:
+    """
+    Check that the text content of each keypoints schema cell matches the DOCX.
+
+    Returns:
+        {
+            "available": bool,
+            "text_fidelity": float,   # matched_cells / total_cells
+            "mismatches": [...],      # list of per-cell mismatch dicts
+            "pass": bool,             # True only if mismatches == []
+        }
+
+    For testing without a real DOCX, supply:
+        _schema_override: pre-loaded keypoints schema dict
+        _docx_rows_override: list of row dicts (same format as kp_table_raw["rows"])
+    """
+    # ── Load schema ───────────────────────────────────────────────────────────
+    if _schema_override is not None:
+        kp_schema = _schema_override
+    else:
+        kp_path = Path(schema_dir) / f"{lesson_id}.keypoints.yml"
+        if not kp_path.exists():
+            return {
+                "available": False,
+                "note": "no keypoints.yml",
+                "text_fidelity": 0.0,
+                "mismatches": [],
+                "pass": False,
+            }
+        with open(kp_path, encoding="utf-8") as f:
+            kp_schema = yaml.safe_load(f)
+
+    rows_out = kp_schema.get("keypoints", {}).get("rows", [])
+    structure = kp_schema.get("keypoints", {}).get("structure", "flat")
+
+    if not rows_out:
+        return {
+            "available": False,
+            "note": "schema has no rows",
+            "text_fidelity": 1.0,
+            "mismatches": [],
+            "pass": True,
+        }
+
+    # ── Load DOCX rows ────────────────────────────────────────────────────────
+    if _docx_rows_override is not None:
+        docx_raw_rows = _docx_rows_override
+        skip = 0  # caller provides data rows directly (no title/header)
+    else:
+        raw_blocks = bls.extract_raw(str(docx_path))
+        kp_table_raw = bls.find_keypoints_table(raw_blocks, lesson_id)
+        if kp_table_raw is None:
+            return {
+                "available": False,
+                "note": "find_keypoints_table returned None",
+                "text_fidelity": 0.0,
+                "mismatches": [],
+                "pass": False,
+            }
+        docx_raw_rows = kp_table_raw["rows"]
+        skip = _skip_header_rows(docx_raw_rows)
+
+    docx_flat = _flatten_docx_rows(docx_raw_rows, skip)
+    schema_flat = _flatten_schema_rows(rows_out, structure)
+
+    # ── Positional comparison ─────────────────────────────────────────────────
+    mismatches = []
+    total_cells = 0
+    matched_cells = 0
+
+    n_pairs = min(len(schema_flat), len(docx_flat))
+
+    for idx in range(n_pairs):
+        s = schema_flat[idx]
+        d = docx_flat[idx]
+
+        docx_value_text = d["value_text"]
+        schema_text = s["schema_text"]
+        blanks = s["blanks"]
+        field = s["field"]
+        row_idx = s["row_idx"]
+        label = s["label"]
+
+        # ── Compare template/value text (blanks replaced with __) ────────────
+        docx_as_template = normalize_text(docx_text_to_template(docx_value_text))
+        schema_normalized = normalize_text(schema_text)
+        total_cells += 1
+
+        if docx_as_template == schema_normalized:
+            matched_cells += 1
+        else:
+            mismatches.append({
+                "row": row_idx,
+                "label": label,
+                "field": field,
+                "match": False,
+                "schema_text": schema_normalized,
+                "docx_text": docx_as_template,
+                "diff": _short_diff(schema_normalized, docx_as_template),
+            })
+
+        # ── Compare blank answers ─────────────────────────────────────────────
+        docx_blanks = extract_blanks_from_docx_text(docx_value_text)
+        for b_idx, blank_spec in enumerate(blanks):
+            schema_answer = blank_spec.get("answer") or ""
+            schema_answer_norm = normalize_text(str(schema_answer))
+            total_cells += 1
+
+            if b_idx < len(docx_blanks):
+                docx_answer = normalize_text(docx_blanks[b_idx])
+                # Handle multi-answer (slash-separated): accept if any part matches
+                if _answers_match(schema_answer_norm, docx_answer):
+                    matched_cells += 1
+                else:
+                    mismatches.append({
+                        "row": row_idx,
+                        "label": label,
+                        "field": f"answer[{b_idx}]",
+                        "match": False,
+                        "schema_text": schema_answer_norm,
+                        "docx_text": docx_answer,
+                        "diff": _short_diff(schema_answer_norm, docx_answer),
+                    })
+            else:
+                # DOCX has fewer blanks than schema expects
+                mismatches.append({
+                    "row": row_idx,
+                    "label": label,
+                    "field": f"answer[{b_idx}]",
+                    "match": False,
+                    "schema_text": schema_answer_norm,
+                    "docx_text": "<missing>",
+                    "diff": "blank not found in DOCX",
+                })
+
+    text_fidelity = matched_cells / total_cells if total_cells > 0 else 1.0
+
+    return {
+        "available": True,
+        "text_fidelity": round(text_fidelity, 4),
+        "total_cells_checked": total_cells,
+        "matched_cells": matched_cells,
+        "mismatches": mismatches,
+        "pass": len(mismatches) == 0,
+    }
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _answers_match(schema_answer: str, docx_answer: str) -> bool:
+    """
+    Allow slash-separated alternatives: "天亮／提前開啟" means either is acceptable.
+    Also normalize variations of slash character.
+    """
+    # Normalize slash variants
+    schema_parts = re.split(r"[/／]", schema_answer)
+    schema_parts = [p.strip() for p in schema_parts if p.strip()]
+    docx_parts = re.split(r"[/／]", docx_answer)
+    docx_parts = [p.strip() for p in docx_parts if p.strip()]
+
+    # Accept if any schema part matches any docx part
+    for sp in schema_parts:
+        for dp in docx_parts:
+            if sp == dp:
+                return True
+    return False
+
+
+def _short_diff(a: str, b: str, max_len: int = 80) -> str:
+    """Short human-readable diff string."""
+    if a == b:
+        return ""
+    # Find first differing character
+    for i, (ca, cb) in enumerate(zip(a, b)):
+        if ca != cb:
+            start = max(0, i - 10)
+            snippet_a = a[start:start + max_len]
+            snippet_b = b[start:start + max_len]
+            return f"first diff at char {i}: schema='{snippet_a}' docx='{snippet_b}'"
+    # One is longer
+    shorter_len = min(len(a), len(b))
+    return f"schema({len(a)}chars) vs docx({len(b)}chars), same first {shorter_len} chars"

--- a/scripts/eval_lesson_schema.py
+++ b/scripts/eval_lesson_schema.py
@@ -20,6 +20,28 @@ from pathlib import Path
 
 import yaml
 
+# ─── Load eval_keypoints_text_fidelity module ─────────────────────────────────
+
+def load_text_fidelity_module():
+    spec = importlib.util.spec_from_file_location(
+        "ektf", Path(__file__).parent / "eval_keypoints_text_fidelity.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ─── Load gen_lesson_intent module ────────────────────────────────────────────
+
+def load_intent_module():
+    spec = importlib.util.spec_from_file_location(
+        "gli", Path(__file__).parent / "gen_lesson_intent.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 # ─── Load build_lesson_schema module ──────────────────────────────────────────
 
 def load_bls():
@@ -414,7 +436,15 @@ def eval_strategy(lesson_id: str, docx_path: Path, bls) -> dict:
     }
 
 
-def eval_lesson(lesson_id: str, docx_path: Path, schema_dir: Path, bls) -> dict:
+def eval_lesson(
+    lesson_id: str,
+    docx_path: Path,
+    schema_dir: Path,
+    bls,
+    *,
+    include_text_fidelity: bool = False,
+    include_intent_drift: bool = False,
+) -> dict:
     """Full eval for one lesson."""
     if not Path(docx_path).exists():
         return {"lesson_id": lesson_id, "error": "DOCX not found"}
@@ -423,12 +453,29 @@ def eval_lesson(lesson_id: str, docx_path: Path, schema_dir: Path, bls) -> dict:
     sp = eval_spotlight(lesson_id, docx_path, schema_dir, bls)
     st = eval_strategy(lesson_id, docx_path, bls)
 
-    return {
+    result = {
         "lesson_id": lesson_id,
         "strategy": st,
         "keypoints": kp,
         "spotlight": sp,
     }
+
+    if include_text_fidelity:
+        ektf_mod = load_text_fidelity_module()
+        kp_tf = ektf_mod.eval_keypoints_text_fidelity(
+            lesson_id=lesson_id,
+            docx_path=docx_path,
+            schema_dir=schema_dir,
+            bls=bls,
+        )
+        result["keypoints_text_fidelity"] = kp_tf
+
+    if include_intent_drift:
+        gli_mod = load_intent_module()
+        drift = gli_mod.check_intent_stale_from_files(lesson_id, Path(schema_dir))
+        result["intent_drift"] = drift
+
+    return result
 
 
 # ─── Reporting ─────────────────────────────────────────────────────────────────
@@ -500,6 +547,16 @@ def main():
     parser.add_argument("--test", action="store_true", help="Eval TEST set (15 held-out lessons)")
     parser.add_argument("--report", action="store_true", help="Full report (DEV + TEST + gap)")
     parser.add_argument("--all", action="store_true", help="Eval all discovered DOCX lessons")
+    parser.add_argument(
+        "--text-fidelity",
+        action="store_true",
+        help="Also run keypoints text fidelity check (Slice ②)",
+    )
+    parser.add_argument(
+        "--check-intent-drift",
+        action="store_true",
+        help="Also check intent drift (Slice ③ drift-lock)",
+    )
     args = parser.parse_args()
 
     bls = load_bls()
@@ -521,7 +578,11 @@ def main():
         batch = importlib.util.module_from_spec(batch_spec)
         batch_spec.loader.exec_module(batch)
         all_results = [
-            eval_lesson(lid, path, schema_dir, bls)
+            eval_lesson(
+                lid, path, schema_dir, bls,
+                include_text_fidelity=args.text_fidelity,
+                include_intent_drift=args.check_intent_drift,
+            )
             for lid, path in batch.discover_lessons()
         ]
         kp_eligible = [r for r in all_results if r.get("keypoints", {}).get("available")]
@@ -544,7 +605,14 @@ def main():
 
     if args.lesson_id and args.docx_path:
         # Single lesson eval
-        result = eval_lesson(args.lesson_id, Path(args.docx_path), schema_dir, bls)
+        result = eval_lesson(
+            args.lesson_id,
+            Path(args.docx_path),
+            schema_dir,
+            bls,
+            include_text_fidelity=args.text_fidelity,
+            include_intent_drift=args.check_intent_drift,
+        )
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return
 

--- a/scripts/eval_lesson_schema.py
+++ b/scripts/eval_lesson_schema.py
@@ -601,6 +601,65 @@ def main():
             print("FAILURES:")
             for lid, kp in kp_fail:
                 print(f"  {lid}: row_recall={kp.get('row_recall')} blank_recall={kp.get('blank_recall')} label_family={kp.get('label_family_correct')}")
+
+        # ── Text fidelity summary (Slice ②) ──────────────────────────────────
+        if args.text_fidelity:
+            fid_results = [
+                r for r in all_results
+                if r.get("keypoints_text_fidelity") is not None
+            ]
+            # available=False means no keypoints.yml — treat as NA, not FAIL
+            fid_available = [r for r in fid_results if r["keypoints_text_fidelity"].get("available")]
+            fid_not_available = [r for r in fid_results if not r["keypoints_text_fidelity"].get("available")]
+            fid_unsupported = [r for r in fid_available if r["keypoints_text_fidelity"].get("structure_unsupported")]
+            fid_pass = [r for r in fid_available if r["keypoints_text_fidelity"].get("pass") and not r["keypoints_text_fidelity"].get("structure_unsupported")]
+            fid_fail = [r for r in fid_available if not r["keypoints_text_fidelity"].get("pass") and not r["keypoints_text_fidelity"].get("structure_unsupported")]
+            fid_na = [r for r in all_results if r.get("keypoints_text_fidelity") is None] + fid_not_available
+
+            print(f"\n{'='*80}")
+            print("TEXT FIDELITY SUMMARY (Slice ②)")
+            print(f"{'='*80}")
+            print(f"PASS (text matches):          {len(fid_pass)}")
+            print(f"FAIL (text mismatch):         {len(fid_fail)}")
+            print(f"NA (structure_unsupported):   {len(fid_unsupported)}")
+            print(f"NA (no keypoints.yml/error):  {len(fid_na)}")
+
+            if fid_fail:
+                print(f"\nFAIL lessons (sorted by fidelity score, lowest first):")
+                fail_sorted = sorted(
+                    fid_fail,
+                    key=lambda r: r["keypoints_text_fidelity"].get("text_fidelity", 0.0)
+                )
+                for r in fail_sorted:
+                    fid = r["keypoints_text_fidelity"]
+                    score = fid.get("text_fidelity", 0.0)
+                    total = fid.get("total_cells_checked", 0)
+                    matched = fid.get("matched_cells", 0)
+                    n_mm = len(fid.get("mismatches", []))
+                    print(f"  {r['lesson_id']:<14} fid={score:.3f} ({matched}/{total} cells) mismatches={n_mm}")
+                    # Print first mismatch for quick human review
+                    mm_list = fid.get("mismatches", [])
+                    first_mm = mm_list[0] if mm_list else None
+                    if first_mm:
+                        print(f"    first mismatch: row={first_mm.get('row')} field={first_mm.get('field')}")
+                        print(f"      schema: {str(first_mm.get('schema_text',''))[:60]}")
+                        print(f"      docx:   {str(first_mm.get('docx_text',''))[:60]}")
+
+            # High-confidence true errors: fidelity >= 0.8 but still FAIL
+            # (most cells match, only 1-2 specific cells diverge → likely real content error)
+            high_conf_errors = [
+                r for r in fid_fail
+                if r["keypoints_text_fidelity"].get("text_fidelity", 0.0) >= 0.8
+            ]
+            if high_conf_errors:
+                print(f"\nHIGH-CONFIDENCE TRUE ERRORS (fid >= 0.8, {len(high_conf_errors)} lessons):")
+                print("  These are most likely real schema content errors (not alignment issues):")
+                for r in sorted(high_conf_errors, key=lambda x: -x["keypoints_text_fidelity"].get("text_fidelity", 0.0)):
+                    fid = r["keypoints_text_fidelity"]
+                    print(f"  {r['lesson_id']:<14} fid={fid.get('text_fidelity'):.3f}")
+                    for mm in fid.get("mismatches", []):
+                        print(f"    [{mm.get('field')}] schema='{str(mm.get('schema_text',''))[:50]}' docx='{str(mm.get('docx_text',''))[:50]}'")
+
         return
 
     if args.lesson_id and args.docx_path:

--- a/scripts/gen_lesson_intent.py
+++ b/scripts/gen_lesson_intent.py
@@ -67,9 +67,14 @@ def infer_cognitive_skill(
 
     Rules (in priority order):
     1. If template contains 推論/判斷/為什麼 keywords → inference
-    2. If label matches 結果/結論/總結 AND has sub_rows → synthesis
-    3. If answer is single char or short phrase (<=5 chars) AND label is 解決 → recall
+    2. If effective_label (sub_label or label) matches 結果/結論/總結 AND structure
+       is nested → synthesis  (section-level labels signal higher-order synthesis)
+    3. If answer is a short phrase (<= VERBATIM_RECALL_THRESHOLD chars) → recall
+       (short, exact-wording answers are verbatim recall regardless of label)
     4. Default → recall
+
+    Note: `strategy_type` is accepted but not used in v1. Reserved for future
+    extensions (e.g., distinguish story-map vs. compare-contrast strategy types).
     """
     effective_label = sub_label or label
 

--- a/scripts/gen_lesson_intent.py
+++ b/scripts/gen_lesson_intent.py
@@ -1,0 +1,411 @@
+"""
+gen_lesson_intent.py — Slice ③: lesson intent draft + drift-lock.
+
+Generates an intent annotation YAML per lesson, capturing:
+  - cognitive_skill per blank/row (rule-based v1)
+  - answer_criterion per blank
+  - schema_fingerprint for drift detection
+
+Usage:
+    # Generate intent for G6-L22
+    python3 scripts/gen_lesson_intent.py G6-L22 \\
+        --schema-dir private/curriculum-source/_online-schema/ \\
+        --docx "private/curriculum-source/2026-05-01/.../G6-L22....docx" \\
+        --output private/curriculum-source/_online-schema/G6-L22.intent.yml
+
+    # Check if intent is stale (schema changed since intent was generated)
+    python3 scripts/gen_lesson_intent.py G6-L22 \\
+        --schema-dir private/curriculum-source/_online-schema/ \\
+        --check-drift
+
+As a module:
+    from gen_lesson_intent import gen_lesson_intent_for_schema, check_intent_stale_from_dicts
+"""
+
+import sys
+import re
+import hashlib
+import json
+import argparse
+import datetime
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+# ─── Fingerprint ─────────────────────────────────────────────────────────────
+
+def compute_schema_fingerprint(kp_schema: dict) -> str:
+    """Compute SHA-256 hex digest of the schema dict (stable JSON serialization)."""
+    canonical = json.dumps(kp_schema, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ─── Cognitive skill inference (rule-based v1) ───────────────────────────────
+
+# Keywords that suggest inference-level thinking
+INFERENCE_KEYWORDS = re.compile(r"推論|判斷|為什麼|原因|影響|如何|怎麼|分析|比較")
+
+# Labels / sub_labels associated with synthesis (result/conclusion)
+SYNTHESIS_LABELS = re.compile(r"^(結果|結論|總結|影響|體會|心得|作者反思)")
+
+# Recall: short single-word answers are typically verbatim recall
+VERBATIM_RECALL_THRESHOLD = 5  # chars — answers <= this are verbatim
+
+
+def infer_cognitive_skill(
+    label: str,
+    sub_label: str,
+    template: str,
+    answer: str,
+    structure: str,
+    strategy_type: str = "",
+) -> str:
+    """
+    Rule-based v1 cognitive skill assignment.
+
+    Rules (in priority order):
+    1. If template contains 推論/判斷/為什麼 keywords → inference
+    2. If label matches 結果/結論/總結 AND has sub_rows → synthesis
+    3. If answer is single char or short phrase (<=5 chars) AND label is 解決 → recall
+    4. Default → recall
+    """
+    effective_label = sub_label or label
+
+    # Rule 1: inference keywords in template
+    if template and INFERENCE_KEYWORDS.search(template):
+        return "inference"
+
+    # Rule 2: synthesis label with structure context
+    if SYNTHESIS_LABELS.match(effective_label) and structure == "nested":
+        return "synthesis"
+
+    # Rule 3: short answer = recall
+    if answer and len(answer.strip()) <= VERBATIM_RECALL_THRESHOLD:
+        return "recall"
+
+    # Default
+    return "recall"
+
+
+def infer_answer_criterion(answer: str, cognitive_skill: str) -> str:
+    """
+    Infer answer_criterion from answer content and cognitive_skill.
+
+    Rules:
+    - If answer contains slash (multiple acceptable variants) → paraphrase_ok
+    - If cognitive_skill is synthesis or evaluation → open_ended
+    - Default → verbatim_recall
+    """
+    if "/" in answer or "／" in answer:
+        return "paraphrase_ok"
+    if cognitive_skill in ("synthesis", "evaluation"):
+        return "open_ended"
+    return "verbatim_recall"
+
+
+# ─── Core generation function ─────────────────────────────────────────────────
+
+def gen_lesson_intent_for_schema(
+    kp_schema: dict,
+    lesson_id: str,
+    strategy_type: str = "",
+) -> dict:
+    """
+    Generate an intent annotation dict from a pre-loaded keypoints schema dict.
+
+    Args:
+        kp_schema: Full keypoints schema dict (with "keypoints" key)
+        lesson_id: e.g. "G6-L22"
+        strategy_type: optional strategy type string from filename detection
+
+    Returns intent dict with:
+        lesson, schema_fingerprint, generated_at, intent_rows
+    """
+    fingerprint = compute_schema_fingerprint(kp_schema)
+    generated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    rows_out = kp_schema.get("keypoints", {}).get("rows", [])
+    structure = kp_schema.get("keypoints", {}).get("structure", "flat")
+
+    intent_rows = []
+
+    for i, row in enumerate(rows_out):
+        label = row.get("label", "")
+
+        if row.get("sub_rows"):
+            # Nested: iterate sub_rows
+            for j, sr in enumerate(row["sub_rows"]):
+                sub_label = sr.get("sub_label", "")
+                template = sr.get("template", "")
+                blanks = sr.get("blanks", [])
+
+                # Row-level entry (no blank_idx) for the sub_row itself
+                cognitive_skill_row = infer_cognitive_skill(
+                    label=label,
+                    sub_label=sub_label,
+                    template=template,
+                    answer="",
+                    structure=structure,
+                    strategy_type=strategy_type,
+                )
+                row_entry = {
+                    "row_idx": f"{i}_{j}",
+                    "label": label,
+                    "sub_label": sub_label,
+                    "cognitive_skill": cognitive_skill_row,
+                    "rationale": _build_rationale(
+                        label, sub_label, template, "", cognitive_skill_row
+                    ),
+                    "answer_criterion": infer_answer_criterion("", cognitive_skill_row),
+                }
+                intent_rows.append(row_entry)
+
+                # Blank-level entries
+                for b_idx, blank in enumerate(blanks):
+                    answer = blank.get("answer") or ""
+                    cs = infer_cognitive_skill(
+                        label=label,
+                        sub_label=sub_label,
+                        template=template,
+                        answer=answer,
+                        structure=structure,
+                        strategy_type=strategy_type,
+                    )
+                    criterion = infer_answer_criterion(answer, cs)
+                    blank_entry = {
+                        "row_idx": f"{i}_{j}",
+                        "label": label,
+                        "sub_label": sub_label,
+                        "blank_idx": b_idx,
+                        "answer": answer,
+                        "cognitive_skill": cs,
+                        "rationale": _build_rationale(
+                            label, sub_label, template, answer, cs
+                        ),
+                        "answer_criterion": criterion,
+                    }
+                    intent_rows.append(blank_entry)
+        else:
+            # Flat row
+            value = row.get("value", "")
+            blanks = row.get("blanks", [])
+
+            cs_row = infer_cognitive_skill(
+                label=label,
+                sub_label="",
+                template=value,
+                answer="",
+                structure=structure,
+                strategy_type=strategy_type,
+            )
+            row_entry = {
+                "row_idx": str(i),
+                "label": label,
+                "cognitive_skill": cs_row,
+                "rationale": _build_rationale(label, "", value, "", cs_row),
+                "answer_criterion": infer_answer_criterion("", cs_row),
+            }
+            intent_rows.append(row_entry)
+
+            for b_idx, blank in enumerate(blanks):
+                answer = blank.get("answer") or ""
+                cs = infer_cognitive_skill(
+                    label=label,
+                    sub_label="",
+                    template=value,
+                    answer=answer,
+                    structure=structure,
+                    strategy_type=strategy_type,
+                )
+                criterion = infer_answer_criterion(answer, cs)
+                blank_entry = {
+                    "row_idx": str(i),
+                    "label": label,
+                    "blank_idx": b_idx,
+                    "answer": answer,
+                    "cognitive_skill": cs,
+                    "rationale": _build_rationale(label, "", value, answer, cs),
+                    "answer_criterion": criterion,
+                }
+                intent_rows.append(blank_entry)
+
+    return {
+        "lesson": lesson_id,
+        "schema_fingerprint": fingerprint,
+        "generated_at": generated_at,
+        "intent_rows": intent_rows,
+    }
+
+
+def _build_rationale(
+    label: str,
+    sub_label: str,
+    template: str,
+    answer: str,
+    cognitive_skill: str,
+) -> str:
+    """Build a short human-readable rationale string for the intent entry."""
+    effective_label = sub_label or label
+    if cognitive_skill == "inference":
+        return f"Template contains inference cues under {effective_label!r}"
+    if cognitive_skill == "synthesis":
+        return f"{effective_label!r} row in nested structure implies synthesis of multiple sub-items"
+    if cognitive_skill == "evaluation":
+        return f"{effective_label!r} requires evaluative judgment"
+    # recall
+    if answer and len(answer) <= VERBATIM_RECALL_THRESHOLD:
+        return f"Short answer ({len(answer)} chars) — verbatim recall from text"
+    return f"Direct fill-in from reading passage under {effective_label!r}"
+
+
+# ─── Drift check ─────────────────────────────────────────────────────────────
+
+def check_intent_stale_from_dicts(
+    current_kp_schema: dict,
+    stored_intent: dict,
+) -> dict:
+    """
+    Check if a stored intent is stale (schema changed since intent was generated).
+
+    Args:
+        current_kp_schema: the current keypoints schema dict
+        stored_intent: the previously generated intent dict (has schema_fingerprint)
+
+    Returns:
+        {"stale": bool, "reason": str, "stored_fingerprint": str, "current_fingerprint": str}
+    """
+    current_fp = compute_schema_fingerprint(current_kp_schema)
+    stored_fp = stored_intent.get("schema_fingerprint", "")
+
+    stale = current_fp != stored_fp
+    reason = "schema changed since intent generated" if stale else "fingerprint matches"
+
+    return {
+        "stale": stale,
+        "reason": reason,
+        "stored_fingerprint": stored_fp,
+        "current_fingerprint": current_fp,
+    }
+
+
+def check_intent_stale_from_files(
+    lesson_id: str,
+    schema_dir: Path,
+) -> dict:
+    """
+    File-based version: load schema and intent from disk, then check stale.
+    Returns {"stale": bool, "reason": str, ...} or {"error": str} if files missing.
+    """
+    kp_path = schema_dir / f"{lesson_id}.keypoints.yml"
+    intent_path = schema_dir / f"{lesson_id}.intent.yml"
+
+    if not kp_path.exists():
+        return {"error": f"keypoints.yml not found: {kp_path}", "stale": True, "reason": "missing schema"}
+    if not intent_path.exists():
+        return {"error": f"intent.yml not found: {intent_path}", "stale": True, "reason": "intent not yet generated"}
+
+    with open(kp_path, encoding="utf-8") as f:
+        kp_schema = yaml.safe_load(f)
+    with open(intent_path, encoding="utf-8") as f:
+        stored_intent = yaml.safe_load(f)
+
+    return check_intent_stale_from_dicts(kp_schema, stored_intent)
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate or check lesson intent annotations"
+    )
+    parser.add_argument("lesson_id", help="Lesson ID, e.g. G6-L22")
+    parser.add_argument(
+        "--schema-dir",
+        default="private/curriculum-source/_online-schema/",
+        help="Directory containing keypoints YAML files",
+    )
+    parser.add_argument(
+        "--docx",
+        help="Path to DOCX file (used to detect strategy_type)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output path for intent YAML (default: <schema-dir>/<lesson_id>.intent.yml)",
+    )
+    parser.add_argument(
+        "--gen-intent",
+        action="store_true",
+        help="Generate intent YAML (default action if --check-drift not given)",
+    )
+    parser.add_argument(
+        "--check-drift",
+        action="store_true",
+        help="Check if intent is stale (schema changed since generation)",
+    )
+    args = parser.parse_args()
+
+    schema_dir = Path(args.schema_dir)
+
+    if args.check_drift:
+        result = check_intent_stale_from_files(args.lesson_id, schema_dir)
+        if result.get("stale"):
+            print(f"STALE: {result.get('reason')}")
+            print(f"  stored fp:  {result.get('stored_fingerprint', 'N/A')}")
+            print(f"  current fp: {result.get('current_fingerprint', 'N/A')}")
+        else:
+            print(f"FRESH: {result.get('reason')}")
+            print(f"  fingerprint: {result.get('current_fingerprint', 'N/A')}")
+        if result.get("error"):
+            print(f"ERROR: {result['error']}")
+            sys.exit(1)
+        return
+
+    # Generate intent
+    kp_path = schema_dir / f"{args.lesson_id}.keypoints.yml"
+    if not kp_path.exists():
+        print(f"ERROR: keypoints.yml not found: {kp_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(kp_path, encoding="utf-8") as f:
+        kp_schema = yaml.safe_load(f)
+
+    # Detect strategy_type from DOCX filename if provided
+    strategy_type = ""
+    if args.docx:
+        import importlib.util
+        bls_spec = importlib.util.spec_from_file_location(
+            "bls", Path(__file__).parent / "build_lesson_schema.py"
+        )
+        bls = importlib.util.module_from_spec(bls_spec)
+        bls_spec.loader.exec_module(bls)
+        _, strategy_type = bls.detect_strategy_from_filename(args.docx)
+
+    intent = gen_lesson_intent_for_schema(
+        kp_schema,
+        lesson_id=args.lesson_id,
+        strategy_type=strategy_type,
+    )
+
+    # Determine output path
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        out_path = schema_dir / f"{args.lesson_id}.intent.yml"
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        yaml.dump(intent, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+    print(f"Intent written to: {out_path}")
+    print(f"  lesson: {intent['lesson']}")
+    print(f"  fingerprint: {intent['schema_fingerprint']}")
+    print(f"  intent_rows: {len(intent['intent_rows'])}")
+    blank_rows = [r for r in intent["intent_rows"] if "blank_idx" in r]
+    print(f"  blank entries: {len(blank_rows)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_keypoints_text_fidelity.py
+++ b/tests/test_keypoints_text_fidelity.py
@@ -264,55 +264,62 @@ SCHEMA_CHECKBOX = {
         "columns": ["label", "value"],
         "rows": [
             {
-                "label": "一、二",
+                "label": "挫折事件",
                 "sub_rows": [
                     {
-                        "sub_label": "被傳訊息告白",
+                        "sub_label": "雅加達亞運",
                         # Template contains checkbox markers □ and inline option list
-                        "template": "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜 \n惱怒 煩躁",
-                        "blanks": [
-                            {"answer": "如何回應", "hint": ""},
-                            {"answer": "尷尬", "hint": ""},
-                        ],
-                    }
+                        # blanks=[] → checkbox-only cell, SHOULD be skipped
+                        "template": "（單選）\n□驕傲地奪得銀牌     \n不甘心以微小的差距奪得銀牌",
+                        "blanks": [],
+                    },
+                    {
+                        "sub_label": "拿坡里世大運",
+                        # Also checkbox-only (blanks=[])
+                        "template": "比賽時受傷了，他選擇（單選）\n積極的面對與復健   □放棄跑步、不願治療",
+                        "blanks": [],
+                    },
                 ],
             }
         ],
     }
 }
 
-# The DOCX for this structure has a cell that interleaves option checkboxes with blanks
-# in a way that doesn't align positionally with what schema rows expect.
-# The cell layout comes from a physically different table structure.
+# The DOCX for this structure has cells that interleave checkbox options.
+# Since all schema cells are checkbox-only (blanks=[]), the whole lesson
+# should be classified structure_unsupported=True.
 DOCX_ROWS_CHECKBOX = [
-    # The value column cell contains the full checkbox+fill-in text, which does NOT
-    # map cleanly to what _flatten_schema_rows produces.
     {"cells": [
-        {"text": "一、二", "dup": False},
-        {"text": "(勾選,可複選) 驚訝 □驚喜 □惱怒 煩躁", "dup": False},  # ← different cell layout
+        {"text": "挫折事件", "dup": False},
+        {"text": "雅加達亞運", "dup": False},
+        {"text": "（單選）\n□驕傲地奪得銀牌\n不甘心以微小的差距奪得銀牌", "dup": False},
+    ]},
+    {"cells": [
+        {"text": "挫折事件", "dup": True},
+        {"text": "拿坡里世大運", "dup": False},
+        {"text": "比賽時受傷了，他選擇（單選）\n積極的面對與復健   □放棄跑步、不願治療", "dup": False},
     ]},
 ]
 
 
 class TestCheckboxStructureNotFailed:
     """
-    Regression lock: checkbox/勾選 table structures must NOT be reported as FAIL.
+    Regression lock: all-checkbox table structures must NOT be reported as FAIL.
     They should be classified as structure_unsupported and skipped (NA).
 
-    Root cause of false-positive: G5-L20 scored 1/15 (1 match out of 15 cells)
-    because the checker paired schema rows against wrong DOCX cells — the template
-    contains checkbox option text on extra lines that doesn't appear in the value
-    column of the corresponding DOCX row.
+    Cell-level rule: a cell is checkbox-only if template/value has checkbox markers
+    (□/勾選/單選/複選) AND blanks=[]. Only cells with no real fill-in blanks are skipped.
 
-    After the fix: checker detects checkbox inline structure → returns
-    structure_unsupported=True, pass=True (NA skip), mismatches=[].
+    When ALL paired cells are checkbox-only → structure_unsupported=True for the lesson.
+
+    Root cause of false-positive: G5-L20-style tables produce checkbox-only cells that
+    cannot be aligned positionally. They should not count as FAIL.
     """
 
     def test_checkbox_template_not_reported_as_fail(self):
         """
-        A schema whose templates contain □ or '勾選' must not produce FAIL.
-        Expected: structure_unsupported=True, pass=True (or available=False with note),
-        mismatches=[].
+        A schema whose ALL templates contain □/勾選/單選 with blanks=[] must
+        not produce FAIL. Expected: structure_unsupported=True, pass=True, mismatches=[].
         """
         result = eval_keypoints_text_fidelity(
             lesson_id="TEST-CHECKBOX",
@@ -322,16 +329,256 @@ class TestCheckboxStructureNotFailed:
             _schema_override=SCHEMA_CHECKBOX,
             _docx_rows_override=DOCX_ROWS_CHECKBOX,
         )
-        # Must NOT be a hard FAIL — the checker doesn't know if it's a true mismatch
-        # or just a structural alignment problem.
+        # Must NOT be a hard FAIL — all cells are checkbox-only (no real fill-ins)
         assert result["pass"] is True, (
-            f"Checkbox structure should not be hard FAIL, got mismatches: {result.get('mismatches')}"
+            f"All-checkbox structure should not be hard FAIL, got mismatches: {result.get('mismatches')}"
         )
         # Must signal that this structure was skipped
         assert result.get("structure_unsupported") is True, (
-            "Checkbox structure must be flagged as structure_unsupported"
+            "All-checkbox structure must be flagged as structure_unsupported"
         )
         # No mismatches reported for an unsupported structure
         assert result["mismatches"] == [], (
             f"No mismatches expected for unsupported structure, got: {result['mismatches']}"
         )
+
+
+# ─── Mixed course fixture (from real G4-L2 pattern) ──────────────────────────
+#
+# G4-L2 has BOTH:
+#   - rows with real fill-in blanks:  主角=楊俊瀚, 他學到了什麼?=擁抱恐懼/對話
+#   - rows with ONLY checkbox options (no blanks):
+#       挫折事件.雅加達亞運: "（單選）\n□驕傲地奪得銀牌..." blanks=[]
+#
+# The old lesson-level guard skipped the ENTIRE lesson → 3 real fill-ins unverified.
+# The new cell-level guard must:
+#   - SKIP the checkbox-only cells (no blanks, template has □ or 勾選/單選)
+#   - VERIFY the real fill-in cells (those with actual blanks[].answer)
+#   - Report at least the real fill-in cells in total_cells_checked
+
+SCHEMA_MIXED_CHECKBOX = {
+    "keypoints": {
+        "lesson": "TEST-MIXED",
+        "structure": "nested",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                # Real fill-in: answer = 楊俊瀚
+                "label": "主角",
+                "value": "__",
+                "blanks": [{"answer": "楊俊瀚", "hint": ""}],
+            },
+            {
+                "label": "挫折事件",
+                "sub_rows": [
+                    {
+                        # Checkbox-only cell — no blanks, template has □
+                        "sub_label": "雅加達亞運",
+                        "template": "（單選）\n□驕傲地奪得銀牌\n不甘心以微小的差距奪得銀牌",
+                        "blanks": [],
+                    },
+                    {
+                        # Checkbox-only cell — no blanks, template has □
+                        "sub_label": "拿坡里世大運",
+                        "template": "比賽時受傷了，他選擇（單選）\n積極的面對與復健   □放棄跑步、不願治療",
+                        "blanks": [],
+                    },
+                ],
+            },
+            {
+                # Real fill-in: 2 answers = 擁抱恐懼, 對話
+                "label": "他學到了什麼?",
+                "value": "他學會了先了解害怕的事物，__，再戰勝它。\n2.學習和自己__，找尋答案。",
+                "blanks": [
+                    {"answer": "擁抱恐懼", "hint": ""},
+                    {"answer": "對話", "hint": ""},
+                ],
+            },
+        ],
+    }
+}
+
+# DOCX rows matching the real fill-in cells correctly
+# (checkbox cells are present in DOCX but won't be compared since they're skipped)
+DOCX_ROWS_MIXED_CORRECT = [
+    # Row 0: 主角 — real fill-in, DOCX has 【楊俊瀚】
+    {"cells": [{"text": "主角", "dup": False}, {"text": "【楊俊瀚】", "dup": False}]},
+    # Row 1_0: 雅加達亞運 — checkbox only, DOCX value is the checkbox text
+    {"cells": [{"text": "挫折事件", "dup": False}, {"text": "（單選）\n□驕傲地奪得銀牌\n不甘心以微小的差距奪得銀牌", "dup": False}]},
+    # Row 1_1: 拿坡里世大運 — checkbox only
+    {"cells": [{"text": "挫折事件", "dup": True}, {"text": "比賽時受傷了，他選擇（單選）\n積極的面對與復健   □放棄跑步、不願治療", "dup": False}]},
+    # Row 2: 他學到了什麼? — real fill-in, DOCX has 【擁抱恐懼】 and 【對話】
+    {"cells": [{"text": "他學到了什麼?", "dup": False}, {"text": "他學會了先了解害怕的事物，【擁抱恐懼】，再戰勝它。\n2.學習和自己【對話】，找尋答案。", "dup": False}]},
+]
+
+
+class TestMixedCheckboxCellLevel:
+    """
+    Regression lock: mixed courses (checkbox cells + real fill-in cells) must:
+    - SKIP checkbox-only cells (no blanks + template has □/單選/複選)
+    - VERIFY real fill-in cells (have blanks[].answer)
+    - total_cells_checked > 0
+    - NOT return structure_unsupported=True for the whole lesson
+
+    Root cause: old lesson-level guard skipped all of G4-L2 → 3 real fill-ins unverified.
+    """
+
+    def test_mixed_lesson_verifies_real_fillin_cells(self):
+        """Real fill-in cells (with blanks) must be checked even in checkbox-mixed lessons."""
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-MIXED",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_MIXED_CHECKBOX,
+            _docx_rows_override=DOCX_ROWS_MIXED_CORRECT,
+        )
+        assert result["available"] is True
+        # Must NOT skip the whole lesson
+        assert result.get("structure_unsupported") is not True, (
+            "Mixed lesson should not be entirely structure_unsupported"
+        )
+        # Must have checked at least the real fill-in cells
+        assert result["total_cells_checked"] > 0, (
+            "Mixed lesson must verify real fill-in cells, not skip everything"
+        )
+        # Correct fill-in text → must pass
+        assert result["pass"] is True, (
+            f"Mixed lesson with correct fill-ins should pass. mismatches={result.get('mismatches')}"
+        )
+        assert result["mismatches"] == []
+
+    def test_mixed_lesson_still_catches_fillin_mismatch(self):
+        """If a real fill-in cell is wrong, it must still be caught."""
+        # Same schema but DOCX has wrong answer for 主角
+        docx_wrong = [
+            {"cells": [{"text": "主角", "dup": False}, {"text": "【錯誤答案】", "dup": False}]},
+            {"cells": [{"text": "挫折事件", "dup": False}, {"text": "（單選）\n□驕傲地奪得銀牌\n不甘心", "dup": False}]},
+            {"cells": [{"text": "挫折事件", "dup": True}, {"text": "比賽時受傷了，積極的面對與復健   □放棄", "dup": False}]},
+            {"cells": [{"text": "他學到了什麼?", "dup": False}, {"text": "他學會了先了解害怕的事物，【擁抱恐懼】，再戰勝它。\n2.學習和自己【對話】，找尋答案。", "dup": False}]},
+        ]
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-MIXED",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_MIXED_CHECKBOX,
+            _docx_rows_override=docx_wrong,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, "Wrong fill-in answer must be caught"
+        fields = [m.get("field", "") for m in result["mismatches"]]
+        assert any("answer" in f for f in fields), f"Expected answer mismatch, got: {fields}"
+
+
+# ─── Blank marker normalization fixture (from real 文-L5 pattern) ─────────────
+#
+# 文-L5 schema row value = "內容摘要\n【 】處填入原文，找不到原文時，再用自己的話寫。"
+# DOCX cell text       = "內容摘要\n__處填入原文，找不到原文時，再用自己的話寫。"
+#
+# The schema has an empty blank marker 【 】 (instruction) where DOCX has __.
+# Both mean "a blank to fill in" — they are semantically equivalent.
+# The checker should treat 【 】/【　】/【】 (empty-content blanks) as __ during comparison.
+#
+# BUT: if the schema has 【answer】 (non-empty content inside) and the DOCX has
+# different text, that IS a real mismatch. This must not be swallowed.
+
+SCHEMA_BLANK_MARKER = {
+    "keypoints": {
+        "lesson": "TEST-BLANK-MARKER",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                # Instruction row: schema has 【 】 (empty blank), DOCX has __
+                # Both are blank markers → should PASS after normalization
+                "label": "說明",
+                "value": "內容摘要 【 】處填入原文，找不到原文時，再用自己的話寫。",
+                "blanks": [],
+            },
+            {
+                # Real fill-in row: schema answer = 荀巨伯, DOCX has 【荀巨伯】 → PASS
+                "label": "起因",
+                "value": "__去看望__，卻遇上胡兵。",
+                "blanks": [
+                    {"answer": "荀巨伯", "hint": ""},
+                    {"answer": "友人", "hint": ""},
+                ],
+            },
+        ],
+    }
+}
+
+DOCX_ROWS_BLANK_MARKER_PASS = [
+    # Instruction row: DOCX uses __ instead of 【 】
+    {"cells": [{"text": "說明", "dup": False}, {"text": "內容摘要 __處填入原文，找不到原文時，再用自己的話寫。", "dup": False}]},
+    # Real fill-in: correct answers
+    {"cells": [{"text": "起因", "dup": False}, {"text": "【荀巨伯】去看望【友人】，卻遇上胡兵。", "dup": False}]},
+]
+
+# Anti-case: schema has 【非空答案】 but DOCX has 【不同答案】 → must be FAIL (not swallowed)
+SCHEMA_NON_EMPTY_BLANK_REAL_ERROR = {
+    "keypoints": {
+        "lesson": "TEST-BLANK-MARKER-REAL-ERROR",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                # The value text itself doesn't have 【】, but blanks[0].answer = 正確答案
+                # DOCX has 【錯誤答案】 → must detect as mismatch
+                "label": "起因",
+                "value": "__去看望朋友。",
+                "blanks": [{"answer": "正確答案", "hint": ""}],
+            },
+        ],
+    }
+}
+DOCX_ROWS_NON_EMPTY_BLANK_REAL_ERROR = [
+    {"cells": [{"text": "起因", "dup": False}, {"text": "【錯誤答案】去看望朋友。", "dup": False}]},
+]
+
+
+class TestBlankMarkerNormalization:
+    """
+    Regression lock: 【 】 (empty blank marker in schema) ≡ __ (blank in DOCX).
+    Root cause of 文-L5/6/7/10 false-positives: instruction rows with 【 】 were
+    compared against DOCX __ and reported as mismatch.
+    """
+
+    def test_empty_blank_marker_normalized_to_match(self):
+        """
+        Schema value '【 】處填入原文' vs DOCX '__處填入原文' — semantically same.
+        After normalization both become '__處填入原文' → PASS.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-BLANK-MARKER",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_BLANK_MARKER,
+            _docx_rows_override=DOCX_ROWS_BLANK_MARKER_PASS,
+        )
+        assert result["available"] is True
+        assert result["pass"] is True, (
+            f"【 】≡__ should pass. mismatches={result.get('mismatches')}"
+        )
+        assert result["mismatches"] == []
+
+    def test_non_empty_blank_with_real_error_still_caught(self):
+        """
+        If schema blank answer = '正確答案' but DOCX has '【錯誤答案】' → real mismatch.
+        Normalization must NOT swallow this.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-BLANK-MARKER-REAL-ERROR",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_NON_EMPTY_BLANK_REAL_ERROR,
+            _docx_rows_override=DOCX_ROWS_NON_EMPTY_BLANK_REAL_ERROR,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, (
+            "Real answer mismatch must not be swallowed by blank-marker normalization"
+        )
+        assert len(result["mismatches"]) >= 1

--- a/tests/test_keypoints_text_fidelity.py
+++ b/tests/test_keypoints_text_fidelity.py
@@ -1,0 +1,242 @@
+"""
+tests/test_keypoints_text_fidelity.py
+
+TDD tests for Slice ②: keypoints text fidelity check.
+
+These tests run BEFORE implementation (RED phase).
+The fidelity function is designed to accept _docx_rows_override to avoid
+real DOCX loading in unit tests.
+"""
+
+import sys
+import os
+import pytest
+from pathlib import Path
+
+# Add scripts to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from eval_keypoints_text_fidelity import eval_keypoints_text_fidelity
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+# A minimal schema that mirrors the G6-L22 PSE structure (nested, 3-col)
+SCHEMA_NESTED_CORRECT = {
+    "keypoints": {
+        "lesson": "TEST-FIDELITY",
+        "structure": "nested",
+        "columns": ["label", "sub_label", "value"],
+        "rows": [
+            {
+                "label": "問題",
+                "value": "秦昭王軟禁了孟嘗君而且想殺掉他，孟嘗君想要逃離秦國。",
+                "blanks": [],
+            },
+            {
+                "label": "解決",
+                "sub_rows": [
+                    {
+                        "sub_label": "問題1",
+                        "template": "孟嘗君求幸姬幫忙，幸姬要求孟嘗君給她白狐裘，但大衣已經送給秦昭王，不給，自己就__，孟嘗君去哪裡再找一件皮大衣呢?",
+                        "blanks": [{"answer": "凶多吉少", "hint": ""}],
+                    },
+                    {
+                        "sub_label": "解決1",
+                        "template": "食客中有一位會模仿__的樣子和動作潛入家戶偷東西，他可以潛入寶庫中偷出白狐裘。",
+                        "blanks": [{"answer": "狗", "hint": ""}],
+                    },
+                ],
+            },
+            {
+                "label": "結果",
+                "value": "孟嘗君在食客們的幫助下成功逃離秦國。",
+                "blanks": [],
+            },
+        ],
+    }
+}
+
+# DOCX rows matching the schema exactly
+DOCX_ROWS_CORRECT = [
+    # problem row (no blanks, direct value)
+    {"cells": [{"text": "問題", "dup": False}, {"text": "無", "dup": False}, {"text": "秦昭王軟禁了孟嘗君而且想殺掉他，孟嘗君想要逃離秦國。", "dup": False}]},
+    # 解決 sub_row 1: 問題1
+    {"cells": [{"text": "解決", "dup": False}, {"text": "問題1", "dup": False}, {"text": "孟嘗君求幸姬幫忙，幸姬要求孟嘗君給她白狐裘，但大衣已經送給秦昭王，不給，自己就【凶多吉少】，孟嘗君去哪裡再找一件皮大衣呢?", "dup": False}]},
+    # 解決 sub_row 2: 解決1
+    {"cells": [{"text": "解決", "dup": True}, {"text": "解決1", "dup": False}, {"text": "食客中有一位會模仿【狗】的樣子和動作潛入家戶偷東西，他可以潛入寶庫中偷出白狐裘。", "dup": False}]},
+    # 結果 row
+    {"cells": [{"text": "結果", "dup": False}, {"text": "無", "dup": False}, {"text": "孟嘗君在食客們的幫助下成功逃離秦國。", "dup": False}]},
+]
+
+# DOCX rows where one VALUE cell is garbled (counts still match → false-pass without fidelity)
+DOCX_ROWS_GARBLED_VALUE = [
+    # problem row — value is GARBLED (different text)
+    {"cells": [{"text": "問題", "dup": False}, {"text": "無", "dup": False}, {"text": "孟嘗君想要逃走，秦昭王不讓。", "dup": False}]},  # garbled
+    # 解決 sub_row 1 — correct
+    {"cells": [{"text": "解決", "dup": False}, {"text": "問題1", "dup": False}, {"text": "孟嘗君求幸姬幫忙，幸姬要求孟嘗君給她白狐裘，但大衣已經送給秦昭王，不給，自己就【凶多吉少】，孟嘗君去哪裡再找一件皮大衣呢?", "dup": False}]},
+    # 解決 sub_row 2 — correct
+    {"cells": [{"text": "解決", "dup": True}, {"text": "解決1", "dup": False}, {"text": "食客中有一位會模仿【狗】的樣子和動作潛入家戶偷東西，他可以潛入寶庫中偷出白狐裘。", "dup": False}]},
+    # 結果 row — correct
+    {"cells": [{"text": "結果", "dup": False}, {"text": "無", "dup": False}, {"text": "孟嘗君在食客們的幫助下成功逃離秦國。", "dup": False}]},
+]
+
+# Schema and DOCX rows for blank-answer mismatch test
+SCHEMA_BLANK_MISMATCH = {
+    "keypoints": {
+        "lesson": "TEST-BLANK-MISMATCH",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                "label": "特質",
+                "value": "主角非常__和勇敢。",
+                "blanks": [{"answer": "狗", "hint": ""}],  # schema says 狗
+            }
+        ],
+    }
+}
+
+# DOCX has 猫 instead of 狗 inside the blank
+DOCX_ROWS_BLANK_MISMATCH = [
+    {"cells": [{"text": "特質", "dup": False}, {"text": "主角非常【猫】和勇敢。", "dup": False}]},
+]
+
+# Schema for full-width normalization test
+SCHEMA_FULLWIDTH = {
+    "keypoints": {
+        "lesson": "TEST-FULLWIDTH",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                # value uses ASCII "A" (U+0041)
+                "label": "測試",
+                "value": "秦昭A王統治秦國。",
+                "blanks": [],
+            }
+        ],
+    }
+}
+
+# DOCX has full-width "Ａ" (U+FF21) — after NFKC normalization should match ASCII "A"
+DOCX_ROWS_FULLWIDTH = [
+    {"cells": [{"text": "測試", "dup": False}, {"text": "秦昭Ａ王統治秦國。", "dup": False}]},
+]
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestTextFidelityCounts:
+    """
+    Test 1: counts match but text garbled → must FAIL fidelity check.
+    This is the core false-pass scenario that motivated this slice.
+    """
+
+    def test_garbled_value_fails_even_though_counts_match(self):
+        """
+        The false-pass scenario: row_recall=1.0, blank_recall=1.0,
+        but one cell value is garbled. Fidelity must catch this.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-FIDELITY",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_NESTED_CORRECT,
+            _docx_rows_override=DOCX_ROWS_GARBLED_VALUE,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, (
+            "Garbled value text should fail fidelity check"
+        )
+        assert len(result["mismatches"]) >= 1, (
+            f"Expected at least 1 mismatch, got: {result['mismatches']}"
+        )
+
+
+class TestTextFidelityMatch:
+    """Test 2: text matches exactly → must PASS fidelity check."""
+
+    def test_matching_text_passes(self):
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-FIDELITY",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_NESTED_CORRECT,
+            _docx_rows_override=DOCX_ROWS_CORRECT,
+        )
+        assert result["available"] is True
+        assert result["pass"] is True, (
+            f"Matching text should pass. Mismatches: {result.get('mismatches')}"
+        )
+        assert result["mismatches"] == [], (
+            f"Expected no mismatches, got: {result['mismatches']}"
+        )
+
+
+class TestBlankAnswerMismatch:
+    """Test 3: blank answer in schema ≠ blank content in DOCX → mismatch detected."""
+
+    def test_blank_answer_mismatch_detected(self):
+        """Schema says answer='狗', DOCX has 【猫】 → should detect as mismatch."""
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-BLANK-MISMATCH",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_BLANK_MISMATCH,
+            _docx_rows_override=DOCX_ROWS_BLANK_MISMATCH,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, (
+            "Blank answer mismatch should fail fidelity"
+        )
+        mismatches = result["mismatches"]
+        assert len(mismatches) >= 1
+        # At least one mismatch should mention the answer field
+        fields = [m.get("field", "") for m in mismatches]
+        assert any("answer" in f or "blank" in f for f in fields), (
+            f"Expected answer mismatch, got fields: {fields}"
+        )
+
+
+class TestFullWidthNormalization:
+    """Test 4: full-width char in DOCX vs ASCII in schema — normalization makes them match."""
+
+    def test_fullwidth_normalized_to_match(self):
+        """
+        Schema has ASCII "A", DOCX has full-width "Ａ" (U+FF21).
+        After NFKC normalization they become identical → should PASS.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-FULLWIDTH",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_FULLWIDTH,
+            _docx_rows_override=DOCX_ROWS_FULLWIDTH,
+        )
+        assert result["available"] is True
+        assert result["pass"] is True, (
+            f"Full-width normalized text should pass. Mismatches: {result.get('mismatches')}"
+        )
+        assert result["mismatches"] == []
+
+
+class TestFidelityScorePresent:
+    """Structural check: result always has text_fidelity float."""
+
+    def test_score_in_result(self):
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-FIDELITY",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_NESTED_CORRECT,
+            _docx_rows_override=DOCX_ROWS_CORRECT,
+        )
+        assert "text_fidelity" in result
+        assert isinstance(result["text_fidelity"], float)
+        assert 0.0 <= result["text_fidelity"] <= 1.0

--- a/tests/test_keypoints_text_fidelity.py
+++ b/tests/test_keypoints_text_fidelity.py
@@ -582,3 +582,137 @@ class TestBlankMarkerNormalization:
             "Real answer mismatch must not be swallowed by blank-marker normalization"
         )
         assert len(result["mismatches"]) >= 1
+
+
+# ─── BLOCKING 1: Row cardinality truncation → silent pass ──────────────────
+#
+# n_pairs = min(len(schema_flat), len(docx_flat)) silently drops unmatched rows.
+# When schema has more rows than DOCX, the extra schema rows never enter the
+# comparison loop → no mismatch produced → pass=True even though content is missing.
+#
+# Fix: unmatched schema rows (beyond n_pairs) must each produce a mismatch
+# (field="<row missing from DOCX>").
+
+SCHEMA_EXTRA_ROWS = {
+    "keypoints": {
+        "lesson": "TEST-EXTRA-ROWS",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                "label": "起因",
+                # Template text matches DOCX exactly — first row is a clean PASS
+                "value": "主角想要逃跑。",
+                "blanks": [],
+            },
+            {
+                # This row exists in schema but has no DOCX counterpart
+                "label": "結果",
+                "value": "主角成功逃走。",
+                "blanks": [],
+            },
+        ],
+    }
+}
+
+# DOCX only has 1 row — schema has 2. The second schema row has no DOCX counterpart.
+# First row matches perfectly, so n_pairs logic is the only thing that can catch this.
+DOCX_ROWS_MISSING_ROW = [
+    {"cells": [{"text": "起因", "dup": False}, {"text": "主角想要逃跑。", "dup": False}]},
+    # ← second row absent: schema 結果 row has no DOCX counterpart
+]
+
+
+class TestRowCardinalityMismatch:
+    """
+    BLOCKING regression: schema has more rows than DOCX → must FAIL, not silently pass.
+
+    Before fix: n_pairs = min(2,1) = 1, only first row compared, second row silently
+    dropped → pass=True even though 結果 row is entirely missing from DOCX.
+
+    After fix: unmatched schema rows produce a mismatch → pass=False.
+    """
+
+    def test_schema_has_more_rows_than_docx_must_fail(self):
+        """
+        Schema has 2 rows, DOCX has 1 row. The unmatched schema row must produce
+        a mismatch. Result must be pass=False.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-EXTRA-ROWS",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_EXTRA_ROWS,
+            _docx_rows_override=DOCX_ROWS_MISSING_ROW,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, (
+            f"Schema has 2 rows, DOCX has 1 — unmatched schema row must produce FAIL. "
+            f"Got: pass={result['pass']}, mismatches={result.get('mismatches')}"
+        )
+        assert len(result["mismatches"]) >= 1, (
+            f"Expected at least 1 mismatch for missing DOCX row, got: {result['mismatches']}"
+        )
+
+
+# ─── BLOCKING 2: n_pairs==0 empty pass (non-checkbox context) ──────────────
+#
+# When schema has rows but DOCX has 0 rows (all skipped/missing), n_pairs=0,
+# the loop never runs, total_cells=0, mismatches=[], pass=True.
+# This is an "honest 0" — the checker compared nothing and silently declared pass.
+#
+# Fix: if total_cells==0 AND skipped_cells==0 (not a checkbox-only lesson),
+# that means DOCX had zero extractable rows for a non-empty schema → FAIL or
+# flag as extraction_empty.
+
+SCHEMA_FOR_EMPTY_DOCX = {
+    "keypoints": {
+        "lesson": "TEST-EMPTY-DOCX",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                "label": "主角",
+                "value": "__",
+                "blanks": [{"answer": "楊俊瀚", "hint": ""}],
+            },
+        ],
+    }
+}
+
+# DOCX provides zero data rows (empty list after header skip)
+DOCX_ROWS_EMPTY = []
+
+
+class TestEmptyDocxNonCheckbox:
+    """
+    BLOCKING regression: non-checkbox schema with 0 extractable DOCX rows must NOT pass.
+
+    Before fix: n_pairs=min(1,0)=0, loop never runs, total_cells=0, mismatches=[],
+    pass=True. Zero comparison ≠ passing.
+
+    After fix: total_cells==0 and skipped_cells==0 → extraction_empty=True, pass=False.
+    """
+
+    def test_empty_docx_non_checkbox_must_not_pass(self):
+        """
+        Schema has 1 real fill-in row, DOCX has 0 data rows.
+        This is not a checkbox lesson (no cells skipped). Must NOT pass=True.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-EMPTY-DOCX",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_FOR_EMPTY_DOCX,
+            _docx_rows_override=DOCX_ROWS_EMPTY,
+        )
+        assert result["available"] is True
+        assert result.get("structure_unsupported") is not True, (
+            "Non-checkbox empty result must not be classified as structure_unsupported"
+        )
+        assert result["pass"] is False, (
+            f"DOCX has 0 rows for non-checkbox schema — must FAIL, not silently pass. "
+            f"Got: pass={result['pass']}, total_cells_checked={result.get('total_cells_checked')}"
+        )

--- a/tests/test_keypoints_text_fidelity.py
+++ b/tests/test_keypoints_text_fidelity.py
@@ -240,3 +240,98 @@ class TestFidelityScorePresent:
         assert "text_fidelity" in result
         assert isinstance(result["text_fidelity"], float)
         assert 0.0 <= result["text_fidelity"] <= 1.0
+
+
+# ─── Checkbox/勾選 structure fixture (from real G5-L20 pattern) ───────────────
+#
+# G5-L20 has templates like:
+#   "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜 \n惱怒 煩躁"
+#
+# The DOCX for this kind of lesson has a table where the "value" column cell
+# contains a mix of fill-in blanks AND checkbox option lists on separate lines.
+# Positional alignment of schema rows → DOCX rows breaks here because the DOCX
+# may group multiple checklist items under one physical row with a different
+# cell layout than what the schema's flat/nested rows expect.
+#
+# The checker must NOT report FAIL for this structure. It should report
+# structure_unsupported=True and skip (return pass=True, available=True,
+# structure_unsupported=True, mismatches=[]).
+
+SCHEMA_CHECKBOX = {
+    "keypoints": {
+        "lesson": "TEST-CHECKBOX",
+        "structure": "nested",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                "label": "一、二",
+                "sub_rows": [
+                    {
+                        "sub_label": "被傳訊息告白",
+                        # Template contains checkbox markers □ and inline option list
+                        "template": "1.不知該__\n2.擔心相處會變得__ (勾選，可複選)\n驚訝 □驚喜 \n惱怒 煩躁",
+                        "blanks": [
+                            {"answer": "如何回應", "hint": ""},
+                            {"answer": "尷尬", "hint": ""},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+}
+
+# The DOCX for this structure has a cell that interleaves option checkboxes with blanks
+# in a way that doesn't align positionally with what schema rows expect.
+# The cell layout comes from a physically different table structure.
+DOCX_ROWS_CHECKBOX = [
+    # The value column cell contains the full checkbox+fill-in text, which does NOT
+    # map cleanly to what _flatten_schema_rows produces.
+    {"cells": [
+        {"text": "一、二", "dup": False},
+        {"text": "(勾選,可複選) 驚訝 □驚喜 □惱怒 煩躁", "dup": False},  # ← different cell layout
+    ]},
+]
+
+
+class TestCheckboxStructureNotFailed:
+    """
+    Regression lock: checkbox/勾選 table structures must NOT be reported as FAIL.
+    They should be classified as structure_unsupported and skipped (NA).
+
+    Root cause of false-positive: G5-L20 scored 1/15 (1 match out of 15 cells)
+    because the checker paired schema rows against wrong DOCX cells — the template
+    contains checkbox option text on extra lines that doesn't appear in the value
+    column of the corresponding DOCX row.
+
+    After the fix: checker detects checkbox inline structure → returns
+    structure_unsupported=True, pass=True (NA skip), mismatches=[].
+    """
+
+    def test_checkbox_template_not_reported_as_fail(self):
+        """
+        A schema whose templates contain □ or '勾選' must not produce FAIL.
+        Expected: structure_unsupported=True, pass=True (or available=False with note),
+        mismatches=[].
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-CHECKBOX",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_CHECKBOX,
+            _docx_rows_override=DOCX_ROWS_CHECKBOX,
+        )
+        # Must NOT be a hard FAIL — the checker doesn't know if it's a true mismatch
+        # or just a structural alignment problem.
+        assert result["pass"] is True, (
+            f"Checkbox structure should not be hard FAIL, got mismatches: {result.get('mismatches')}"
+        )
+        # Must signal that this structure was skipped
+        assert result.get("structure_unsupported") is True, (
+            "Checkbox structure must be flagged as structure_unsupported"
+        )
+        # No mismatches reported for an unsupported structure
+        assert result["mismatches"] == [], (
+            f"No mismatches expected for unsupported structure, got: {result['mismatches']}"
+        )

--- a/tests/test_keypoints_text_fidelity.py
+++ b/tests/test_keypoints_text_fidelity.py
@@ -716,3 +716,72 @@ class TestEmptyDocxNonCheckbox:
             f"DOCX has 0 rows for non-checkbox schema — must FAIL, not silently pass. "
             f"Got: pass={result['pass']}, total_cells_checked={result.get('total_cells_checked')}"
         )
+
+
+# ─── BLOCKING 1b: docx > schema (reverse cardinality) → silent pass ────────
+#
+# When DOCX has more rows than schema, n_pairs=min(schema, docx)=len(schema),
+# so extra DOCX rows are silently ignored. A schema with 1 row / DOCX with 2 rows
+# → only the first pair is compared. If the first pair matches, pass=True even
+# though an entire DOCX row went unverified.
+#
+# Fix: unmatched DOCX rows (idx n_pairs..len(docx_flat)) should produce mismatches
+# just like unmatched schema rows do. Since _flatten_docx_rows already skips headers
+# (via _skip_header_rows), all remaining rows are content rows.
+
+SCHEMA_FEWER_ROWS = {
+    "keypoints": {
+        "lesson": "TEST-FEWER-ROWS",
+        "structure": "flat",
+        "columns": ["label", "value"],
+        "rows": [
+            {
+                # Schema has only 1 row; DOCX will have 2
+                "label": "起因",
+                "value": "主角想要逃跑。",
+                "blanks": [],
+            },
+            # ← schema is missing the 結果 row entirely
+        ],
+    }
+}
+
+# DOCX has 2 content rows: first matches schema, second has no schema counterpart
+DOCX_ROWS_EXTRA_ROW = [
+    {"cells": [{"text": "起因", "dup": False}, {"text": "主角想要逃跑。", "dup": False}]},
+    # Extra DOCX row — schema has no counterpart for this
+    {"cells": [{"text": "結果", "dup": False}, {"text": "主角成功逃走。", "dup": False}]},
+]
+
+
+class TestReverseCardinalityMismatch:
+    """
+    BLOCKING regression: DOCX has more rows than schema → must FAIL, not silently pass.
+
+    Before fix: n_pairs=min(1,2)=1, second DOCX row silently dropped,
+    first row matches → pass=True. The extra DOCX content is invisible to the checker.
+
+    After fix: unmatched DOCX rows produce a mismatch → pass=False.
+    """
+
+    def test_docx_has_more_rows_than_schema_must_fail(self):
+        """
+        Schema has 1 row, DOCX has 2 rows. The unmatched DOCX row must produce
+        a mismatch. Result must be pass=False.
+        """
+        result = eval_keypoints_text_fidelity(
+            lesson_id="TEST-FEWER-ROWS",
+            docx_path=None,
+            schema_dir=None,
+            bls=None,
+            _schema_override=SCHEMA_FEWER_ROWS,
+            _docx_rows_override=DOCX_ROWS_EXTRA_ROW,
+        )
+        assert result["available"] is True
+        assert result["pass"] is False, (
+            f"Schema has 1 row, DOCX has 2 — unmatched DOCX row must produce FAIL. "
+            f"Got: pass={result['pass']}, mismatches={result.get('mismatches')}"
+        )
+        assert len(result["mismatches"]) >= 1, (
+            f"Expected at least 1 mismatch for extra DOCX row, got: {result['mismatches']}"
+        )

--- a/tests/test_lesson_intent.py
+++ b/tests/test_lesson_intent.py
@@ -1,0 +1,227 @@
+"""
+tests/test_lesson_intent.py
+
+TDD tests for Slice ③: lesson intent draft + drift-lock.
+
+These tests run BEFORE implementation (RED phase).
+The intent functions are designed to work on pre-loaded dicts for testability.
+"""
+
+import sys
+import json
+import hashlib
+import pytest
+from pathlib import Path
+
+# Add scripts to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from gen_lesson_intent import (
+    gen_lesson_intent_for_schema,
+    check_intent_stale_from_dicts,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+# G6-L22 style schema (nested PSE, 7 blanks total)
+KP_SCHEMA_G6_L22_STYLE = {
+    "keypoints": {
+        "lesson": "TEST-INTENT-L1",
+        "structure": "nested",
+        "columns": ["label", "sub_label", "value"],
+        "rows": [
+            {
+                "label": "問題",
+                "value": "秦昭王軟禁了孟嘗君而且想殺掉他，孟嘗君想要逃離秦國。",
+                "blanks": [],
+            },
+            {
+                "label": "解決",
+                "sub_rows": [
+                    {
+                        "sub_label": "問題1",
+                        "template": "孟嘗君求幸姬幫忙，幸姬要求孟嘗君給她白狐裘，但大衣已經送給秦昭王，不給，自己就__，孟嘗君去哪裡再找一件皮大衣呢?",
+                        "blanks": [{"answer": "凶多吉少", "hint": ""}],
+                    },
+                    {
+                        "sub_label": "解決1",
+                        "template": "食客中有一位會模仿__的樣子和動作潛入家戶偷東西，他可以潛入寶庫中偷出白狐裘。",
+                        "blanks": [{"answer": "狗", "hint": ""}],
+                    },
+                    {
+                        "sub_label": "結果1",
+                        "template": "幸姬得到了白狐裘，替孟嘗君求情，秦昭王解除了對孟嘗君的__。",
+                        "blanks": [{"answer": "軟禁", "hint": ""}],
+                    },
+                    {
+                        "sub_label": "問題2",
+                        "template": "一行人想趕快逃離秦國，他們到了函谷關，但是規定__時，士兵才能把城門打開，現在他們__。",
+                        "blanks": [
+                            {"answer": "天亮", "hint": ""},
+                            {"answer": "出不了關", "hint": ""},
+                        ],
+                    },
+                    {
+                        "sub_label": "解決2",
+                        "template": "食客中有一位會模仿__的人，他唯妙唯肖的叫聲，讓公雞們以為天亮了，也都跟著鳴叫，騙過守門人。",
+                        "blanks": [{"answer": "公雞叫", "hint": ""}],
+                    },
+                    {
+                        "sub_label": "結果3",
+                        "template": "城門__，孟嘗君也順利出關。",
+                        "blanks": [{"answer": "終於打開／提前開啟", "hint": ""}],
+                    },
+                ],
+            },
+            {
+                "label": "結果",
+                "value": "孟嘗君在食客們的幫助下成功逃離秦國。",
+                "blanks": [],
+            },
+        ],
+    }
+}
+
+# A slightly modified version (one field changed — simulates schema evolution)
+import copy
+
+KP_SCHEMA_V2 = copy.deepcopy(KP_SCHEMA_G6_L22_STYLE)
+# Change one answer to simulate schema drift
+KP_SCHEMA_V2["keypoints"]["rows"][1]["sub_rows"][0]["blanks"][0]["answer"] = "大難臨頭"
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestGenIntentOutputStructure:
+    """Test 1: gen_lesson_intent_for_schema output has required keys and valid values."""
+
+    def test_output_has_required_keys(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        assert "lesson" in intent, "intent must have 'lesson'"
+        assert "schema_fingerprint" in intent, "intent must have 'schema_fingerprint'"
+        assert "generated_at" in intent, "intent must have 'generated_at'"
+        assert "intent_rows" in intent, "intent must have 'intent_rows'"
+
+    def test_intent_rows_is_nonempty_list(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        rows = intent["intent_rows"]
+        assert isinstance(rows, list), "intent_rows must be a list"
+        assert len(rows) > 0, "intent_rows must not be empty"
+
+    def test_cognitive_skill_valid_enum(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        valid_skills = {"recall", "inference", "synthesis", "evaluation"}
+        for row in intent["intent_rows"]:
+            cs = row.get("cognitive_skill")
+            assert cs in valid_skills, (
+                f"cognitive_skill '{cs}' not in valid set {valid_skills}"
+            )
+
+    def test_each_row_has_label(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        for row in intent["intent_rows"]:
+            assert "label" in row, f"Row missing 'label': {row}"
+
+    def test_schema_fingerprint_is_sha256_hex(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        fp = intent["schema_fingerprint"]
+        assert isinstance(fp, str), "fingerprint must be a string"
+        assert len(fp) == 64, f"Expected SHA-256 hex (64 chars), got: {len(fp)}"
+
+    def test_generated_at_is_iso8601(self):
+        import datetime
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        generated_at = intent["generated_at"]
+        # Should parse as ISO datetime
+        try:
+            datetime.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            pytest.fail(f"generated_at '{generated_at}' is not valid ISO 8601")
+
+
+class TestDriftDetectionMismatch:
+    """Test 2: fingerprint from v1 schema checked against v2 schema → stale=True."""
+
+    def test_drift_detected_on_schema_change(self):
+        # Generate intent from v1
+        intent_v1 = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-DRIFT",
+        )
+        # Check stale using v2 (changed schema)
+        result = check_intent_stale_from_dicts(
+            current_kp_schema=KP_SCHEMA_V2,
+            stored_intent=intent_v1,
+        )
+        assert result["stale"] is True, (
+            "Schema changed → should detect as stale"
+        )
+        assert "reason" in result, "stale result must include 'reason'"
+
+
+class TestDriftDetectionNoChange:
+    """Test 3: same schema used for both gen and check → stale=False."""
+
+    def test_no_drift_when_schema_unchanged(self):
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-DRIFT",
+        )
+        result = check_intent_stale_from_dicts(
+            current_kp_schema=KP_SCHEMA_G6_L22_STYLE,
+            stored_intent=intent,
+        )
+        assert result["stale"] is False, (
+            f"Same schema → should not be stale. Got: {result}"
+        )
+
+
+class TestIntentRowsCoverage:
+    """Test 4: G6-L22 style schema (7 blanks) → at least 7 blank_idx entries."""
+
+    def test_blank_coverage_at_least_7(self):
+        """For schema with 7 blanks, intent_rows must have >= 7 entries with blank_idx."""
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        blank_rows = [r for r in intent["intent_rows"] if "blank_idx" in r]
+        assert len(blank_rows) >= 7, (
+            f"Expected >= 7 blank_idx entries for 7-blank schema, got {len(blank_rows)}: "
+            f"{[r.get('blank_idx') for r in blank_rows]}"
+        )
+
+    def test_answer_criterion_present(self):
+        """Each row with blank_idx should have answer_criterion."""
+        intent = gen_lesson_intent_for_schema(
+            KP_SCHEMA_G6_L22_STYLE,
+            lesson_id="TEST-INTENT-L1",
+        )
+        for row in intent["intent_rows"]:
+            if "blank_idx" in row:
+                assert "answer_criterion" in row, (
+                    f"Row with blank_idx missing answer_criterion: {row}"
+                )
+                valid_criteria = {"verbatim_recall", "paraphrase_ok", "open_ended"}
+                assert row["answer_criterion"] in valid_criteria, (
+                    f"Invalid answer_criterion '{row['answer_criterion']}'"
+                )

--- a/tests/test_lesson_intent.py
+++ b/tests/test_lesson_intent.py
@@ -196,18 +196,33 @@ class TestDriftDetectionNoChange:
 
 
 class TestIntentRowsCoverage:
-    """Test 4: G6-L22 style schema (7 blanks) → at least 7 blank_idx entries."""
+    """Test 4: G6-L22 style schema (7 blanks) → exactly 7 blank_idx entries (one per blank)."""
 
     def test_blank_coverage_at_least_7(self):
-        """For schema with 7 blanks, intent_rows must have >= 7 entries with blank_idx."""
+        """
+        For schema with exactly 7 blanks, intent_rows must have exactly 7 entries
+        with blank_idx (one entry per blank, no duplicates, no omissions).
+
+        KP_SCHEMA_G6_L22_STYLE blanks: 解決.問題1(1) + 解決1(1) + 結果1(1) + 問題2(2) +
+        解決2(1) + 結果3(1) = 7 total.
+
+        Uniqueness check: each (row_idx, blank_idx) pair must appear exactly once.
+        """
         intent = gen_lesson_intent_for_schema(
             KP_SCHEMA_G6_L22_STYLE,
             lesson_id="TEST-INTENT-L1",
         )
         blank_rows = [r for r in intent["intent_rows"] if "blank_idx" in r]
-        assert len(blank_rows) >= 7, (
-            f"Expected >= 7 blank_idx entries for 7-blank schema, got {len(blank_rows)}: "
-            f"{[r.get('blank_idx') for r in blank_rows]}"
+        assert len(blank_rows) == 7, (
+            f"Expected exactly 7 blank_idx entries for 7-blank schema, got {len(blank_rows)}: "
+            f"{[(r.get('row_idx'), r.get('blank_idx')) for r in blank_rows]}"
+        )
+        # Uniqueness: no (row_idx, blank_idx) pair should appear more than once
+        pairs = [(r["row_idx"], r["blank_idx"]) for r in blank_rows]
+        unique_pairs = set(pairs)
+        assert len(pairs) == len(unique_pairs), (
+            f"Duplicate (row_idx, blank_idx) pairs found: "
+            f"{[p for p in pairs if pairs.count(p) > 1]}"
         )
 
     def test_answer_criterion_present(self):


### PR DESCRIPTION
Related to #2397

## Summary

Implements two new keypoints QA slices for the Content Evidence Gate:

**② Text Fidelity Check (deterministic, `eval_keypoints_text_fidelity`)**
- Bug closed: `eval_keypoints` previously only checked row/blank COUNT. A schema with `row_recall=1.0, blank_recall=1.0` but garbled/merged/wrong cell text would silently PASS.
- New `eval_keypoints_text_fidelity()` in `scripts/eval_keypoints_text_fidelity.py`: normalizes both schema and DOCX text (NFKC, strip, collapse spaces) → compares positionally → reports per-cell match/mismatch + `text_fidelity` score → fail-closed (any mismatch = fail).
- Integrated into `eval_lesson_schema.py` as `result["keypoints_text_fidelity"]`. New `--text-fidelity` CLI flag.
- Blank-answer matching: splits on `/`/`／` for multi-answer cells (e.g., `"天亮／提前開啟"`).

**③ Lesson Intent Draft + Drift-Lock (`scripts/gen_lesson_intent.py`)**
- New script: reads `<lesson_id>.keypoints.yml` → infers cognitive_skill per row/blank (rule-based: position in PSE + answer length) → writes `<lesson_id>.intent.yml` with schema fingerprint (SHA-256).
- Drift-lock: `--check-drift` recomputes fingerprint against live schema → flags STALE if schema changed since intent was generated. Fail-closed.
- v1 = AI-draft as working ground truth. Human review layer is TODO (not implemented per spec).

## New files
- `scripts/eval_keypoints_text_fidelity.py` — ② fidelity module
- `scripts/gen_lesson_intent.py` — ③ intent + drift-lock module
- `tests/test_keypoints_text_fidelity.py` — 5 TDD tests for ②
- `tests/test_lesson_intent.py` — 10 TDD tests for ③

## Modified files
- `scripts/eval_lesson_schema.py` — imports both modules, adds `keypoints_text_fidelity` to `eval_lesson()`, adds `--text-fidelity` flag

## Test plan

```
# All 15 unit tests GREEN
python3 -m pytest tests/test_keypoints_text_fidelity.py tests/test_lesson_intent.py -v
# → 15 passed in 0.04s

# ② G6-L22 real run: 15 cells checked, text_fidelity=1.0, pass=true
# ② G6-L23 real run: 10 cells checked, text_fidelity=1.0, pass=true

# ③ G6-L22 intent: 15 intent_rows, 7 blank entries, drift=FRESH
```

## Key regression lock

`TestTextFidelityCounts::test_garbled_value_fails_even_though_counts_match` confirms a schema with matching counts but wrong cell text returns `pass=False`. This is the root regression lock for the ② false-pass blind spot.