### PR TITLE
feat(spotlight): table→fill_table (G5-L16/G9-L9) + ratchet hardening (4 fingerprints, drift-fails) (#2397)

### DIFF
--- a/backend/data/curriculum_qa/spotlight_regression_baseline.json
+++ b/backend/data/curriculum_qa/spotlight_regression_baseline.json
@@ -309,11 +309,10 @@
   "G5-L16": {
     "tier": "catalog",
     "n_blocks": 17,
-    "n_questions": 1,
+    "n_questions": 3,
     "type_counts": {
       "guide": 14,
-      "figure": 2,
-      "fill_table": 1
+      "fill_table": 3
     },
     "content_hash": "d60121be0f8f0c1b",
     "source_code": "G5-L16"
@@ -1468,12 +1467,12 @@
   "G9-L9": {
     "tier": "test15",
     "n_blocks": 22,
-    "n_questions": 8,
+    "n_questions": 9,
     "type_counts": {
       "guide": 11,
       "passage": 2,
       "free_text": 8,
-      "figure": 1
+      "fill_table": 1
     },
     "content_hash": "7629c121ac340d4c",
     "source_code": null

--- a/backend/data/curriculum_qa/spotlight_regression_baseline.json
+++ b/backend/data/curriculum_qa/spotlight_regression_baseline.json
@@ -11,7 +11,8 @@
       "figure": 2,
       "self_check": 1
     },
-    "fingerprint": "d4851b2f9b453fe7"
+    "content_hash": "6d1c5a87c254e647",
+    "source_code": null
   },
   "G4-L11": {
     "tier": "catalog",
@@ -24,7 +25,8 @@
       "passage": 3,
       "figure": 2
     },
-    "fingerprint": "eab0b2c3c42bfc09"
+    "content_hash": "226452fb1bc9486d",
+    "source_code": null
   },
   "G4-L13": {
     "tier": "test15",
@@ -36,7 +38,8 @@
       "figure": 2,
       "passage": 3
     },
-    "fingerprint": "c07c05630fe869b7"
+    "content_hash": "cc0e361531ffdbe5",
+    "source_code": null
   },
   "G4-L15": {
     "tier": "catalog",
@@ -47,7 +50,8 @@
       "figure": 1,
       "passage": 1
     },
-    "fingerprint": "6102ca07d98bcd6b"
+    "content_hash": "d213ee78c8b66e0e",
+    "source_code": null
   },
   "G4-L16": {
     "tier": "catalog",
@@ -59,7 +63,8 @@
       "free_text": 5,
       "passage": 1
     },
-    "fingerprint": "394ca3ef255b3168"
+    "content_hash": "8f9193e1ed5a7788",
+    "source_code": null
   },
   "G4-L18": {
     "tier": "catalog",
@@ -67,7 +72,9 @@
     "n_questions": 0,
     "type_counts": {
       "guide": 20
-    }
+    },
+    "content_hash": "fc53c09d8f92cd03",
+    "source_code": null
   },
   "G4-L19": {
     "tier": "catalog",
@@ -79,7 +86,8 @@
       "free_text": 9,
       "single": 5
     },
-    "fingerprint": "6a0e3fefb49f309b"
+    "content_hash": "ecd218705342e64c",
+    "source_code": null
   },
   "G4-L2": {
     "tier": "catalog",
@@ -91,7 +99,8 @@
       "figure": 1,
       "passage": 1
     },
-    "fingerprint": "4d861876b7e83384"
+    "content_hash": "64083bb7bd82b880",
+    "source_code": null
   },
   "G4-L20": {
     "tier": "catalog",
@@ -101,7 +110,8 @@
       "guide": 4,
       "single": 5
     },
-    "fingerprint": "b18f36e5f6727933"
+    "content_hash": "f809479cd99bc3a1",
+    "source_code": "G4-L20"
   },
   "G4-L23": {
     "tier": "catalog",
@@ -112,7 +122,8 @@
       "self_check": 8,
       "free_text": 4
     },
-    "fingerprint": "6aa9f9987b75eeba"
+    "content_hash": "240f659c1a892d59",
+    "source_code": null
   },
   "G4-L24": {
     "tier": "catalog",
@@ -123,7 +134,8 @@
       "single": 7,
       "multi": 6
     },
-    "fingerprint": "b8e915ca4132dc23"
+    "content_hash": "3f700f9452bb99f0",
+    "source_code": null
   },
   "G4-L25": {
     "tier": "catalog",
@@ -134,7 +146,8 @@
       "figure": 2,
       "free_text": 3
     },
-    "fingerprint": "e92064c6e90f3427"
+    "content_hash": "9233bfc5b60a67d5",
+    "source_code": null
   },
   "G4-L26": {
     "tier": "catalog",
@@ -145,7 +158,8 @@
       "figure": 2,
       "free_text": 3
     },
-    "fingerprint": "c3e160d303ca875e"
+    "content_hash": "b4ab82c8ace20ab7",
+    "source_code": null
   },
   "G4-L27": {
     "tier": "catalog",
@@ -158,7 +172,8 @@
       "free_text": 2,
       "multi": 1
     },
-    "fingerprint": "517ffdc243b5da79"
+    "content_hash": "e6cc69ed4c16a068",
+    "source_code": null
   },
   "G4-L3": {
     "tier": "catalog",
@@ -170,7 +185,8 @@
       "single": 1,
       "passage": 2
     },
-    "fingerprint": "2d35a522080588b0"
+    "content_hash": "9a8396ab230b780c",
+    "source_code": null
   },
   "G4-L4": {
     "tier": "catalog",
@@ -182,7 +198,8 @@
       "figure": 1,
       "guide": 1
     },
-    "fingerprint": "cd4cbeaef3b43a00"
+    "content_hash": "3d9b2ada9561d98c",
+    "source_code": null
   },
   "G4-L5": {
     "tier": "catalog",
@@ -191,7 +208,8 @@
     "type_counts": {
       "guide": 1
     },
-    "fingerprint": "17bb77539002c262"
+    "content_hash": "ce344d1027a19d83",
+    "source_code": null
   },
   "G4-L6": {
     "tier": "catalog",
@@ -202,7 +220,8 @@
       "free_text": 3,
       "passage": 1
     },
-    "fingerprint": "b5fe5bcad4a2a739"
+    "content_hash": "e8e4971b9e59e5c1",
+    "source_code": null
   },
   "G4-L7": {
     "tier": "catalog",
@@ -213,7 +232,8 @@
       "free_text": 5,
       "single": 1
     },
-    "fingerprint": "7bb6eafe772dad28"
+    "content_hash": "8ff81fb11783256d",
+    "source_code": null
   },
   "G4-L8": {
     "tier": "catalog",
@@ -223,7 +243,8 @@
       "guide": 9,
       "free_text": 4
     },
-    "fingerprint": "82b79a06aec249eb"
+    "content_hash": "e280bff90a8eb0a4",
+    "source_code": null
   },
   "G4-L9": {
     "tier": "catalog",
@@ -234,7 +255,8 @@
       "free_text": 8,
       "passage": 1
     },
-    "fingerprint": "102fa93ec2c6afa7"
+    "content_hash": "a6f5c0bcb99a6868",
+    "source_code": null
   },
   "G5-L10": {
     "tier": "test15",
@@ -245,7 +267,8 @@
       "free_text": 2,
       "single": 3
     },
-    "fingerprint": "4e355457b64b287d"
+    "content_hash": "cd097710c03fb192",
+    "source_code": null
   },
   "G5-L12": {
     "tier": "catalog",
@@ -254,7 +277,9 @@
     "type_counts": {
       "guide": 1,
       "single": 8
-    }
+    },
+    "content_hash": "02011ab61dd67a4c",
+    "source_code": null
   },
   "G5-L13": {
     "tier": "catalog",
@@ -265,7 +290,8 @@
       "free_text": 2,
       "passage": 1
     },
-    "fingerprint": "87efbdd8a43b782c"
+    "content_hash": "1e16a7ef6888ff2d",
+    "source_code": null
   },
   "G5-L14": {
     "tier": "catalog",
@@ -277,7 +303,8 @@
       "free_text": 16,
       "passage": 1
     },
-    "fingerprint": "ca550204a6f9d21d"
+    "content_hash": "edf525bf1ab0b4fe",
+    "source_code": "G5-L14"
   },
   "G5-L16": {
     "tier": "catalog",
@@ -288,7 +315,8 @@
       "figure": 2,
       "fill_table": 1
     },
-    "fingerprint": "4b037f56ba9031ac"
+    "content_hash": "d60121be0f8f0c1b",
+    "source_code": "G5-L16"
   },
   "G5-L17": {
     "tier": "catalog",
@@ -298,7 +326,8 @@
       "guide": 1,
       "single": 10
     },
-    "fingerprint": "c0cd371dd18992ba"
+    "content_hash": "ee61440336e8e5b0",
+    "source_code": null
   },
   "G5-L18": {
     "tier": "catalog",
@@ -311,7 +340,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "86d61ca3f187c5a9"
+    "content_hash": "c93a88d8bcca1a0b",
+    "source_code": null
   },
   "G5-L2": {
     "tier": "catalog",
@@ -321,7 +351,8 @@
       "guide": 5,
       "free_text": 30
     },
-    "fingerprint": "91486f2f2abb48f7"
+    "content_hash": "76ee97e14a45733c",
+    "source_code": null
   },
   "G5-L20": {
     "tier": "catalog",
@@ -332,7 +363,8 @@
       "single": 1,
       "passage": 1
     },
-    "fingerprint": "22901f6eb80e24a8"
+    "content_hash": "990f1062131ab1b1",
+    "source_code": null
   },
   "G5-L21": {
     "tier": "catalog",
@@ -342,7 +374,8 @@
       "guide": 4,
       "free_text": 4
     },
