### PR TITLE
fix(spotlight): null legacy strategy_exercise for 4 render-confirmed cross_lesson slots (#2397)

### DIFF
--- a/backend/app/services/lesson_indexes.py
+++ b/backend/app/services/lesson_indexes.py
@@ -19,7 +19,10 @@ from app.services.lesson_layer_loaders import (
     build_layer2_enrichment_index,
 )
 from app.services.spotlight_figure_images import merge_spotlight_images
-from app.services.spotlight_v2_loader import load_spotlight_v2
+from app.services.spotlight_v2_loader import (
+    load_spotlight_v2,
+    should_suppress_legacy_strategy_exercise,
+)
 
 
 def _reapply_spotlight_images(lesson: dict) -> None:
@@ -79,6 +82,16 @@ def build_all_lessons() -> list[dict]:
         _reapply_spotlight_images(lesson)
 
     all_lessons = layer1 + layer2
+
+    # #2397: render-confirmed cross_lesson via the legacy strategy_exercise
+    # fallback. Applied AFTER the Layer-2 enrichment merge above (which would
+    # otherwise re-populate strategy_exercise with the foreign example), so the
+    # null sticks. The frontend StrategyExercisePage then shows the honest
+    # "no spotlight yet" placeholder instead of another topic's content.
+    for lesson in all_lessons:
+        code = lesson.get("lesson_code") or lesson.get("grade_code") or ""
+        if should_suppress_legacy_strategy_exercise(code):
+            lesson["strategy_exercise"] = None
 
     # Sort: Layer-1 by lesson_number, Layer-2 by display_order, then mix.
     # Use display_order from manifest for Layer-2; for Layer-1 use lesson_number as proxy.

--- a/backend/app/services/spotlight_v2_loader.py
+++ b/backend/app/services/spotlight_v2_loader.py
@@ -50,6 +50,43 @@ _UNVERIFIED_SPOTLIGHT_SLOT_DENYLIST = frozenset({
 })
 
 
+# Render-confirmed cross_lesson via the LEGACY strategy_exercise fallback (#2397).
+# These slots have no verified spotlight source (already in known_gaps + the
+# unverified denylist above → spotlight_v2 None), but their legacy
+# strategy_exercise embeds a FOREIGN worked example that is NEVER applied to the
+# lesson's own passage (verified: the example text is absent from the lesson
+# paragraphs). The frontend StrategyExercisePage falls back to strategy_exercise
+# when spotlight_v2 is empty → student sees another topic's example. Nulling the
+# legacy field makes the honest "no spotlight yet" placeholder render instead.
+# gap >> 放錯課.
+#
+# Scope is deliberately NARROW: lessons whose legacy strategy_exercise is itself
+# faithful (e.g. G7-L31 旅人鴿 — its strategy quotes the lesson's own passage)
+# must keep rendering it, so they are NOT listed here even though their
+# spotlight_v2 is fail-closed above.
+_LEGACY_STRATEGY_EXERCISE_DENYLIST = frozenset({
+    "G5-L15",  # 上位概念 example = 大安森林公園裝置藝術 (≠ 信件的力量; absent from passage)
+    "G6-L12",  # 找主題句 example = 烏龍茶製程 (≠ 愛冒險逞強的雄性動物; absent from passage)
+    "G7-L7",   # 折線圖判讀 example = 臺北市平均氣溫 (≠ 人口負成長; absent from passage)
+    "G9-L8",   # 圖表判讀 example = 新生兒性別比 (≠ 臺灣學生閱讀力; absent from passage)
+})
+
+
+def should_suppress_legacy_strategy_exercise(lesson_code: str) -> bool:
+    """True when the lesson's legacy strategy_exercise must be nulled (#2397).
+
+    Verified by content evidence: the strategy's worked example does not appear
+    in the lesson's own passage, so rendering the legacy fallback shows another
+    topic's content. See _LEGACY_STRATEGY_EXERCISE_DENYLIST.
+    """
+    raw = (lesson_code or "").strip()
+    norm = normalize_manifest_code(raw)
+    return (
+        raw in _LEGACY_STRATEGY_EXERCISE_DENYLIST
+        or norm in _LEGACY_STRATEGY_EXERCISE_DENYLIST
+    )
+
+
 def _is_zero_padded_grade_code(code: str) -> bool:
     return bool(_ZERO_PADDED_GRADE_CODE_RE.match(code or ""))
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 真根因（code-confirmed，非 API 推論）

`StrategyExercisePage.tsx` render 優先序：`spotlight_v2` → **fallback `strategy_exercise`（legacy）** → 誠實 placeholder。

前一個 PR 把這 4 課的 `spotlight_v2` fail-close 成 None（known_gaps），但**前端掉到 fallback 去 render `strategy_exercise`**,而該欄位裝的是**別主題的 worked example**（沒套用本課原文）→ 學生仍看到放錯課內容。這就是「fail-close 卻沒解」的根因。

## 證據（staging API + 本課 paragraphs 比對）

每課 strategy example 文字**都不在本課原文**：

| 課 | strategy 用的例子 | 在本課原文? |
|---|---|---|
| G5-L15 信件的力量 | 大安森林公園裝置藝術 上位概念 | ❌ |
| G6-L12 愛冒險逞強動物 | 烏龍茶製程 找主題句 | ❌ |
| G7-L7 人口負成長 | 臺北市平均氣溫 折線圖判讀 | ❌ |
| G9-L8 臺灣學生閱讀力 | 新生兒性別比 圖表判讀 | ❌ |

## Fix

`build_all_lessons()` 在 Layer-2 enrichment merge **之後**把這 4 課 `strategy_exercise` 設 None（merge 會 re-populate,所以必須在 merge 後）→ 前端 render 誠實 placeholder。`gap >> 放錯課`。

## 刻意窄 scope（不誤傷好內容）

- **G7-L31 旅人鴿**：sv2 也 fail-closed,但 legacy strategy_exercise 是 faithful（引本課原文）→ 保留 render
- **G5-L14 垃圾食物 / G7-L20 偽科學**：vision judge 判 cross 但其實 FAITHFUL（G5-L14 用臺東例子教刪除法後套用本課垃圾食物；G7-L20 假消息策略=本課偽科學主題）→ judge false positive,不動

## 驗證

- 本機 loader 載入 7 課控制組：4 cross → strategy_exercise=None；3 faithful 保留 ✅
- backend spec 233 passed / 0 failed ✅
- 部署後 vision sweep 確認 4 課 render placeholder（非 cross）

Related to #2397