### PR TITLE
feat(testset): record.html 新增 mp3/wav 上傳途徑 + 返回測試集按鈕 (#2426)

### DIFF
--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -402,14 +402,26 @@
 </div>
 <script>
 /* ===== Tab switching ===== */
+function activatePane(id){
+  var btn=document.querySelector('.tab[data-pane="'+id+'"]');
+  var pane=document.getElementById(id);
+  if(!btn||!pane) return false;
+  document.querySelectorAll('.tab').forEach(function(b){b.classList.remove('active')});
+  document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
+  btn.classList.add('active');
+  pane.classList.add('active');
+  return true;
+}
 document.querySelectorAll('.tab').forEach(function(btn){
-  btn.addEventListener('click',function(){
-    document.querySelectorAll('.tab').forEach(function(b){b.classList.remove('active')});
-    document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
-    btn.classList.add('active');
-    document.getElementById(btn.dataset.pane).classList.add('active');
-  });
+  btn.addEventListener('click',function(){ activatePane(btn.dataset.pane); });
 });
+// 支援用 URL hash 直接開到指定分頁（例：record.html 返回時帶 #testset 回到「④ 測試集」）
+function activatePaneFromHash(){
+  var id=(location.hash||'').replace('#','');
+  if(id) activatePane(id);
+}
+activatePaneFromHash();
+window.addEventListener('hashchange',activatePaneFromHash);
 
 // ===== Arch animations =====
 function startTypingAnim() {

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -417,7 +417,8 @@ document.querySelectorAll('.tab').forEach(function(btn){
 });
 // 支援用 URL hash 直接開到指定分頁（例：record.html 返回時帶 #testset 回到「④ 測試集」）
 function activatePaneFromHash(){
-  var id=(location.hash||'').replace('#','');
+  // 淨化 hash（只留英數/底線/連字號）再進 querySelector，避免惡意/畸形 hash 拋 DOMException
+  var id=(location.hash||'').replace('#','').replace(/[^a-z0-9_-]/gi,'');
   if(id) activatePane(id);
 }
 activatePaneFromHash();

--- a/frontend/public/testset-7f3a91c4/index.html
+++ b/frontend/public/testset-7f3a91c4/index.html
@@ -18,9 +18,6 @@
   .btn-sec:hover{background:var(--chip)}
   .note{font-size:.82rem;color:var(--muted);margin-top:16px}
   .icon{font-size:2.5rem;margin-bottom:12px}
-  /* 從 record.html「返回測試集」帶 ?focus= 回來時，短暫高亮剛剛那一課 */
-  .focus-hl{box-shadow:0 0 0 3px var(--purple);animation:focusPulse 2.4s ease-out}
-  @keyframes focusPulse{0%{box-shadow:0 0 0 6px rgba(91,79,196,.55)}100%{box-shadow:0 0 0 3px rgba(91,79,196,0)}}
 </style>
 </head>
 <body>
@@ -59,24 +56,12 @@ async function loadLessons(){
     var h='';
     stories.forEach(function(s){
       var url='./record.html?lesson='+encodeURIComponent(s.id);
-      h+='<a id="lesson-'+esc(s.id)+'" class="btn-main" href="'+esc(url)+'">'+esc(s.title)+'<span style="display:block;font-size:.75rem;opacity:.7;font-weight:400">'+esc(s.id)+'</span></a>';
+      h+='<a class="btn-main" href="'+esc(url)+'">'+esc(s.title)+'<span style="display:block;font-size:.75rem;opacity:.7;font-weight:400">'+esc(s.id)+'</span></a>';
     });
     el.innerHTML=h;
-    focusLesson();  // 若帶 ?focus= 回來，捲動並高亮該課
   }catch(e){
     el.innerHTML='<p style="color:#dc2626;font-size:.9rem">課文清單載入失敗：'+esc(e.message)+'<br><button onclick="loadLessons()" style="margin-top:8px;padding:6px 14px;cursor:pointer;border:1px solid #dc2626;background:#fff;border-radius:6px;color:#dc2626">重試</button></p>';
   }
-}
-
-// 返回測試集時定位到剛剛錄製/上傳的課文（record.html 帶 ?focus=<lessonId>）
-function focusLesson(){
-  var focus=new URLSearchParams(location.search).get('focus');
-  if(!focus) return;
-  var target=document.getElementById('lesson-'+focus);
-  if(!target) return;
-  target.scrollIntoView({behavior:'smooth',block:'center'});
-  target.classList.add('focus-hl');
-  setTimeout(function(){ target.classList.remove('focus-hl'); },2400);
 }
 
 loadLessons();

--- a/frontend/public/testset-7f3a91c4/index.html
+++ b/frontend/public/testset-7f3a91c4/index.html
@@ -18,6 +18,9 @@
   .btn-sec:hover{background:var(--chip)}
   .note{font-size:.82rem;color:var(--muted);margin-top:16px}
   .icon{font-size:2.5rem;margin-bottom:12px}
+  /* 從 record.html「返回測試集」帶 ?focus= 回來時，短暫高亮剛剛那一課 */
+  .focus-hl{box-shadow:0 0 0 3px var(--purple);animation:focusPulse 2.4s ease-out}
+  @keyframes focusPulse{0%{box-shadow:0 0 0 6px rgba(91,79,196,.55)}100%{box-shadow:0 0 0 3px rgba(91,79,196,0)}}
 </style>
 </head>
 <body>
@@ -56,12 +59,24 @@ async function loadLessons(){
     var h='';
     stories.forEach(function(s){
       var url='./record.html?lesson='+encodeURIComponent(s.id);
-      h+='<a class="btn-main" href="'+esc(url)+'">'+esc(s.title)+'<span style="display:block;font-size:.75rem;opacity:.7;font-weight:400">'+esc(s.id)+'</span></a>';
+      h+='<a id="lesson-'+esc(s.id)+'" class="btn-main" href="'+esc(url)+'">'+esc(s.title)+'<span style="display:block;font-size:.75rem;opacity:.7;font-weight:400">'+esc(s.id)+'</span></a>';
     });
     el.innerHTML=h;
+    focusLesson();  // 若帶 ?focus= 回來，捲動並高亮該課
   }catch(e){
     el.innerHTML='<p style="color:#dc2626;font-size:.9rem">課文清單載入失敗：'+esc(e.message)+'<br><button onclick="loadLessons()" style="margin-top:8px;padding:6px 14px;cursor:pointer;border:1px solid #dc2626;background:#fff;border-radius:6px;color:#dc2626">重試</button></p>';
   }
+}
+
+// 返回測試集時定位到剛剛錄製/上傳的課文（record.html 帶 ?focus=<lessonId>）
+function focusLesson(){
+  var focus=new URLSearchParams(location.search).get('focus');
+  if(!focus) return;
+  var target=document.getElementById('lesson-'+focus);
+  if(!target) return;
+  target.scrollIntoView({behavior:'smooth',block:'center'});
+  target.classList.add('focus-hl');
+  setTimeout(function(){ target.classList.remove('focus-hl'); },2400);
 }
 
 loadLessons();

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -70,7 +70,7 @@
 </head>
 <body>
 <div class="wrap">