-    "fingerprint": "c4b4c0aca61836cf"
+    "content_hash": "8a2d17dab6325d42",
+    "source_code": null
   },
   "G5-L22": {
     "tier": "catalog",
@@ -353,7 +386,8 @@
       "single": 1,
       "figure": 2
     },
-    "fingerprint": "7ffff3aeb7af50cc"
+    "content_hash": "127678f36541ff70",
+    "source_code": null
   },
   "G5-L23": {
     "tier": "catalog",
@@ -365,7 +399,8 @@
       "figure": 1,
       "self_check": 1
     },
-    "fingerprint": "e0c0c6d0b245cf68"
+    "content_hash": "b06360558e7ca0bb",
+    "source_code": null
   },
   "G5-L24": {
     "tier": "catalog",
@@ -376,7 +411,8 @@
       "figure": 1,
       "free_text": 3
     },
-    "fingerprint": "e7d3a410b7a0d4b5"
+    "content_hash": "8f54ccd52b7ae0a4",
+    "source_code": null
   },
   "G5-L26": {
     "tier": "test15",
@@ -388,7 +424,8 @@
       "figure": 3,
       "single": 4
     },
-    "fingerprint": "ad71ed2f3faa73c9"
+    "content_hash": "191a4b3bb90254a0",
+    "source_code": null
   },
   "G5-L27": {
     "tier": "catalog",
@@ -399,7 +436,8 @@
       "free_text": 7,
       "figure": 1
     },
-    "fingerprint": "de2567e98f8e283b"
+    "content_hash": "fa2ea46ef58d1d74",
+    "source_code": null
   },
   "G5-L3": {
     "tier": "catalog",
@@ -411,7 +449,8 @@
       "single": 3,
       "passage": 1
     },
-    "fingerprint": "31eaa77d0eccf9a8"
+    "content_hash": "175f25258267eb15",
+    "source_code": null
   },
   "G5-L4": {
     "tier": "catalog",
@@ -422,7 +461,8 @@
       "free_text": 8,
       "self_check": 1
     },
-    "fingerprint": "e0ac4cae4a5ae7a5"
+    "content_hash": "0d9fe2142fc472d2",
+    "source_code": null
   },
   "G5-L5": {
     "tier": "catalog",
@@ -432,7 +472,8 @@
       "guide": 22,
       "free_text": 6
     },
-    "fingerprint": "cf5f139663ae1962"
+    "content_hash": "e82a11914afe9ece",
+    "source_code": null
   },
   "G5-L6": {
     "tier": "catalog",
@@ -442,7 +483,8 @@
       "guide": 19,
       "free_text": 11
     },
-    "fingerprint": "7c7f877c5491fc7c"
+    "content_hash": "425359d51864e3e1",
+    "source_code": null
   },
   "G5-L7": {
     "tier": "test15",
@@ -453,7 +495,8 @@
       "single": 3,
       "free_text": 2
     },
-    "fingerprint": "38a775c882f2ab5a"
+    "content_hash": "7d037e4e40fec837",
+    "source_code": null
   },
   "G5-L8": {
     "tier": "catalog",
@@ -464,7 +507,8 @@
       "free_text": 3,
       "match": 2
     },
-    "fingerprint": "8b72eb2841bf5227"
+    "content_hash": "3afa466d4b07a984",
+    "source_code": null
   },
   "G5-L9": {
     "tier": "catalog",
@@ -475,7 +519,8 @@
       "free_text": 2,
       "figure": 1
     },
-    "fingerprint": "fea46a6a891a72aa"
+    "content_hash": "96a934ce887799c8",
+    "source_code": null
   },
   "G6-L10": {
     "tier": "catalog",
@@ -485,7 +530,8 @@
       "guide": 15,
       "free_text": 6
     },
-    "fingerprint": "877695e598ac02d1"
+    "content_hash": "5b527b4582538651",
+    "source_code": null
   },
   "G6-L11": {
     "tier": "catalog",
@@ -495,7 +541,8 @@
       "guide": 12,
       "free_text": 18
     },
-    "fingerprint": "5521e3a422c08e2a"
+    "content_hash": "42f3956efa95043b",
+    "source_code": null
   },
   "G6-L13": {
     "tier": "catalog",
@@ -505,7 +552,8 @@
       "guide": 8,
       "free_text": 6
     },
-    "fingerprint": "842c54dc07add7ce"
+    "content_hash": "22c05fb54a999176",
+    "source_code": null
   },
   "G6-L14": {
     "tier": "test15",
@@ -516,7 +564,8 @@
       "free_text": 2,
       "figure": 1
     },
-    "fingerprint": "7de0056f7c7de096"
+    "content_hash": "8bbba2e127b6fc75",
+    "source_code": null
   },
   "G6-L15": {
     "tier": "catalog",
@@ -527,7 +576,8 @@
       "free_text": 4,
       "single": 8
     },
-    "fingerprint": "deb326f11ddcd183"
+    "content_hash": "d3ebaa59723e9dc6",
+    "source_code": null
   },
   "G6-L17": {
     "tier": "catalog",
@@ -537,7 +587,9 @@
       "guide": 1,
       "single": 3,
       "free_text": 1
-    }
+    },
+    "content_hash": "65ee9a95121d029c",
+    "source_code": null
   },
   "G6-L18": {
     "tier": "catalog",
@@ -547,7 +599,8 @@
       "guide": 1,
       "free_text": 2
     },
-    "fingerprint": "a798600539a04e8e"
+    "content_hash": "3b673055c9e84ef3",
+    "source_code": null
   },
   "G6-L2": {
     "tier": "catalog",
@@ -556,7 +609,9 @@
     "type_counts": {
       "guide": 1,
       "single": 4
-    }
+    },
+    "content_hash": "41ed27ae11e2d90e",
+    "source_code": "G6-L2"
   },
   "G6-L20": {
     "tier": "catalog",
@@ -567,7 +622,8 @@
       "passage": 3,
       "figure": 1
     },
-    "fingerprint": "ac751d0a1a6bf9a2"
+    "content_hash": "9e0375973b768d2a",
+    "source_code": null
   },
   "G6-L22": {
     "tier": "dev7",
@@ -580,7 +636,8 @@
       "free_text": 1,
       "fill_table": 1
     },
-    "fingerprint": "e9fc3aee5c22efb3"
+    "content_hash": "ab991697e6b30f9e",
+    "source_code": null
   },
   "G6-L23": {
     "tier": "dev7",
@@ -594,7 +651,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "5e8d8f59a0a18192"
+    "content_hash": "63062e0ace581952",
+    "source_code": null
   },
   "G6-L24": {
     "tier": "dev7",
@@ -606,7 +664,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "9c3b29ab6e893467"
+    "content_hash": "0dadb6ff3544d9a4",
+    "source_code": null
   },
   "G6-L25": {
     "tier": "dev7",
@@ -618,7 +677,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "64e723812e15a561"
+    "content_hash": "4805058ed16b933e",
+    "source_code": null
   },
   "G6-L3": {
     "tier": "test15",
@@ -630,7 +690,8 @@
       "single": 2,
       "free_text": 2
     },
-    "fingerprint": "e0ae5bbe1041a998"
+    "content_hash": "494347a15fe2aa45",
+    "source_code": null
   },
   "G6-L4": {
     "tier": "catalog",
@@ -640,7 +701,8 @@
       "guide": 16,
       "free_text": 2
     },
-    "fingerprint": "8408e846c3d6aff1"
+    "content_hash": "3e98a7f48cdc1f2a",
+    "source_code": null
   },
   "G6-L5": {
     "tier": "catalog",
@@ -650,7 +712,8 @@
       "guide": 15,
       "free_text": 6
     },
-    "fingerprint": "b23aadb9c34c73c3"
+    "content_hash": "701a16a5813a02ce",
+    "source_code": null
   },
   "G6-L6": {
     "tier": "catalog",
@@ -661,7 +724,8 @@
       "free_text": 5,
       "passage": 1
     },
-    "fingerprint": "34c5abca0c79bc53"
+    "content_hash": "13ecff4f2d27fb4f",
+    "source_code": null
   },
   "G6-L7": {
     "tier": "catalog",
@@ -673,7 +737,8 @@
       "free_text": 8,
       "passage": 6
     },
-    "fingerprint": "cb16cc954657d14d"
+    "content_hash": "4dcb6fa95eb720a7",
+    "source_code": null
   },
   "G6-L8": {
     "tier": "test15",
@@ -682,7 +747,9 @@
     "type_counts": {
       "guide": 17,
       "free_text": 17
-    }
+    },
+    "content_hash": "23ce3b52f4a4d7d5",
+    "source_code": null
   },
   "G6-L9": {
     "tier": "catalog",
@@ -692,7 +759,8 @@
       "guide": 10,
       "free_text": 2
     },
-    "fingerprint": "5d95313ba9ed925f"
+    "content_hash": "abe964599e475ca8",
+    "source_code": null
   },
   "G7-L1": {
     "tier": "catalog",
@@ -702,7 +770,9 @@
       "guide": 1,
       "single": 8,
       "free_text": 3
-    }
+    },
+    "content_hash": "352ae89e1ca50da3",
+    "source_code": null
   },
   "G7-L10": {
     "tier": "catalog",
@@ -716,7 +786,8 @@
       "figure": 1,
       "self_check": 1
     },
-    "fingerprint": "b070aab2a671cd43"
+    "content_hash": "3427bab625d70a9f",
+    "source_code": null
   },
   "G7-L11": {
     "tier": "catalog",
@@ -730,7 +801,8 @@
       "free_text": 2,
       "self_check": 1
     },
-    "fingerprint": "436734ff6ece6930"
+    "content_hash": "5a18352d436b19c9",
+    "source_code": null
   },
   "G7-L12": {
     "tier": "catalog",
@@ -743,7 +815,8 @@
       "passage": 5,
       "self_check": 1
     },
