### PR TITLE
fix(frontend): npm run dev — optimizeDeps target=esnext 解 esbuild destructuring 降級錯誤 (#2428)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,16 @@ export default defineConfig({
   build: {
     target: 'esnext',
   },
+  // Match the dev dependency pre-bundle target to the build target. Vite's
+  // default optimizeDeps target includes safari14, which makes esbuild attempt
+  // a destructuring down-level it can't do ("Transforming destructuring ... is
+  // not supported yet") on deps like date-fns / d3-array / @floating-ui,
+  // crashing `npm run dev`. esnext skips that lowering entirely. (#2428)
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## 目的

Fixes #2428。在 `frontend/` 跑 `npm run dev` 會噴 ~1205 個 esbuild 錯誤、dev server 無法啟動：

```
✘ Transforming destructuring to the configured target environment
("chrome87","edge88","es2020","firefox78","safari14" + 2 overrides) is not supported yet
  date-fns / d3-array / internmap / @floating-ui ...
```

## 根因

`vite.config.ts` 只設了 `build.target: 'esnext'`，**沒設 `optimizeDeps` target** → dev server 依賴預打包用 Vite **預設** esbuild target（含 **safari14**）。Safari 14 有 destructuring bug，esbuild 嘗試降級繞過但「not supported yet」→ 整批依賴爆錯。

- `npm run build` 沒事：`build.target: esnext` 跳過降級。
- **CI 全綠也合理**：CI 只跑 `npm run build` + vitest + playwright，**不跑 `npm run dev`**。

## 修法

```ts
optimizeDeps: {
  esbuildOptions: { target: 'esnext' },
},
```
讓 dev 依賴預打包 target 對齊 build target。

## 驗證

- ✅ `vite optimize --force`（即 dev 預打包路徑）→ exit 0、**0 errors**
- ✅ `npm run build` → exit 0（不受影響）
- 在乾淨 `npm ci` 環境重現過原錯誤，套用本修正後消失

## 影響 / 嚴重性

🟡 中 — 只影響本機 `npm run dev`（已多次擋住本機開發）；不影響 production / staging / preview（走 build）。單檔 config 改動。

Fixes #2428