-  <a class="back" id="backLink" href="./index.html" onclick="return goBack()">← 返回測試集</a>
+  <a class="back" id="backLink" href="../presentation/reading-pipeline.html#testset">← 返回測試集</a>
   <h1>朗讀錄音貢獻</h1>
   <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
 
@@ -144,12 +144,8 @@ function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'
 
 var lessonId=qs('lesson')||'';
 
-// 「返回測試集」= 回到一開始開啟此頁的來源頁（瀏覽器上一頁）。
-// 若是直接貼網址開啟（沒有上一頁），才退回課文列表 index.html（href fallback）。
-function goBack(){
-  if(history.length>1){ history.back(); return false; }
-  return true;  // 無上一頁 → 走 href fallback (./index.html)
-}
+// 「返回測試集」直接走 <a href> 到 reading-pipeline.html#testset（④ 測試集 分頁）。
+// record.html 是用 target="_blank" 從測試集頁開的新分頁，故用導頁而非 history.back()。
 var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
 var NAME_KEY='testset_name';

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -70,7 +70,7 @@
 </head>
 <body>
 <div class="wrap">
-  <a class="back" id="backLink" href="./index.html">← 返回測試集</a>
+  <a class="back" id="backLink" href="./index.html" onclick="return goBack()">← 返回測試集</a>
   <h1>朗讀錄音貢獻</h1>
   <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
 
@@ -144,11 +144,12 @@ function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'
 
 var lessonId=qs('lesson')||'';
 