-    "fingerprint": "30e5f0a3fcb9ffa3"
+    "content_hash": "2f1f5dcd488c3511",
+    "source_code": null
   },
   "G7-L13": {
     "tier": "catalog",
@@ -753,7 +826,8 @@
       "guide": 2,
       "free_text": 2
     },
-    "fingerprint": "7aa0ac8c553ba101"
+    "content_hash": "5c61e38036816a30",
+    "source_code": null
   },
   "G7-L14": {
     "tier": "catalog",
@@ -763,7 +837,9 @@
       "guide": 6,
       "free_text": 5,
       "passage": 2
-    }
+    },
+    "content_hash": "3dc221b3d52067c3",
+    "source_code": null
   },
   "G7-L16": {
     "tier": "catalog",
@@ -773,7 +849,8 @@
       "guide": 1,
       "free_text": 6
     },
-    "fingerprint": "3c60b8f968dc3bb3"
+    "content_hash": "c36aed2ac01e7558",
+    "source_code": null
   },
   "G7-L17": {
     "tier": "test15",
@@ -783,7 +860,8 @@
       "guide": 2,
       "free_text": 2
     },
-    "fingerprint": "315fed6ebb969b49"
+    "content_hash": "101c351670364f2f",
+    "source_code": null
   },
   "G7-L18": {
     "tier": "catalog",
@@ -793,7 +871,9 @@
       "guide": 1,
       "single": 10,
       "free_text": 3
-    }
+    },
+    "content_hash": "cee2e86ccb246847",
+    "source_code": null
   },
   "G7-L19": {
     "tier": "test15",
@@ -803,7 +883,8 @@
       "guide": 2,
       "passage": 1
     },
-    "fingerprint": "9ffdfc7adb78d70d"
+    "content_hash": "f63c773089541206",
+    "source_code": null
   },
   "G7-L2": {
     "tier": "catalog",
@@ -813,7 +894,9 @@
       "guide": 1,
       "single": 4,
       "free_text": 1
-    }
+    },
+    "content_hash": "9073c88e1bb38c47",
+    "source_code": null
   },
   "G7-L21": {
     "tier": "catalog",
@@ -823,7 +906,8 @@
       "guide": 3,
       "free_text": 3
     },
-    "fingerprint": "74bd4b7f66573e82"
+    "content_hash": "0c68202e7b97f2fc",
+    "source_code": null
   },
   "G7-L23": {
     "tier": "catalog",
@@ -836,7 +920,8 @@
       "free_text": 6,
       "single": 16
     },
-    "fingerprint": "6c0d2b7c2ec950fd"
+    "content_hash": "a6c86ae87eaa7e56",
+    "source_code": null
   },
   "G7-L24": {
     "tier": "catalog",
@@ -848,7 +933,8 @@
       "free_text": 22,
       "single": 8
     },
-    "fingerprint": "c9f3fe183b06b591"
+    "content_hash": "d27ce1b31d7453b4",
+    "source_code": null
   },
   "G7-L25": {
     "tier": "catalog",
@@ -859,7 +945,8 @@
       "single": 3,
       "passage": 1
     },
-    "fingerprint": "26adc8eca58b520e"
+    "content_hash": "04862c5b30a387ab",
+    "source_code": null
   },
   "G7-L26": {
     "tier": "catalog",
@@ -868,7 +955,9 @@
     "type_counts": {
       "guide": 1,
       "single": 13
-    }
+    },
+    "content_hash": "d7c74c4293f2ec2d",
+    "source_code": null
   },
   "G7-L28": {
     "tier": "dev7",
@@ -883,7 +972,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "c606d313b91d51c2"
+    "content_hash": "294a8757ede0a2a6",
+    "source_code": null
   },
   "G7-L29": {
     "tier": "dev7",
@@ -896,7 +986,8 @@
       "single": 24,
       "self_check": 1
     },
-    "fingerprint": "86bf43cc4bea96e1"
+    "content_hash": "0b07dff9291ec862",
+    "source_code": null
   },
   "G7-L3": {
     "tier": "catalog",
@@ -905,7 +996,9 @@
     "type_counts": {
       "guide": 1,
       "single": 5
-    }
+    },
+    "content_hash": "47609b2b01e1d4ce",
+    "source_code": null
   },
   "G7-L30": {
     "tier": "dev7",
@@ -919,7 +1012,8 @@
       "passage": 2,
       "self_check": 1
     },
-    "fingerprint": "62718265783f8a03"
+    "content_hash": "da8ff59a794678f3",
+    "source_code": null
   },
   "G7-L4": {
     "tier": "catalog",
@@ -929,7 +1023,9 @@
       "guide": 1,
       "single": 3,
       "free_text": 2
-    }
+    },
+    "content_hash": "915e664f125c00f8",
+    "source_code": null
   },
   "G7-L5": {
     "tier": "catalog",
@@ -938,7 +1034,9 @@
     "type_counts": {
       "guide": 2,
       "free_text": 3
-    }
+    },
+    "content_hash": "e1f5938a3f47534b",
+    "source_code": null
   },
   "G7-L8": {
     "tier": "catalog",
@@ -948,7 +1046,8 @@
       "guide": 5,
       "free_text": 2
     },
-    "fingerprint": "9495c0d652534395"
+    "content_hash": "be8da481d8682209",
+    "source_code": null
   },
   "G7-L9": {
     "tier": "test15",
@@ -958,7 +1057,8 @@
       "guide": 9,
       "free_text": 2
     },
-    "fingerprint": "ea1428e765ae472a"
+    "content_hash": "8c22f157d0fb2076",
+    "source_code": null
   },
   "G8-L1": {
     "tier": "catalog",
@@ -969,7 +1069,8 @@
       "single": 2,
       "free_text": 1
     },
-    "fingerprint": "93d50f285f741451"
+    "content_hash": "64085081f28022bd",
+    "source_code": null
   },
   "G8-L11": {
     "tier": "catalog",
@@ -980,7 +1081,8 @@
       "passage": 1,
       "free_text": 3
     },
-    "fingerprint": "5188650f0a43365d"
+    "content_hash": "4e36ecd7481cd153",
+    "source_code": "G8-L14"
   },
   "G8-L12": {
     "tier": "catalog",
@@ -992,7 +1094,8 @@
       "figure": 1,
       "self_check": 1
     },
-    "fingerprint": "db4eb04d5865c98b"
+    "content_hash": "c218cc295b0dd1ea",
+    "source_code": null
   },
   "G8-L13": {
     "tier": "catalog",
@@ -1005,7 +1108,8 @@
       "figure": 1,
       "fill_table": 1
     },
-    "fingerprint": "d294d3c27f7de3a0"
+    "content_hash": "01a2eba5f9db73a8",
+    "source_code": "G8-L17"
   },
   "G8-L14": {
     "tier": "catalog",
@@ -1018,7 +1122,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "7ba53ece7ed5a105"
+    "content_hash": "54a7e9d8801d9c21",
+    "source_code": "G8-L18"
   },
   "G8-L15": {
     "tier": "catalog",
@@ -1028,7 +1133,9 @@
       "guide": 11,
       "passage": 5,
       "multi": 2
-    }
+    },
+    "content_hash": "71f975a6a4fdad75",
+    "source_code": "G8-L19"
   },
   "G8-L16": {
     "tier": "catalog",
@@ -1040,7 +1147,8 @@
       "passage": 2,
       "self_check": 1
     },
-    "fingerprint": "fe1fc771dbb4941e"
+    "content_hash": "c23df9a49c02d00c",
+    "source_code": null
   },
   "G8-L17": {
     "tier": "catalog",
@@ -1053,7 +1161,8 @@
       "figure": 1,
       "fill_table": 1
     },
-    "fingerprint": "d294d3c27f7de3a0"
+    "content_hash": "01a2eba5f9db73a8",
+    "source_code": null
   },
   "G8-L18": {
     "tier": "catalog",
@@ -1066,7 +1175,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "7ba53ece7ed5a105"
+    "content_hash": "54a7e9d8801d9c21",
+    "source_code": null
   },
   "G8-L19": {
     "tier": "catalog",
@@ -1076,7 +1186,9 @@
       "guide": 11,
       "passage": 5,
       "multi": 2
-    }
+    },
+    "content_hash": "71f975a6a4fdad75",
+    "source_code": null
   },
   "G8-L3": {
     "tier": "catalog",
@@ -1089,7 +1201,8 @@
       "single": 5,
       "figure": 1
     },
-    "fingerprint": "19354adcafb7d784"
+    "content_hash": "137d8ae3080598a6",
+    "source_code": null
   },
   "G8-L3b": {
     "tier": "test15",
@@ -1102,7 +1215,8 @@
       "passage": 1,
       "single": 1
     },
-    "fingerprint": "e3fdf7cc14521ba9"
+    "content_hash": "d3b6c6c1185dc546",
+    "source_code": null
   },
   "G8-L4": {
     "tier": "catalog",
@@ -1113,7 +1227,8 @@
       "free_text": 4,
       "passage": 4
     },
-    "fingerprint": "2197cdb4b7ae670f"
+    "content_hash": "5f854259dadc5068",
+    "source_code": null
   },
   "G8-L5": {
     "tier": "catalog",
@@ -1125,7 +1240,8 @@
       "passage": 2,
       "single": 3
     },
-    "fingerprint": "3a9cb17f982b8499"
+    "content_hash": "2fe31c7ba849bdf8",
+    "source_code": null
   },
   "G8-L6": {
     "tier": "catalog",
@@ -1136,7 +1252,8 @@
       "free_text": 8,
       "passage": 2
     },
