### PR TITLE
fix(worksheet): 老師可下載 Word 版學習單 (Fixes #2422 · 教授 6/5 #15)

### DIFF
--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -308,13 +308,27 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                     type="button"
                     onClick={() => { void handleDownloadWorksheet(story.worksheetPdfUrl!, 'pdf'); }}
                     className="inline-flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-indigo-300 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1"
-                    aria-label="下載紙本學習單"
+                    aria-label="下載紙本學習單 PDF"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                     </svg>
-                    下載紙本學習單
+                    下載 PDF
                   </button>
+                  {/* #2422 教授 6/5 #15：Word + PDF 同時上架讓老師自選（docx 已上 GCS，先前被 PDF 分支吞掉拿不到）*/}
+                  {story.worksheetDocxUrl && (
+                    <button
+                      type="button"
+                      onClick={() => { void handleDownloadWorksheet(story.worksheetDocxUrl!, 'docx'); }}
+                      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-emerald-300 bg-emerald-50 hover:bg-emerald-100 text-emerald-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-1"
+                      aria-label="下載紙本學習單 Word"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                      下載 Word
+                    </button>
+                  )}
                 </>
               ) : story.worksheetDocxUrl ? (
                 <button


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 問題(逐課內容抽查時發現)
教授 6/5 #15 要「Word + PDF 同時上架讓老師自選」。實際:Intro.tsx 下載邏輯 `pdf ? PDF鈕 : docx鈕`(二選一),7 課都有 pdf → **docx 鈕永遠不顯示,老師拿不到 Word**。
驗證:`worksheets/{code}.pdf` + `.docx` GCS 全 200、API 兩 url 都回傳,純 UI 吞掉。

## 修
pdf 分支內,docx 存在時加綠色「下載 Word」鈕;PDF 下載鈕改標「下載 PDF」區分。

## 驗證
- tsc: Intro.tsx 0 error
- render-smoke: 13/13 passed
- /qa preview 截圖(PR preview 起來後補)

Fixes #2422

🤖 Generated with [Claude Code](https://claude.com/claude-code)