### PR TITLE
feat(login): 快速登入新增「登入朗讀測試頁面」按鈕 (#2410)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -96,8 +96,12 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
       if (err instanceof AuthError) {
         setError(err.message);
       } else {
-        setError('登入失敗');
+        setError('登入失敗，請稍後再試');
       }
+      // Only reset on failure: on success the component unmounts after redirect,
+      // so resetting in a finally block would be a no-op (and could warn on an
+      // unmounted component). The form's handleSubmit uses finally because it
+      // never redirects on the same path.
       setIsSubmitting(false);
     }
   };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -69,6 +69,39 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
     }
   };
 
+  /**
+   * Shared quick-login (demo) handler. Logs in with the given demo credentials
+   * (real login — token + session, same as the form), then redirects.
+   * @param redirectTo  override target. When `external` is true the target is a
+   *   static page outside the SPA router (e.g. /presentation/*.html) and must be
+   *   reached via window.location, not react-router navigate().
+   */
+  const quickLogin = async (
+    demoEmail: string,
+    demoPw: string,
+    redirectTo?: { path: string; external?: boolean },
+  ) => {
+    setError('');
+    setIsSubmitting(true);
+    try {
+      const result = await login(demoEmail, demoPw);
+      if (result.mustChangePassword) {
+        navigate('/change-password', { replace: true });
+      } else if (redirectTo?.external) {
+        window.location.href = redirectTo.path;
+      } else {
+        navigate(redirectTo?.path ?? from, { replace: true });
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setError(err.message);
+      } else {
+        setError('登入失敗');
+      }
+      setIsSubmitting(false);
+    }
+  };
+
   const handleGoogleCredential = async (credential: string) => {
     setError('');
     setIsSubmitting(true);
@@ -220,25 +253,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
                   key={acc.email}
                   type="button"
                   disabled={isSubmitting}
-                  onClick={async () => {
-                    setError('');
-                    setIsSubmitting(true);
-                    try {
-                      const result = await login(acc.email, acc.pw);
-                      if (result.mustChangePassword) {
-                        navigate('/change-password', { replace: true });
-                      } else {
-                        navigate(from, { replace: true });
-                      }
-                    } catch (err) {
-                      if (err instanceof AuthError) {
-                        setError(err.message);
-                      } else {
-                        setError('登入失敗');
-                      }
-                      setIsSubmitting(false);
-                    }
-                  }}
+                  onClick={() => quickLogin(acc.email, acc.pw)}
                   className={`border rounded-lg px-2 py-2.5 text-center transition-colors cursor-pointer disabled:opacity-50 ${acc.color}`}
                 >
                   <div className="text-xs font-bold">{acc.label}</div>
@@ -246,6 +261,24 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
                 </button>
               ))}
             </div>
+
+            {/* Reading-test shortcut: real student login, then jump straight to
+                the (hidden) reading-pipeline test page. #2410 */}
+            <button
+              type="button"
+              disabled={isSubmitting}
+              onClick={() =>
+                quickLogin(
+                  import.meta.env.VITE_DEMO_STUDENT_EMAIL ?? '',
+                  import.meta.env.VITE_DEMO_STUDENT_PW ?? '',
+                  { path: '/presentation/reading-pipeline.html', external: true },
+                )
+              }
+              className="mt-2 w-full flex items-center justify-center gap-2 border rounded-lg px-2 py-2.5 text-xs font-bold transition-colors cursor-pointer disabled:opacity-50 bg-purple-50 border-purple-200 text-purple-700 hover:bg-purple-100"
+            >
+              <span className="material-symbols-outlined text-sm">record_voice_over</span>
+              登入朗讀測試頁面
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 目的

Fixes #2410。做朗讀測試時，原本要「點學生小明登入 → 再手動貼 `/presentation/reading-pipeline.html` 網址」兩步。本 PR 在 `/login` 的「快速登入（測試用）」加一顆捷徑按鈕一次完成。

## 改動

`frontend/src/pages/LoginPage.tsx`：

- 三顆角色按鈕下方新增全寬按鈕 **「登入朗讀測試頁面」**（🟣 紫色，含 `record_voice_over` icon）。
- ⚠️ **真正登入**：沿用學生 demo 帳號（`VITE_DEMO_STUDENT_EMAIL` / `_PW`）呼叫 `login()` 取得 token + 建立 session，與其他快速登入按鈕一致，**不是純頁面切換**。
- 登入成功後導向 `/presentation/reading-pipeline.html`。該頁是 SPA router 外的靜態 HTML，因此用 `window.location.href` 而非 react-router `navigate()`。
- 抽出共用 `quickLogin(email, pw, redirectTo?)` helper，三顆既有角色按鈕一併改用，移除重複的 try/catch 登入邏輯。
- 仍受既有 `VITE_SHOW_DEMO_LOGIN` 旗標保護（僅非 production 顯示），不影響正式登入流程，無後端改動。

## Frontend Render-Safety Verification (ui-pr-verify SOP)

- ESLint: ✅ 0 errors（`npm run lint`，22 個皆 pre-existing warnings，無一在 LoginPage.tsx）
- vitest smoke: ✅ 13/13 pass（`npm run test -- src/__smoke__/`）
- tsc: ✅ LoginPage.tsx 無型別錯誤
- Page console: ⬜ 待 preview 部署後在 `/login` 實機驗 console = 0 errors（補在留言）

## 嚴重性

🟢 低 — 測試輔助用，受 demo-login 旗標保護，不影響正式功能。

Fixes #2410