-    "fingerprint": "d11909f052012bd1"
+    "content_hash": "ea95a14e36b1d1eb",
+    "source_code": null
   },
   "G8-L6b": {
     "tier": "test15",
@@ -1146,7 +1263,9 @@
       "guide": 23,
       "free_text": 5,
       "passage": 3
-    }
+    },
+    "content_hash": "832cc861dc5c7352",
+    "source_code": null
   },
   "G8-L7": {
     "tier": "catalog",
@@ -1160,7 +1279,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "61333f17c329973f"
+    "content_hash": "c9004dddce1e3192",
+    "source_code": null
   },
   "G8-L8": {
     "tier": "catalog",
@@ -1172,7 +1292,8 @@
       "passage": 3,
       "figure": 1
     },
-    "fingerprint": "4037bbb237863c25"
+    "content_hash": "d44cdc33f32f8250",
+    "source_code": null
   },
   "G8-L9": {
     "tier": "catalog",
@@ -1183,7 +1304,8 @@
       "figure": 1,
       "self_check": 1
     },
-    "fingerprint": "3d83182c9eb55915"
+    "content_hash": "6ee228e8abf732b1",
+    "source_code": null
   },
   "G8-L9a": {
     "tier": "catalog",
@@ -1194,7 +1316,8 @@
       "figure": 2,
       "self_check": 1
     },
-    "fingerprint": "1c0187eee2eac0cd"
+    "content_hash": "6ee228e8abf732b1",
+    "source_code": null
   },
   "G9-L1": {
     "tier": "catalog",
@@ -1204,7 +1327,8 @@
       "guide": 5,
       "free_text": 2
     },
-    "fingerprint": "b08a04080291b04e"
+    "content_hash": "ccb7343fd3ab6fdf",
+    "source_code": null
   },
   "G9-L11": {
     "tier": "catalog",
@@ -1219,7 +1343,8 @@
       "fill_table": 1,
       "self_check": 1
     },
-    "fingerprint": "e50027aaa61beb3b"
+    "content_hash": "0b279eac9fdc06a8",
+    "source_code": null
   },
   "G9-L12": {
     "tier": "catalog",
@@ -1231,7 +1356,8 @@
       "multi": 2,
       "self_check": 1
     },
-    "fingerprint": "caf9232ef0f2f0a6"
+    "content_hash": "d386d7a117a98907",
+    "source_code": null
   },
   "G9-L13": {
     "tier": "catalog",
@@ -1243,7 +1369,8 @@
       "figure": 2,
       "self_check": 1
     },
-    "fingerprint": "4710599614f95359"
+    "content_hash": "291533a9bf13c002",
+    "source_code": null
   },
   "G9-L14": {
     "tier": "catalog",
@@ -1256,7 +1383,8 @@
       "free_text": 3,
       "self_check": 1
     },
-    "fingerprint": "1217a6c98f8c93f9"
+    "content_hash": "e9ab1bd4dcdacc65",
+    "source_code": null
   },
   "G9-L15": {
     "tier": "catalog",
@@ -1267,7 +1395,8 @@
       "single": 3,
       "free_text": 1
     },
-    "fingerprint": "4b2fc6ee9dae6506"
+    "content_hash": "c9b8848d710fd81b",
+    "source_code": null
   },
   "G9-L17": {
     "tier": "catalog",
@@ -1279,7 +1408,8 @@
       "single": 2,
       "free_text": 1
     },
-    "fingerprint": "08b233eb82e24a31"
+    "content_hash": "13a5f9945d6d453f",
+    "source_code": null
   },
   "G9-L2": {
     "tier": "catalog",
@@ -1289,7 +1419,8 @@
       "guide": 2,
       "free_text": 13
     },
-    "fingerprint": "5a3562fe3ba8db74"
+    "content_hash": "12f5f321a49ba135",
+    "source_code": null
   },
   "G9-L3": {
     "tier": "catalog",
@@ -1298,7 +1429,9 @@
     "type_counts": {
       "guide": 1,
       "single": 4
-    }
+    },
+    "content_hash": "7ba9f6551cdff00e",
+    "source_code": null
   },
   "G9-L4": {
     "tier": "catalog",
@@ -1307,7 +1440,9 @@
     "type_counts": {
       "guide": 1,
       "single": 4
-    }
+    },
+    "content_hash": "54df76d447a5cb1b",
+    "source_code": null
   },
   "G9-L5": {
     "tier": "catalog",
@@ -1316,7 +1451,8 @@
     "type_counts": {
       "guide": 8
     },
-    "fingerprint": "8cb47c7549f6f9e8"
+    "content_hash": "5957ea2d91c1a8b1",
+    "source_code": null
   },
   "G9-L6": {
     "tier": "catalog",
@@ -1326,7 +1462,8 @@
       "guide": 3,
       "free_text": 5
     },
-    "fingerprint": "bfc9dda607fbd5de"
+    "content_hash": "0b913a933fc41bd5",
+    "source_code": null
   },
   "G9-L9": {
     "tier": "test15",
@@ -1338,7 +1475,8 @@
       "free_text": 8,
       "figure": 1
     },
-    "fingerprint": "92d1f0dbd545d0ab"
+    "content_hash": "7629c121ac340d4c",
+    "source_code": null
   },
   "文-L1": {
     "tier": "catalog",
@@ -1349,7 +1487,8 @@
       "free_text": 3,
       "passage": 1
     },
-    "fingerprint": "825f29011f16161b"
+    "content_hash": "8281026ce7492ee5",
+    "source_code": null
   },
   "文-L2": {
     "tier": "catalog",
@@ -1361,6 +1500,7 @@
       "passage": 3,
       "single": 2
     },
-    "fingerprint": "d3bbe9dce3cb74e3"
+    "content_hash": "885971d22a42eb63",
+    "source_code": null
   }
 }

--- a/backend/data/curriculum_qa/spotlight_regression_baseline.json
+++ b/backend/data/curriculum_qa/spotlight_regression_baseline.json
@@ -12,6 +12,7 @@
       "self_check": 1
     },
     "content_hash": "6d1c5a87c254e647",
+    "schema_hash": "7b76824c540363f0",
     "source_code": null
   },
   "G4-L11": {
@@ -26,6 +27,7 @@
       "figure": 2
     },
     "content_hash": "226452fb1bc9486d",
+    "schema_hash": "13cdaba252daf74e",
     "source_code": null
   },
   "G4-L13": {
@@ -39,6 +41,7 @@
       "passage": 3
     },
     "content_hash": "cc0e361531ffdbe5",
+    "schema_hash": "2330d6a4e348c1fa",
     "source_code": null
   },
   "G4-L15": {
@@ -51,6 +54,7 @@
       "passage": 1
     },
     "content_hash": "d213ee78c8b66e0e",
+    "schema_hash": "a809d66f0b9c7139",
     "source_code": null
   },
   "G4-L16": {
@@ -64,6 +68,7 @@
       "passage": 1
     },
     "content_hash": "8f9193e1ed5a7788",
+    "schema_hash": "a86d7353caf2c842",
     "source_code": null
   },
   "G4-L18": {
@@ -74,6 +79,7 @@
       "guide": 20
     },
     "content_hash": "fc53c09d8f92cd03",
+    "schema_hash": "4794a6773f561da6",
     "source_code": null
   },
   "G4-L19": {
@@ -87,6 +93,7 @@
       "single": 5
     },
     "content_hash": "ecd218705342e64c",
+    "schema_hash": "2ff9244242c9599d",
     "source_code": null
   },
   "G4-L2": {
@@ -100,6 +107,7 @@
       "passage": 1
     },
     "content_hash": "64083bb7bd82b880",
+    "schema_hash": "659c71a5766a8f55",
     "source_code": null
   },
   "G4-L20": {
@@ -111,6 +119,7 @@
       "single": 5
     },
     "content_hash": "f809479cd99bc3a1",
+    "schema_hash": "6c712f42129da91e",
     "source_code": "G4-L20"
   },
   "G4-L23": {
@@ -123,6 +132,7 @@
       "free_text": 4
     },
     "content_hash": "240f659c1a892d59",
+    "schema_hash": "5ce6388f1ff0f700",
     "source_code": null
   },
   "G4-L24": {
@@ -135,6 +145,7 @@
       "multi": 6
     },
     "content_hash": "3f700f9452bb99f0",
+    "schema_hash": "d3487dd3fbee9096",
     "source_code": null
   },
   "G4-L25": {
@@ -147,6 +158,7 @@
       "free_text": 3
     },
     "content_hash": "9233bfc5b60a67d5",
+    "schema_hash": "6ba89783b480a6d8",
     "source_code": null
   },
   "G4-L26": {
@@ -159,6 +171,7 @@
       "free_text": 3
     },
     "content_hash": "b4ab82c8ace20ab7",
+    "schema_hash": "5f30f3661faa6fdc",
     "source_code": null
   },
   "G4-L27": {
@@ -173,6 +186,7 @@
       "multi": 1
     },
     "content_hash": "e6cc69ed4c16a068",
+    "schema_hash": "d5113a9a56825611",
     "source_code": null
   },
   "G4-L3": {
@@ -186,6 +200,7 @@
       "passage": 2
     },
     "content_hash": "9a8396ab230b780c",
+    "schema_hash": "e397d32a4170ba38",
     "source_code": null
   },
   "G4-L4": {
@@ -199,6 +214,7 @@
       "guide": 1
     },
     "content_hash": "3d9b2ada9561d98c",
+    "schema_hash": "d73c8f056bbb603d",
     "source_code": null
   },
   "G4-L5": {
@@ -209,6 +225,7 @@
       "guide": 1
     },
     "content_hash": "ce344d1027a19d83",
+    "schema_hash": "b61af29e8792d1c8",
     "source_code": null
   },
   "G4-L6": {
@@ -221,6 +238,7 @@
       "passage": 1
     },
     "content_hash": "e8e4971b9e59e5c1",
+    "schema_hash": "f873cbb089662a71",
     "source_code": null
   },
   "G4-L7": {
@@ -233,6 +251,7 @@
       "single": 1
     },
     "content_hash": "8ff81fb11783256d",