-// 「返回測試集」帶上 lesson，回到列表後可定位到剛剛這一課
-(function initBack(){
-  var b=document.getElementById('backLink');
-  if(b) b.href='./index.html'+(lessonId?('?focus='+encodeURIComponent(lessonId)):'');
-})();
+// 「返回測試集」= 回到一開始開啟此頁的來源頁（瀏覽器上一頁）。
+// 若是直接貼網址開啟（沒有上一頁），才退回課文列表 index.html（href fallback）。
+function goBack(){
+  if(history.length>1){ history.back(); return false; }
+  return true;  // 無上一頁 → 走 href fallback (./index.html)
+}
 var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
 var NAME_KEY='testset_name';

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -245,6 +245,11 @@ var MAX_AUDIO_BYTES=8*1024*1024;  // 與後端 /api/testset/upload 上限一致
 function onFileSelected(ev){
   var f=ev.target.files&&ev.target.files[0];
   if(!f) return;
+  // 錄音進行中不接受選檔，避免 blob 被錄音 onstop 覆寫（競爭）
+  if(mediaRec&&mediaRec.state==='recording'){
+    document.getElementById('status').innerHTML='<span class="err">錄音進行中，請先停止錄音再上傳檔案</span>';
+    ev.target.value=''; return;
+  }
   var nm=(f.name||'').toLowerCase();
   var isWav=f.type.indexOf('wav')>-1||nm.slice(-4)==='.wav';
   var isMp3=f.type.indexOf('mpeg')>-1||f.type.indexOf('mp3')>-1||nm.slice(-4)==='.mp3';

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -34,6 +34,11 @@
   .btn-rec.recording{background:#7f1d1d}
   .btn-up{background:var(--purple);color:#fff;width:100%}
   .btn:disabled{opacity:.4;cursor:not-allowed}
+  /* 上傳音檔途徑（與錄音二選一）*/
+  .or-sep{display:flex;align-items:center;gap:10px;color:var(--muted);font-size:.8rem;margin:12px 0}
+  .or-sep::before,.or-sep::after{content:"";flex:1;height:1px;background:var(--line)}
+  .btn-file{display:block;width:100%;padding:12px;border:1px dashed var(--purple);border-radius:10px;background:var(--chip);color:var(--purple);font-weight:600;text-align:center;cursor:pointer}
+  .btn-file:hover{background:#e6dffb}
   audio{width:100%}
   /* 播放器 + 右側小重錄鈕同列（重錄縮小、不被誤觸）*/
   .player-row{display:flex;align-items:center;gap:8px;margin-top:10px}
@@ -65,6 +70,7 @@
 </head>
 <body>
 <div class="wrap">
+  <a class="back" id="backLink" href="./index.html">← 返回測試集</a>
   <h1>朗讀錄音貢獻</h1>
   <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
 
@@ -90,12 +96,17 @@
 
       <!-- 錄音 -->
       <div class="card" id="rec-card">
-        <div class="step">② 照著念 + 錄音</div>
+        <div class="step">② 照著念 + 錄音，或上傳音檔</div>
         <div class="vtabs">
           <div class="vtab sel" data-v="correct" onclick="selVersion('correct')">正確版<span class="hint">盡量念正確</span></div>
           <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
         </div>
         <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
+        <!-- 上傳既有音檔（mp3/wav）— 與錄音二選一，後續流程一致 -->
+        <div class="or-sep">或</div>
+        <label class="btn-file">📁 選擇 mp3 / wav 檔
+          <input type="file" id="fileInput" accept="audio/mpeg,audio/wav,.mp3,.wav" hidden onchange="onFileSelected(event)">
+        </label>
         <div class="player-row" id="playerRow" style="display:none">
           <audio id="player" controls></audio>
           <button class="btn-rerec" id="reRecBtn" onclick="reRecord()" title="重新錄音">↻ 重錄</button>
@@ -129,8 +140,15 @@ var API=apiBase();
 function qs(key){
   return new URLSearchParams(location.search).get(key);
 }
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 
 var lessonId=qs('lesson')||'';
+
+// 「返回測試集」帶上 lesson，回到列表後可定位到剛剛這一課
+(function initBack(){
+  var b=document.getElementById('backLink');
+  if(b) b.href='./index.html'+(lessonId?('?focus='+encodeURIComponent(lessonId)):'');
+})();
 var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
 var NAME_KEY='testset_name';
@@ -221,7 +239,35 @@ function resetRec(){
   document.getElementById('playerRow').style.display='none';
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='';
+  var fi=document.getElementById('fileInput'); if(fi) fi.value='';  // 讓同一檔可重新選取
   var b=document.getElementById('recBtn'); b.style.display=''; b.classList.remove('recording'); b.textContent='● 開始錄音';
+}
+
+/* ── 上傳既有音檔（mp3/wav）── 與錄音共用同一條 upload() 流程 ── */
+var MAX_AUDIO_BYTES=8*1024*1024;  // 與後端 /api/testset/upload 上限一致
+function onFileSelected(ev){
+  var f=ev.target.files&&ev.target.files[0];
+  if(!f) return;
+  var nm=(f.name||'').toLowerCase();
+  var isWav=f.type.indexOf('wav')>-1||nm.slice(-4)==='.wav';
+  var isMp3=f.type.indexOf('mpeg')>-1||f.type.indexOf('mp3')>-1||nm.slice(-4)==='.mp3';
+  if(!isWav&&!isMp3){
+    document.getElementById('status').innerHTML='<span class="err">只接受 mp3 或 wav 檔</span>';
+    ev.target.value=''; return;
+  }
+  if(f.size>MAX_AUDIO_BYTES){
+    document.getElementById('status').innerHTML='<span class="err">檔案超過 8MB，請改用較短的音檔</span>';
+    ev.target.value=''; return;
+  }
+  // 正規化 content-type 為後端白名單接受的 MIME（避免 audio/x-wav 之類被擋）
+  var mime=isWav?'audio/wav':'audio/mpeg';
+  blob=new Blob([f],{type:mime});
+  // 收起大錄音鈕、顯示播放器預覽 + 開放上傳（與錄完一段後同樣的 UI 狀態）
+  var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
+  document.getElementById('playerRow').style.display='flex';
+  document.getElementById('recBtn').style.display='none';
+  document.getElementById('upBtn').disabled=false;
+  document.getElementById('status').innerHTML='<span style="color:var(--muted)">已選擇檔案：'+esc(f.name)+'，可上傳</span>';
 }
 
 async function toggleRec(){
@@ -271,11 +317,13 @@ async function upload(){
   localStorage.setItem(NAME_KEY,name);
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='<span style="color:var(--muted)">上傳中…</span>';
+  // 副檔名跟著實際內容走（錄音=webm；上傳檔=mp3/wav），content-type 由 blob.type 帶出
+  var ext=(blob.type.indexOf('wav')>-1)?'wav':((blob.type.indexOf('mpeg')>-1||blob.type.indexOf('mp3')>-1)?'mp3':'webm');
   var fd=new FormData();
   fd.append('contributor_name',name);
   fd.append('lesson_id',lessonId);
   fd.append('version',cur.version);
-  fd.append('audio',blob,lessonId+'_'+cur.version+'.webm');
+  fd.append('audio',blob,lessonId+'_'+cur.version+'.'+ext);
   try{
     var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
     if(!r.ok){ throw new Error('HTTP '+r.status); }

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -152,6 +152,7 @@ var NAME_KEY='testset_name';
 var done=JSON.parse(localStorage.getItem('testset_done_v2_'+lessonId)||'{}');
 var doneUrls={correct:null,error:null};  // server 簽名播放 URL（聽取用，10 分鐘有效）
 var mediaRec=null,chunks=[],blob=null;
+var blobSource=null;  // 'rec' = 錄音；'file' = 上傳檔 — 決定「重錄/重選」鈕行為與標籤
 
 /* ── 進度：server-truth（換裝置/清快取仍讀得回，localStorage 只當快取） ── */
 async function loadProgress(){
@@ -231,12 +232,13 @@ function selVersion(v){
 }
 
 function resetRec(){
-  blob=null;
+  blob=null; blobSource=null;
   var p=document.getElementById('player'); p.src='';
   document.getElementById('playerRow').style.display='none';
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='';
   var fi=document.getElementById('fileInput'); if(fi) fi.value='';  // 讓同一檔可重新選取
+  var rr=document.getElementById('reRecBtn'); if(rr){ rr.textContent='↻ 重錄'; rr.title='重新錄音'; }
   var b=document.getElementById('recBtn'); b.style.display=''; b.classList.remove('recording'); b.textContent='● 開始錄音';
 }
 
@@ -263,11 +265,13 @@ function onFileSelected(ev){
   }
   // 正規化 content-type 為後端白名單接受的 MIME（避免 audio/x-wav 之類被擋）
   var mime=isWav?'audio/wav':'audio/mpeg';
-  blob=new Blob([f],{type:mime});
+  blob=new Blob([f],{type:mime}); blobSource='file';
   // 收起大錄音鈕、顯示播放器預覽 + 開放上傳（與錄完一段後同樣的 UI 狀態）
   var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
   document.getElementById('playerRow').style.display='flex';
   document.getElementById('recBtn').style.display='none';
+  // 來源是檔案 → 小鈕改為「重選」語意（避免「重錄」誤導去開麥克風）
+  var rr=document.getElementById('reRecBtn'); if(rr){ rr.textContent='↻ 重選'; rr.title='重新選擇檔案'; }
   document.getElementById('upBtn').disabled=false;
   document.getElementById('status').innerHTML='<span style="color:var(--muted)">已選擇檔案：'+esc(f.name)+'，可上傳</span>';
 }
@@ -280,7 +284,7 @@ async function toggleRec(){
     chunks=[]; mediaRec=new MediaRecorder(stream);
     mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
     mediaRec.onstop=function(){
-      blob=new Blob(chunks,{type:'audio/webm'});
+      blob=new Blob(chunks,{type:'audio/webm'}); blobSource='rec';
       var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
       // 完成：收起大錄音鈕，改顯示「播放器 + 右側小重錄鈕」（避免誤觸重錄）
       document.getElementById('playerRow').style.display='flex';
@@ -300,8 +304,13 @@ async function toggleRec(){
   }
 }
 
-// 重錄：先確認再捨棄目前這段（小鈕在播放器右邊，避免誤觸）
+// 「重錄/重選」：依目前來源決定行為，避免上傳檔時誤開麥克風
 function reRecord(){
+  if(blobSource==='file'){
+    // 來源是上傳檔 → 回到可錄音或重新選檔的狀態，不直接開麥克風
+    resetRec();
+    return;
+  }
   if(!confirm('確定要重錄嗎？目前這段會被捨棄。')) return;
   toggleRec();
 }


### PR DESCRIPTION
## 目的

Fixes #2426。測試集錄音頁原本只能即時錄音，本 PR **多一條上傳途徑**：可直接上傳既有 mp3/wav 檔。**後續流程完全不變** —— 一樣走 `/api/testset/upload`、一樣退回測試集按「跑分」做 AI 評分。**不新增評分端點、不改評分邏輯。** 另加「返回測試集」按鈕。

## 改動（皆為 `frontend/public/testset-7f3a91c4/` 靜態頁）

**`record.html`**
- 「② 照著念 + 錄音」區塊新增 **「📁 選擇 mp3/wav 檔」** 上傳途徑（與錄音二選一）。選檔後沿用既有 `upload()`（同 `FormData` / 同 `POST /api/testset/upload` / 同欄位），只是 `audio` 來源改成使用者選的檔。
- 檔案驗證：限 mp3/wav、`≤8MB`（對齊後端 `_MAX_AUDIO_BYTES`）；以 `new Blob([f],{type})` **正規化 content-type** 為 `audio/wav` / `audio/mpeg`，避免 `audio/x-wav` 等被後端 `_ALLOWED_MIME` 擋。
- `upload()` 上傳檔名副檔名跟著實際內容走（webm/mp3/wav）。
- 新增 **「← 返回測試集」** 按鈕 → `./index.html?focus=<lessonId>`。

**`index.html`**
- 每課 `<a>` 加 `id="lesson-{id}"`；帶 `?focus=` 回來時 `scrollIntoView` + 短暫高亮，**直接定位到剛剛錄製/上傳的課文**。

## 驗證

- ✅ 兩頁 `<script>` 皆過 `node --check`（靜態頁無 build/eslint/vitest 覆蓋，語法檢查為主要 gate）
- ⬜ Preview 實機：上傳 mp3/wav → 進度更新；返回鈕跳回列表並定位該課；console 乾淨（preview 部署後補截圖）

> 註：`/api/testset/upload` 目前不論格式都以 `.webm` 副檔名存檔（既有行為）。mp3/wav 內容仍能被 batch-eval 正確轉錄（Gemini 原生支援 mp3/wav；ffmpeg 也依實際內容判讀，與副檔名無關）。若實測發現副檔名/mime 導致評分異常，再開 follow-up 於 `backend/app/routes/testset.py` 微調。

## 嚴重性

🟢 低 — 測試集內部工具（隱藏 unguessable path），不影響正式學習流程；不動評分核心；無後端改動。

Fixes #2426