### PR TITLE
fix(testset): magic-bytes validation on upload — reject spoofed MIME (#2430)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -66,6 +66,25 @@ def _slug(name: str) -> str:
     return (s.strip("_") or "anon")[:40]
 
 
+def _audio_bytes_match_declared_mime(data: bytes, declared_mime: str) -> bool:
+    """Verify leading magic bytes match client-declared MIME (anti spoofing)."""
+    if not data:
+        return False
+    if declared_mime == "audio/wav":
+        return len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE"
+    if declared_mime == "audio/mpeg":
+        if data[:3] == b"ID3":
+            return True
+        return len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0
+    if declared_mime == "audio/webm":
+        return data[:4] == b"\x1a\x45\xdf\xa3"
+    if declared_mime == "audio/ogg":
+        return data[:4] == b"OggS"
+    if declared_mime == "audio/mp4":
+        return len(data) >= 12 and data[4:8] == b"ftyp"
+    return False
+
+
 def _resolve_target_text(lesson_id: str) -> str | None:
     """Return full_text for lesson_id (numeric int or code string like 'G6-L22').
 
@@ -140,7 +159,9 @@ async def testset_upload(
     if len(audio_bytes) == 0:
         raise HTTPException(400, "empty audio")
     if len(audio_bytes) > _MAX_AUDIO_BYTES:
-        raise HTTPException(413, "audio too large (max 15MB)")
+        raise HTTPException(413, "audio too large (max 8MB)")
+    if not _audio_bytes_match_declared_mime(audio_bytes, base_mime):
+        raise HTTPException(400, "audio content does not match declared type")
 
     bucket = _get_gcs_bucket()
     if bucket is None:
@@ -233,6 +254,11 @@ def testset_recordings():
     公開（Young 2026-06-21：不需登入即顯示貢獻者暱稱/數量）。暱稱為自選暱稱、
     朗讀公開課文，非敏感 PII；list.html 現況表不登入就能看到誰貢獻了哪幾課。
     （此前曾 admin/teacher → 任何登入者 → 現全公開。）
+
+    DECISION NEEDED — auth: 此 endpoint 日後應改為 require_role(system_admin, org_admin)，
+    但 frontend/public/testset-7f3a91c4/dashboard.html 目前無登入/token 機制；
+    現階段加 require_role 會 403 並讓 admin 無法看錄音清單。須先讓 dashboard 接上
+    auth flow 再鎖 endpoint；在此之前維持公開、勿在此加 require_role。
     """
     bucket = _get_gcs_bucket()
     if bucket is None:

--- a/backend/tests/test_testset_upload_magic_bytes.py
+++ b/backend/tests/test_testset_upload_magic_bytes.py
@@ -1,0 +1,51 @@
+"""Regression lock for testset upload magic-bytes validation.
+
+Bug (verified 2026-06-30 against staging): POST /testset/upload trusted only the
+client-supplied content_type form field, so a non-audio file relabelled as
+audio/wav (spoofed MIME) was accepted and stored in GCS, polluting the training
+manifest. Fix added `_audio_bytes_match_declared_mime` which inspects the actual
+leading bytes; the upload route now raises 400 when bytes don't match the
+declared MIME.
+
+This test locks the function's behavior (deterministic, no mocks). The route
+call site (`if not _audio_bytes_match_declared_mime(...): raise HTTPException(400)`)
+is verified by reading testset.py.
+
+Run:
+    cd backend && python -m pytest tests/test_testset_upload_magic_bytes.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.routes.testset import _audio_bytes_match_declared_mime as match
+
+
+@pytest.mark.parametrize(
+    "data,mime,expected",
+    [
+        # real headers accepted
+        (b"RIFF\x24\x00\x00\x00WAVEfmt ", "audio/wav", True),
+        (b"ID3\x03\x00\x00\x00", "audio/mpeg", True),          # MP3 ID3 tag
+        (b"\xff\xfb\x90\x00", "audio/mpeg", True),              # MP3 frame sync
+        (b"\x1a\x45\xdf\xa3rest", "audio/webm", True),          # WebM EBML
+        (b"OggS\x00\x02\x00\x00", "audio/ogg", True),           # Ogg container
+        (b"\x00\x00\x00\x18ftypM4A ", "audio/mp4", True),       # ISO BMFF / M4A
+        # THE BUG: spoofed non-audio relabelled as audio must be rejected
+        (b"this is not audio at all", "audio/wav", False),
+        (b"this is not audio at all", "audio/mpeg", False),
+        (b"<html>nope</html>", "audio/webm", False),
+        (b"this is not audio", "audio/ogg", False),
+        (b"this is not audio", "audio/mp4", False),
+        # empty / truncated rejected
+        (b"", "audio/wav", False),
+        (b"RIFF", "audio/wav", False),                          # too short for WAVE check
+    ],
+)
+def test_magic_bytes_match(data, mime, expected):
+    assert match(data, mime) is expected


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2430

## 問題（2026-06-30 staging 實測）
`POST /api/testset/upload`（公開未登入）只信前端 `content_type`,把 .txt 標成 `audio/wav` 會被存進 GCS、污染訓練 manifest。

## 修法（後端,不靠前端擋）
- `_audio_bytes_match_declared_mime` 驗全 5 型白名單真實檔頭:WAV(RIFF/WAVE)、MP3(ID3/frame sync)、WebM(EBML)、OGG(OggS)、MP4(ftyp box),fallthrough `return False`(deny-by-default),不符回 400
- 保留 content_type 白名單 / 8MB cap / filename sanitize；順修 413 訊息(15MB→8MB)

## 不在本 PR（後續）
- `recordings` 維持公開 + decision-needed 註記:應加 `require_role(system_admin/org_admin)`,但 dashboard.html 無 auth flow,現在鎖會 403 break dashboard → 需先補 dashboard 登入
- `batch-eval` 未碰

## 驗證
- regression test 13 cases(5 型 real+spoof),本機 13 passed
- cursor-agent 實作;獨立 code review 兩輪(抓出並修掉 ogg/mp4 bypass,最終 SHIP);Claude verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)