+    "schema_hash": "b93dea39db69ebf4",
     "source_code": null
   },
   "G4-L8": {
@@ -244,6 +263,7 @@
       "free_text": 4
     },
     "content_hash": "e280bff90a8eb0a4",
+    "schema_hash": "d70cae1def8ba4d6",
     "source_code": null
   },
   "G4-L9": {
@@ -256,6 +276,7 @@
       "passage": 1
     },
     "content_hash": "a6f5c0bcb99a6868",
+    "schema_hash": "9d504d547e1eacd8",
     "source_code": null
   },
   "G5-L10": {
@@ -268,6 +289,7 @@
       "single": 3
     },
     "content_hash": "cd097710c03fb192",
+    "schema_hash": "1e558aab1f6e42e3",
     "source_code": null
   },
   "G5-L12": {
@@ -279,6 +301,7 @@
       "single": 8
     },
     "content_hash": "02011ab61dd67a4c",
+    "schema_hash": "1386ce3bd139dcab",
     "source_code": null
   },
   "G5-L13": {
@@ -291,6 +314,7 @@
       "passage": 1
     },
     "content_hash": "1e16a7ef6888ff2d",
+    "schema_hash": "5a54c3106ac6066e",
     "source_code": null
   },
   "G5-L14": {
@@ -304,6 +328,7 @@
       "passage": 1
     },
     "content_hash": "edf525bf1ab0b4fe",
+    "schema_hash": "0a8fe39a4e40651d",
     "source_code": "G5-L14"
   },
   "G5-L16": {
@@ -315,6 +340,7 @@
       "fill_table": 3
     },
     "content_hash": "d60121be0f8f0c1b",
+    "schema_hash": "7b2fb458bd88a2d1",
     "source_code": "G5-L16"
   },
   "G5-L17": {
@@ -326,6 +352,7 @@
       "single": 10
     },
     "content_hash": "ee61440336e8e5b0",
+    "schema_hash": "f2779c13588f3826",
     "source_code": null
   },
   "G5-L18": {
@@ -340,6 +367,7 @@
       "self_check": 1
     },
     "content_hash": "c93a88d8bcca1a0b",
+    "schema_hash": "60510e6ddb0113df",
     "source_code": null
   },
   "G5-L2": {
@@ -351,6 +379,7 @@
       "free_text": 30
     },
     "content_hash": "76ee97e14a45733c",
+    "schema_hash": "bb7202e8b824147e",
     "source_code": null
   },
   "G5-L20": {
@@ -363,6 +392,7 @@
       "passage": 1
     },
     "content_hash": "990f1062131ab1b1",
+    "schema_hash": "1e146d26a5523a2a",
     "source_code": null
   },
   "G5-L21": {
@@ -374,6 +404,7 @@
       "free_text": 4
     },
     "content_hash": "8a2d17dab6325d42",
+    "schema_hash": "0c9efc488c87839a",
     "source_code": null
   },
   "G5-L22": {
@@ -386,6 +417,7 @@
       "figure": 2
     },
     "content_hash": "127678f36541ff70",
+    "schema_hash": "2046688dd3d9104c",
     "source_code": null
   },
   "G5-L23": {
@@ -399,6 +431,7 @@
       "self_check": 1
     },
     "content_hash": "b06360558e7ca0bb",
+    "schema_hash": "5fb295305a2b3722",
     "source_code": null
   },
   "G5-L24": {
@@ -411,6 +444,7 @@
       "free_text": 3
     },
     "content_hash": "8f54ccd52b7ae0a4",
+    "schema_hash": "d9ec0557ef0904bd",
     "source_code": null
   },
   "G5-L26": {
@@ -424,6 +458,7 @@
       "single": 4
     },
     "content_hash": "191a4b3bb90254a0",
+    "schema_hash": "8e9ae0661c3ad52f",
     "source_code": null
   },
   "G5-L27": {
@@ -436,6 +471,7 @@
       "figure": 1
     },
     "content_hash": "fa2ea46ef58d1d74",
+    "schema_hash": "11d22ce874cac3cc",
     "source_code": null
   },
   "G5-L3": {
@@ -449,6 +485,7 @@
       "passage": 1
     },
     "content_hash": "175f25258267eb15",
+    "schema_hash": "8075bf3ed384a72d",
     "source_code": null
   },
   "G5-L4": {
@@ -461,6 +498,7 @@
       "self_check": 1
     },
     "content_hash": "0d9fe2142fc472d2",
+    "schema_hash": "0e72cb7b7d30de59",
     "source_code": null
   },
   "G5-L5": {
@@ -472,6 +510,7 @@
       "free_text": 6
     },
     "content_hash": "e82a11914afe9ece",
+    "schema_hash": "961646a210642eeb",
     "source_code": null
   },
   "G5-L6": {
@@ -483,6 +522,7 @@
       "free_text": 11
     },
     "content_hash": "425359d51864e3e1",
+    "schema_hash": "84864e0b9c51af12",
     "source_code": null
   },
   "G5-L7": {
@@ -495,6 +535,7 @@
       "free_text": 2
     },
     "content_hash": "7d037e4e40fec837",
+    "schema_hash": "56e8c23d199605ab",
     "source_code": null
   },
   "G5-L8": {
@@ -507,6 +548,7 @@
       "match": 2
     },
     "content_hash": "3afa466d4b07a984",
+    "schema_hash": "4c6b77a7fe8ae3c6",
     "source_code": null
   },
   "G5-L9": {
@@ -519,6 +561,7 @@
       "figure": 1
     },
     "content_hash": "96a934ce887799c8",
+    "schema_hash": "0017e94759cb60d0",
     "source_code": null
   },
   "G6-L10": {
@@ -530,6 +573,7 @@
       "free_text": 6
     },
     "content_hash": "5b527b4582538651",
+    "schema_hash": "1131ed5bdd5af9c5",
     "source_code": null
   },
   "G6-L11": {
@@ -541,6 +585,7 @@
       "free_text": 18
     },
     "content_hash": "42f3956efa95043b",
+    "schema_hash": "65502b4a820744d2",
     "source_code": null
   },
   "G6-L13": {
@@ -552,6 +597,7 @@
       "free_text": 6
     },
     "content_hash": "22c05fb54a999176",
+    "schema_hash": "fe2cb5b41ec8af10",
     "source_code": null
   },
   "G6-L14": {
@@ -564,6 +610,7 @@
       "figure": 1
     },
     "content_hash": "8bbba2e127b6fc75",
+    "schema_hash": "e2e93bef5e76be10",
     "source_code": null
   },
   "G6-L15": {
@@ -576,6 +623,7 @@
       "single": 8
     },
     "content_hash": "d3ebaa59723e9dc6",
+    "schema_hash": "ac0f80773450d61d",
     "source_code": null
   },
   "G6-L17": {
@@ -588,6 +636,7 @@
       "free_text": 1
     },
     "content_hash": "65ee9a95121d029c",
+    "schema_hash": "7b57f7fcb8ecd00f",
     "source_code": null
   },
   "G6-L18": {
@@ -599,6 +648,7 @@
       "free_text": 2
     },
     "content_hash": "3b673055c9e84ef3",
+    "schema_hash": "398f2a859042cff8",
     "source_code": null
   },
   "G6-L2": {
@@ -610,6 +660,7 @@
       "single": 4
     },
     "content_hash": "41ed27ae11e2d90e",
+    "schema_hash": "d95f46ab6d666649",
     "source_code": "G6-L2"
   },
   "G6-L20": {
@@ -622,6 +673,7 @@
       "figure": 1
     },
     "content_hash": "9e0375973b768d2a",
+    "schema_hash": "8ad3d3e1d77650c2",
     "source_code": null
   },
   "G6-L22": {
@@ -636,6 +688,7 @@
       "fill_table": 1
     },
     "content_hash": "ab991697e6b30f9e",
+    "schema_hash": "94c5172e97f9a35a",
     "source_code": null
   },
   "G6-L23": {
@@ -651,6 +704,7 @@
       "self_check": 1
     },
     "content_hash": "63062e0ace581952",
+    "schema_hash": "a4d159f5d218287c",
     "source_code": null
   },
   "G6-L24": {
@@ -664,6 +718,7 @@
       "self_check": 1
     },
     "content_hash": "0dadb6ff3544d9a4",
+    "schema_hash": "7ca7a150889fdf68",
     "source_code": null
   },
   "G6-L25": {
@@ -677,6 +732,7 @@
       "self_check": 1
     },
     "content_hash": "4805058ed16b933e",
+    "schema_hash": "7a05f8d17ef8fc9a",
     "source_code": null
   },
   "G6-L3": {
@@ -690,6 +746,7 @@
       "free_text": 2
     },
     "content_hash": "494347a15fe2aa45",
+    "schema_hash": "396b95361459957c",
     "source_code": null
   },
   "G6-L4": {
@@ -701,6 +758,7 @@
       "free_text": 2
     },
     "content_hash": "3e98a7f48cdc1f2a",
+    "schema_hash": "8cd6e090bee26dfe",
     "source_code": null
   },
   "G6-L5": {
@@ -712,6 +770,7 @@
       "free_text": 6
     },
     "content_hash": "701a16a5813a02ce",
+    "schema_hash": "bbc611d5f52a1407",
     "source_code": null
   },
   "G6-L6": {
@@ -724,6 +783,7 @@
       "passage": 1
     },
     "content_hash": "13ecff4f2d27fb4f",
+    "schema_hash": "83767bc9e4a0beb2",
     "source_code": null
   },
   "G6-L7": {
@@ -737,6 +797,7 @@
       "passage": 6
     },
     "content_hash": "4dcb6fa95eb720a7",
+    "schema_hash": "b93d607324ed0cf2",
     "source_code": null
   },
   "G6-L8": {
@@ -748,6 +809,7 @@
       "free_text": 17
     },
     "content_hash": "23ce3b52f4a4d7d5",
+    "schema_hash": "e4195361377b6a1f",
     "source_code": null
   },
   "G6-L9": {
@@ -759,6 +821,7 @@
       "free_text": 2
     },
     "content_hash": "abe964599e475ca8",
+    "schema_hash": "e21d7829a5a659c6",
     "source_code": null
   },
   "G7-L1": {
@@ -771,6 +834,7 @@
       "free_text": 3
     },
     "content_hash": "352ae89e1ca50da3",
+    "schema_hash": "e4a4e58241fdfd57",
     "source_code": null
   },
   "G7-L10": {
@@ -786,6 +850,7 @@
       "self_check": 1
     },
     "content_hash": "3427bab625d70a9f",
+    "schema_hash": "6f7c53b0a4cb843e",
     "source_code": null
   },
   "G7-L11": {
@@ -801,6 +866,7 @@
       "self_check": 1
     },
     "content_hash": "5a18352d436b19c9",
+    "schema_hash": "d8be39fef08f2fb5",
     "source_code": null
   },
   "G7-L12": {
@@ -815,6 +881,7 @@
       "self_check": 1
     },
     "content_hash": "2f1f5dcd488c3511",
+    "schema_hash": "2b2dd669cfc1d43c",
     "source_code": null
   },
   "G7-L13": {
@@ -826,6 +893,7 @@
       "free_text": 2
     },
     "content_hash": "5c61e38036816a30",
+    "schema_hash": "79633f4b1057c572",
     "source_code": null
   },
   "G7-L14": {
@@ -838,6 +906,7 @@
       "passage": 2
     },
     "content_hash": "3dc221b3d52067c3",
+    "schema_hash": "1c58b7d442d7e28e",
     "source_code": null
   },
   "G7-L16": {
@@ -849,6 +918,7 @@
       "free_text": 6
     },
     "content_hash": "c36aed2ac01e7558",
+    "schema_hash": "9db316e5e16fc652",
     "source_code": null
   },
   "G7-L17": {
@@ -860,6 +930,7 @@
       "free_text": 2
     },
     "content_hash": "101c351670364f2f",
+    "schema_hash": "355dfa43d8dacdd3",
     "source_code": null
   },
   "G7-L18": {
@@ -872,6 +943,7 @@
       "free_text": 3
     },
     "content_hash": "cee2e86ccb246847",
+    "schema_hash": "3d99d3fea551fd0a",
     "source_code": null
   },
   "G7-L19": {
@@ -883,6 +955,7 @@
       "passage": 1
     },
     "content_hash": "f63c773089541206",
+    "schema_hash": "51e1ebf255a25c64",
     "source_code": null
   },
   "G7-L2": {
@@ -895,6 +968,7 @@
       "free_text": 1
     },
     "content_hash": "9073c88e1bb38c47",
+    "schema_hash": "967406bb14d9f75b",
     "source_code": null
   },
   "G7-L21": {
@@ -906,6 +980,7 @@
       "free_text": 3
     },
     "content_hash": "0c68202e7b97f2fc",
+    "schema_hash": "caef322482ae8613",
     "source_code": null
   },
   "G7-L23": {
@@ -920,6 +995,7 @@
       "single": 16
     },
     "content_hash": "a6c86ae87eaa7e56",
+    "schema_hash": "aa35ee95aeb7c252",
     "source_code": null
   },
   "G7-L24": {
@@ -933,6 +1009,7 @@
       "single": 8
     },
     "content_hash": "d27ce1b31d7453b4",
+    "schema_hash": "e2f7363531f336a7",
     "source_code": null
   },
   "G7-L25": {
@@ -945,6 +1022,7 @@
       "passage": 1
     },
     "content_hash": "04862c5b30a387ab",
+    "schema_hash": "179f3cf3bd49a218",
     "source_code": null
   },
   "G7-L26": {
@@ -956,6 +1034,7 @@
       "single": 13
     },
     "content_hash": "d7c74c4293f2ec2d",
+    "schema_hash": "f1590b58d53932cd",
     "source_code": null
   },
   "G7-L28": {
@@ -972,6 +1051,7 @@
       "self_check": 1
     },
     "content_hash": "294a8757ede0a2a6",
+    "schema_hash": "c9a609fb71aa5517",
     "source_code": null
   },
   "G7-L29": {
@@ -986,6 +1066,7 @@
       "self_check": 1
     },
     "content_hash": "0b07dff9291ec862",
+    "schema_hash": "9c899e667a2411c7",
     "source_code": null
   },
   "G7-L3": {
@@ -997,6 +1078,7 @@
       "single": 5
     },
     "content_hash": "47609b2b01e1d4ce",
+    "schema_hash": "44219ecce3769a3b",
     "source_code": null
   },
   "G7-L30": {
@@ -1012,6 +1094,7 @@
       "self_check": 1
     },
     "content_hash": "da8ff59a794678f3",
+    "schema_hash": "77b649971fdf35d7",
     "source_code": null
   },
   "G7-L4": {
@@ -1024,6 +1107,7 @@
       "free_text": 2
     },
     "content_hash": "915e664f125c00f8",
+    "schema_hash": "a87be6af2fc19a56",
     "source_code": null
   },
   "G7-L5": {
@@ -1035,6 +1119,7 @@
       "free_text": 3
     },
     "content_hash": "e1f5938a3f47534b",
+    "schema_hash": "40543283a9b20bee",
     "source_code": null
   },
   "G7-L8": {
@@ -1046,6 +1131,7 @@
       "free_text": 2
     },
     "content_hash": "be8da481d8682209",
+    "schema_hash": "1b797439c93e1be8",
     "source_code": null
   },
   "G7-L9": {
@@ -1057,6 +1143,7 @@
       "free_text": 2
     },
     "content_hash": "8c22f157d0fb2076",
+    "schema_hash": "1c34019c9e60da05",
     "source_code": null
   },
   "G8-L1": {
@@ -1069,6 +1156,7 @@
       "free_text": 1
     },
     "content_hash": "64085081f28022bd",
+    "schema_hash": "870715f21c8c3277",
     "source_code": null
   },
   "G8-L11": {
@@ -1081,6 +1169,7 @@
       "free_text": 3
     },
     "content_hash": "4e36ecd7481cd153",
+    "schema_hash": "47a3b71d3f4f04da",
     "source_code": "G8-L14"
   },
   "G8-L12": {
@@ -1094,6 +1183,7 @@
       "self_check": 1
     },
     "content_hash": "c218cc295b0dd1ea",
+    "schema_hash": "60e623e69599d7be",
     "source_code": null
   },
   "G8-L13": {
@@ -1108,6 +1198,7 @@
       "fill_table": 1
     },
     "content_hash": "01a2eba5f9db73a8",
+    "schema_hash": "785834c84fa3f8fc",
     "source_code": "G8-L17"
   },
   "G8-L14": {
@@ -1122,6 +1213,7 @@
       "self_check": 1
     },
     "content_hash": "54a7e9d8801d9c21",
+    "schema_hash": "949552126a1f98c8",
     "source_code": "G8-L18"
   },
   "G8-L15": {
@@ -1134,6 +1226,7 @@
       "multi": 2
     },
     "content_hash": "71f975a6a4fdad75",
+    "schema_hash": "775ae876f5d07232",
     "source_code": "G8-L19"
   },
   "G8-L16": {
@@ -1147,6 +1240,7 @@
       "self_check": 1
     },
     "content_hash": "c23df9a49c02d00c",
+    "schema_hash": "0e502892f98f81b8",
     "source_code": null
   },
   "G8-L17": {
@@ -1161,6 +1255,7 @@
       "fill_table": 1
     },
     "content_hash": "01a2eba5f9db73a8",
+    "schema_hash": "785834c84fa3f8fc",
     "source_code": null
   },
   "G8-L18": {
@@ -1175,6 +1270,7 @@
       "self_check": 1
     },
     "content_hash": "54a7e9d8801d9c21",
+    "schema_hash": "949552126a1f98c8",
     "source_code": null
   },
   "G8-L19": {
@@ -1187,6 +1283,7 @@
       "multi": 2
     },
     "content_hash": "71f975a6a4fdad75",
+    "schema_hash": "775ae876f5d07232",
     "source_code": null
   },
   "G8-L3": {
@@ -1201,6 +1298,7 @@
       "figure": 1
     },
     "content_hash": "137d8ae3080598a6",
+    "schema_hash": "93611a692e627ead",
     "source_code": null
   },
   "G8-L3b": {
@@ -1215,6 +1313,7 @@
       "single": 1
     },
     "content_hash": "d3b6c6c1185dc546",
+    "schema_hash": "8bc499f916554e62",
     "source_code": null
   },
   "G8-L4": {
@@ -1227,6 +1326,7 @@
       "passage": 4
     },
     "content_hash": "5f854259dadc5068",
+    "schema_hash": "5d9fe9812ed7f706",
     "source_code": null
   },
   "G8-L5": {
@@ -1240,6 +1340,7 @@
       "single": 3
     },
     "content_hash": "2fe31c7ba849bdf8",
+    "schema_hash": "198125656fbf982e",
     "source_code": null
   },
   "G8-L6": {
@@ -1252,6 +1353,7 @@
       "passage": 2
     },
     "content_hash": "ea95a14e36b1d1eb",
+    "schema_hash": "dbaf7b691f692dfa",
     "source_code": null
   },
   "G8-L6b": {
@@ -1264,6 +1366,7 @@
       "passage": 3
     },
     "content_hash": "832cc861dc5c7352",
+    "schema_hash": "23ad4e5ea55284c8",
     "source_code": null
   },
   "G8-L7": {
@@ -1279,6 +1382,7 @@
       "self_check": 1
     },
     "content_hash": "c9004dddce1e3192",
+    "schema_hash": "5bb59edaa93d3513",
     "source_code": null
   },
   "G8-L8": {
@@ -1292,6 +1396,7 @@
       "figure": 1
     },
     "content_hash": "d44cdc33f32f8250",
+    "schema_hash": "f61f0f07814d04c9",
     "source_code": null
   },
   "G8-L9": {
@@ -1304,6 +1409,7 @@
       "self_check": 1
     },
     "content_hash": "6ee228e8abf732b1",
+    "schema_hash": "0d2e3088f936f52e",
     "source_code": null
   },
   "G8-L9a": {
@@ -1316,6 +1422,7 @@
       "self_check": 1
     },
     "content_hash": "6ee228e8abf732b1",
+    "schema_hash": "752f0b870502c431",
     "source_code": null
   },
   "G9-L1": {
@@ -1327,6 +1434,7 @@
       "free_text": 2
     },
     "content_hash": "ccb7343fd3ab6fdf",
+    "schema_hash": "d8d38ede30c49aff",
     "source_code": null
   },
   "G9-L11": {
@@ -1343,6 +1451,7 @@
       "self_check": 1
     },
     "content_hash": "0b279eac9fdc06a8",
+    "schema_hash": "c4771df1931adb33",
     "source_code": null
   },
   "G9-L12": {
@@ -1356,6 +1465,7 @@
       "self_check": 1
     },
     "content_hash": "d386d7a117a98907",
+    "schema_hash": "2976ad87498594bf",
     "source_code": null
   },
   "G9-L13": {
@@ -1369,6 +1479,7 @@
       "self_check": 1
     },
     "content_hash": "291533a9bf13c002",
+    "schema_hash": "e45e078544d337d5",
     "source_code": null
   },
   "G9-L14": {
@@ -1383,6 +1494,7 @@
       "self_check": 1
     },
     "content_hash": "e9ab1bd4dcdacc65",
+    "schema_hash": "ca6c98acd604b6b6",
     "source_code": null
   },
   "G9-L15": {
@@ -1395,6 +1507,7 @@
       "free_text": 1
     },
     "content_hash": "c9b8848d710fd81b",
+    "schema_hash": "7b57f7fcb8ecd00f",
     "source_code": null
   },
   "G9-L17": {
@@ -1408,6 +1521,7 @@
       "free_text": 1
     },
     "content_hash": "13a5f9945d6d453f",
+    "schema_hash": "565c33748da951ad",
     "source_code": null
   },
   "G9-L2": {
@@ -1419,6 +1533,7 @@
       "free_text": 13
     },
     "content_hash": "12f5f321a49ba135",
+    "schema_hash": "fb1481922eae8876",
     "source_code": null
   },
   "G9-L3": {
@@ -1430,6 +1545,7 @@
       "single": 4
     },
     "content_hash": "7ba9f6551cdff00e",
+    "schema_hash": "844aee2f5a80852d",
     "source_code": null
   },
   "G9-L4": {
@@ -1441,6 +1557,7 @@
       "single": 4
     },
     "content_hash": "54df76d447a5cb1b",
+    "schema_hash": "e6344ac0f7d51282",
     "source_code": null
   },
   "G9-L5": {
@@ -1451,6 +1568,7 @@
       "guide": 8
     },
     "content_hash": "5957ea2d91c1a8b1",
+    "schema_hash": "91bca158b1e96f70",
     "source_code": null
   },
   "G9-L6": {
@@ -1462,6 +1580,7 @@
       "free_text": 5
     },
     "content_hash": "0b913a933fc41bd5",
+    "schema_hash": "611b1a262124fd5c",
     "source_code": null
   },
   "G9-L9": {
@@ -1475,6 +1594,7 @@
       "fill_table": 1
     },
     "content_hash": "7629c121ac340d4c",
+    "schema_hash": "7ab4ec343ccdddf6",
     "source_code": null
   },
   "文-L1": {
@@ -1487,6 +1607,7 @@
       "passage": 1
     },
     "content_hash": "8281026ce7492ee5",
+    "schema_hash": "a6d83dac698c33b9",
     "source_code": null
   },
   "文-L2": {
@@ -1500,6 +1621,7 @@
       "single": 2
     },
     "content_hash": "885971d22a42eb63",
+    "schema_hash": "ca568cb58f216060",
     "source_code": null
   }
 }

--- a/backend/data/lessons/spotlight/catalog/G5-L16.spotlight.yml
+++ b/backend/data/lessons/spotlight/catalog/G5-L16.spotlight.yml
@@ -7,10 +7,7 @@ spotlight:
     text: ◎小試身手：以「高砂棒球隊／能高團」為中心，提取相關上位概念。
   - type: guide
     text: 一、找出上位概念：請判斷文章中粗楷體文字的上位概念，並從右欄中選出正確答案，填在【    】裡
-  - type: figure
-    referent: table
-    asset: null
-    bind_paragraph: null
+  - type: fill_table
   - type: guide
     text: 二、練習提取上位概念：請閱讀以下段落，根據內容，填寫對應的上位概念。
   - type: guide
@@ -37,7 +34,4 @@ spotlight:
   - type: fill_table
   - type: guide
     text: 在閱讀聚光燈時，我們整理了部分的上位概念，接著我們要練習從內容那欄中整理的上位概念尋找對應的文章細節，來完成文章重點表。
-  - type: figure
-    referent: table
-    asset: null
-    bind_paragraph: null
+  - type: fill_table

--- a/backend/data/lessons/spotlight/test15/G9-SL9.spotlight.yml
+++ b/backend/data/lessons/spotlight/test15/G9-SL9.spotlight.yml
@@ -37,10 +37,7 @@ spotlight:
     prompt: (3)臺灣「鞍馬王子」李智凱參加2021年東京奧運鞍馬項目競賽，表3是D分組兩位裁判給各動作難度的平均給分，請問李智凱的D分是多少？在空格內填入答案（可以用計算器）。
   - type: guide
     text: 表3. D組某位裁判給李智凱的分數
-  - type: figure
-    referent: table
-    asset: fig1.png
-    bind_paragraph: 目標策略：圖表繪製與判讀——圖文表綜合判讀
+  - type: fill_table
   - type: guide
     text: 提示：
   - type: free_text

--- a/backend/data/lessons/spotlight/test15/gold_manifest.json
+++ b/backend/data/lessons/spotlight/test15/gold_manifest.json
@@ -455,7 +455,7 @@
       "strategy_type": "image_text",
       "block_count": 22,
       "type_histogram": {
-        "figure": 1,
+        "fill_table": 1,
         "free_text": 8,
         "guide": 11,
         "passage": 2
@@ -476,7 +476,7 @@
         "guide",
         "free_text",
         "guide",
-        "figure",
+        "fill_table",
         "guide",
         "free_text",
         "free_text",

--- a/scripts/spotlight_regression_check.py
+++ b/scripts/spotlight_regression_check.py
@@ -51,7 +51,7 @@ def tier(code: str) -> str:
 
 
 def _block_text(blocks: list) -> str:
-    """All readable text across blocks (for the content fingerprint)."""
+    """All readable text across blocks (for the TEXT fingerprint)."""
     out = []
     for b in blocks:
         for k in ("text", "prompt", "instruction", "heading", "title"):
@@ -64,6 +64,24 @@ def _block_text(blocks: list) -> str:
         for opt in b.get("options", []) or []:
             out.append(opt if isinstance(opt, str) else str(opt.get("text", "") if isinstance(opt, dict) else ""))
     return "\n".join(out)
+
+
+def _block_schema(blocks: list) -> str:
+    """Canonical SHAPE of the block sequence (for the SCHEMA fingerprint, per
+    cursor review): catches type-only / asset / referent / answer / option-count
+    / order changes that text_hash misses (e.g. figure→fill_table, asset rebind,
+    answer flipped). Records per block: type, referent, asset, #options, has-answer."""
+    parts = []
+    for b in blocks:
+        parts.append("|".join([
+            str(b.get("type")),
+            str(b.get("referent") or ""),
+            str(b.get("asset") or ""),
+            str(len(b.get("options") or [])),
+            "A" if (b.get("answer") not in (None, "", [])) else "",
+            str(len(b.get("paragraphs") or [])),
+        ]))
+    return "\n".join(parts)
 
 
 def snapshot_one(code: str) -> dict | None:
@@ -84,6 +102,7 @@ def snapshot_one(code: str) -> dict | None:
         type_counts[t] = type_counts.get(t, 0) + 1
     n_q = sum(c for t, c in type_counts.items() if t in Q_TYPES)
     content_hash = hashlib.sha256(_block_text(blocks).encode("utf-8")).hexdigest()[:16]
+    schema_hash = hashlib.sha256(_block_schema(blocks).encode("utf-8")).hexdigest()[:16]
     n = normalize_manifest_code(code)
     try:
         src = get_spotlight_source_code(n, (get_lesson_by_code(code) or {}).get("title"))
@@ -95,6 +114,7 @@ def snapshot_one(code: str) -> dict | None:
         "n_questions": n_q,
         "type_counts": type_counts,
         "content_hash": content_hash,
+        "schema_hash": schema_hash,
         "source_code": normalize_manifest_code(src) if src else None,
     }
 
@@ -129,7 +149,7 @@ def check() -> int:
     baseline = load_baseline()
     regressions = []
     improvements = []
-    content_drifts = []  # 放錯課防線:內容指紋變了(改過要 rebaseline;沒改卻變=ripple/放錯課)
+    drifts = []  # 放錯課防線:內容/結構指紋變了(改過要 rebaseline 鎖;沒 rebaseline 卻變=ripple/放錯課→FAIL)
     for code, base in baseline.items():
         cur = snapshot_one(code)
         if cur is None:
@@ -151,9 +171,13 @@ def check() -> int:
         # 放錯課防線 (#2397, deterministic): 源綁定漂移 = rebinding 到別課的檔 = 幾乎必為 bug
         if base.get("source_code") != cur.get("source_code"):
             regressions.append((code, f"源綁定漂移 source {base.get('source_code')}→{cur.get('source_code')} (rebinding/放錯課風險)"))
-        # 內容指紋變:結構沒退步但內容換了。改過該 rebaseline;沒改卻變 = 別課 ripple(石虎覆蓋蝴蝶蘭那種)
-        elif base.get("content_hash") and cur.get("content_hash") != base.get("content_hash"):
-            content_drifts.append((code, f"內容指紋 {base.get('content_hash')}→{cur.get('content_hash')}"))
+        else:
+            # 指紋漂移(content=文字 / schema=type/asset/referent/options/answer/順序)。
+            # 改過該 rebaseline 鎖;沒 rebaseline 卻漂移 = 別課 ripple/放錯課(石虎覆蓋蝴蝶蘭那種)→ 不准吞,計 FAIL
+            if base.get("content_hash") and cur.get("content_hash") != base.get("content_hash"):
+                drifts.append((code, f"內容(文字)指紋 {base.get('content_hash')}→{cur['content_hash']}"))
+            if base.get("schema_hash") and cur.get("schema_hash") != base.get("schema_hash"):
+                drifts.append((code, f"結構(schema)指紋 {base.get('schema_hash')}→{cur['schema_hash']} (type/asset/referent/options/answer/順序)"))
         if cur["n_blocks"] > base["n_blocks"] or cur["n_questions"] > base["n_questions"]:
             improvements.append((code, f"blocks {base['n_blocks']}→{cur['n_blocks']}, Q {base['n_questions']}→{cur['n_questions']}"))
     # lessons newly loading that weren't in baseline (new content) — informational
@@ -166,18 +190,18 @@ def check() -> int:
             print(f"   {c}: {d}")
     if new_codes:
         print(f"\n🆕 新增 {len(new_codes)} 課（baseline 沒有,--rebaseline-all 納入）: {new_codes[:15]}")
-    if content_drifts:
-        print(f"\n⚠️  內容指紋漂移 {len(content_drifts)} 課（改過→--rebaseline 鎖住;沒改卻漂移=別課 ripple/放錯課,要查!）:")
-        for c, d in content_drifts:
+    if drifts:
+        print(f"\n❌ 指紋漂移 {len(drifts)} 課 —— 內容/結構變了卻沒 rebaseline（改過→`--rebaseline <code>` 鎖;沒改卻漂移=別課 ripple/放錯課,要查!）:")
+        for c, d in drifts:
             print(f"   {c}: {d}")
     if regressions:
-        print(f"\n❌ REGRESSION {len(regressions)} 課 —— 有東西被修壞了:")
+        print(f"\n❌ REGRESSION {len(regressions)} 課 —— 結構/源綁定退步:")
         for c, d in regressions:
             print(f"   {c}: {d}")
+    if regressions or drifts:
         print("\nSPOTLIGHT_REGRESSION=FAIL")
         return 1
-    drift_note = f"（⚠️ {len(content_drifts)} 課內容指紋漂移待 review/rebaseline）" if content_drifts else ""
-    print(f"\n✅ 0 結構/源綁定 regression — 前面的課都沒被修壞 {drift_note}")
+    print("\n✅ 0 regression/漂移 — 結構+源綁定+內容+schema 四重指紋全鎖住,沒被修壞也沒放錯課")
     print("SPOTLIGHT_REGRESSION=PASS")
     return 0
 

--- a/scripts/spotlight_regression_check.py
+++ b/scripts/spotlight_regression_check.py
@@ -20,6 +20,7 @@ Workflow:
 Exit code 0 = PASS (no regressions), 1 = FAIL (regressions found).
 """
 import json
+import hashlib
 import sys
 from pathlib import Path
 
@@ -33,6 +34,8 @@ from app.services.spotlight_contract import (  # noqa: E402
 )
 from app.services.spotlight_v2_loader import load_spotlight_v2  # noqa: E402
 from app.services.lesson_code_normalization import normalize_manifest_code  # noqa: E402
+from app.services.content_mapping_registry import get_spotlight_source_code  # noqa: E402
+from app.services.lesson_loader import get_lesson_by_code  # noqa: E402
 
 BASELINE_PATH = REPO_ROOT / "backend" / "data" / "curriculum_qa" / "spotlight_regression_baseline.json"
 Q_TYPES = {"single", "multi", "free_text", "fill_table", "fill_blank", "sort", "match"}
@@ -47,8 +50,30 @@ def tier(code: str) -> str:
     return "catalog"
 
 
+def _block_text(blocks: list) -> str:
+    """All readable text across blocks (for the content fingerprint)."""
+    out = []
+    for b in blocks:
+        for k in ("text", "prompt", "instruction", "heading", "title"):
+            v = b.get(k)
+            if isinstance(v, str) and v.strip():
+                out.append(v.strip())
+        for p in b.get("paragraphs", []) or []:
+            if isinstance(p, str):
+                out.append(p.strip())
+        for opt in b.get("options", []) or []:
+            out.append(opt if isinstance(opt, str) else str(opt.get("text", "") if isinstance(opt, dict) else ""))
+    return "\n".join(out)
+
+
 def snapshot_one(code: str) -> dict | None:
-    """Current structural snapshot for a lesson, or None if no spotlight loads."""
+    """Structural + content + source-binding snapshot for a lesson (#2397).
+
+    content_hash + source_code make the ratchet catch the 放錯課/rebinding class
+    (deterministic): if a lesson's content silently changes topic (overwrite /
+    registry rebinding drift), the hash/source moves — even when block counts go
+    UP (the structural-only ratchet missed exactly this: 石虎 overwrote 蝴蝶蘭).
+    """
     sp = load_spotlight_v2(code)
     if not sp:
         return None
@@ -58,11 +83,19 @@ def snapshot_one(code: str) -> dict | None:
         t = b.get("type")
         type_counts[t] = type_counts.get(t, 0) + 1
     n_q = sum(c for t, c in type_counts.items() if t in Q_TYPES)
+    content_hash = hashlib.sha256(_block_text(blocks).encode("utf-8")).hexdigest()[:16]
+    n = normalize_manifest_code(code)
+    try:
+        src = get_spotlight_source_code(n, (get_lesson_by_code(code) or {}).get("title"))
+    except Exception:
+        src = None
     return {
         "tier": tier(code),
         "n_blocks": len(blocks),
         "n_questions": n_q,
         "type_counts": type_counts,
+        "content_hash": content_hash,
+        "source_code": normalize_manifest_code(src) if src else None,
     }
 
 
@@ -96,6 +129,7 @@ def check() -> int:
     baseline = load_baseline()
     regressions = []
     improvements = []
+    content_drifts = []  # 放錯課防線:內容指紋變了(改過要 rebaseline;沒改卻變=ripple/放錯課)
     for code, base in baseline.items():
         cur = snapshot_one(code)
         if cur is None:
@@ -114,6 +148,12 @@ def check() -> int:
                       and cur["type_counts"].get(t, 0) == 0]
         if lost_types and cur["n_questions"] <= base["n_questions"]:
             regressions.append((code, f"題型消失且題數未增: {lost_types}"))
+        # 放錯課防線 (#2397, deterministic): 源綁定漂移 = rebinding 到別課的檔 = 幾乎必為 bug
+        if base.get("source_code") != cur.get("source_code"):
+            regressions.append((code, f"源綁定漂移 source {base.get('source_code')}→{cur.get('source_code')} (rebinding/放錯課風險)"))
+        # 內容指紋變:結構沒退步但內容換了。改過該 rebaseline;沒改卻變 = 別課 ripple(石虎覆蓋蝴蝶蘭那種)
+        elif base.get("content_hash") and cur.get("content_hash") != base.get("content_hash"):
+            content_drifts.append((code, f"內容指紋 {base.get('content_hash')}→{cur.get('content_hash')}"))
         if cur["n_blocks"] > base["n_blocks"] or cur["n_questions"] > base["n_questions"]:
             improvements.append((code, f"blocks {base['n_blocks']}→{cur['n_blocks']}, Q {base['n_questions']}→{cur['n_questions']}"))
     # lessons newly loading that weren't in baseline (new content) — informational
@@ -126,13 +166,18 @@ def check() -> int:
             print(f"   {c}: {d}")
     if new_codes:
         print(f"\n🆕 新增 {len(new_codes)} 課（baseline 沒有,--rebaseline-all 納入）: {new_codes[:15]}")
+    if content_drifts:
+        print(f"\n⚠️  內容指紋漂移 {len(content_drifts)} 課（改過→--rebaseline 鎖住;沒改卻漂移=別課 ripple/放錯課,要查!）:")
+        for c, d in content_drifts:
+            print(f"   {c}: {d}")
     if regressions:
         print(f"\n❌ REGRESSION {len(regressions)} 課 —— 有東西被修壞了:")
         for c, d in regressions:
             print(f"   {c}: {d}")
         print("\nSPOTLIGHT_REGRESSION=FAIL")
         return 1
-    print("\n✅ 0 regression — 前面的課都沒被修壞")
+    drift_note = f"（⚠️ {len(content_drifts)} 課內容指紋漂移待 review/rebaseline）" if content_drifts else ""
+    print(f"\n✅ 0 結構/源綁定 regression — 前面的課都沒被修壞 {drift_note}")
     print("SPOTLIGHT_REGRESSION=PASS")
     return 0
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

部署剩餘已驗證的工作:
- **表格 fill_table**:G5-L16/G9-L9 的 figure(referent=table,render 不出)→ fill_table（指向重點表步驟,表格資料本就在那:story_structure_table 5/13 列）
- **ratchet 強化**(獨立 cursor review 後):content/schema/source drift 全 FAIL（放錯課不再被吞）+ schema_hash 抓 type-only 變動。四重決定性指紋,baseline 含此鎖 122 課

Related to #2397