### PR TITLE
test(testset): EDD lock — mp3/wav survive transcription preprocessing (#2430)

### DIFF
--- a/backend/tests/test_testset_upload_formats_edd.py
+++ b/backend/tests/test_testset_upload_formats_edd.py
@@ -1,0 +1,102 @@
+"""EDD lock: #2427 added mp3/wav upload — verify those formats survive the
+reading-transcription preprocessing.
+
+Why this exists (eval derived from the real shipped scenario, not eval-first):
+- #2427 lets contributors upload mp3/wav (previously only webm recordings).
+- upload stores every file under a hardcoded `.webm` path and does NOT record
+  the real content_type in meta (testset.py:174-183).
+- batch-eval therefore calls transcribe_reading_audio(..., mime_type="audio/webm")
+  hardcoded (testset.py:432) for EVERY recording, including mp3/wav.
+
+Empirically verified 2026-07-01: ffmpeg sniffs the real container (the mime only
+picks a temp-file extension, never a hard `-f` input flag), so non-webm bytes
+labeled "audio/webm" still work:
+  - _max_volume_db(wav/mp3, "audio/webm") detects real volume → silence gate OK
+  - _transcode_to_ogg(wav/mp3, "audio/webm") yields valid Ogg/Opus → Gemini gets
+    ogg labeled audio/ogg (service line 354) → transcribes fine.
+
+Net finding: mp3/wav uploads transcribe correctly. The hardcoded mime is a minor
+inefficiency (natively-supported wav/mp3 get an unnecessary transcode), NOT a
+correctness bug. This test catches a regression if a future change to the
+wrong-mime path breaks these formats (e.g. switching ffmpeg to a hard `-f` flag).
+
+ffmpeg required — skips if absent (CI currently installs no ffmpeg; runs locally
+and in any prod-like image where the silence gate already depends on ffmpeg).
+
+Run: cd backend && python -m pytest tests/test_testset_upload_formats_edd.py -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.services.reading_transcription_service import _max_volume_db, _transcode_to_ogg
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
+
+# The mime batch-eval actually passes for every recording (testset.py:432).
+HARDCODED_MIME = "audio/webm"
+
+
+def _gen_tone(fmt: str) -> bytes:
+    """Generate a 2s 440Hz tone in the given real format via ffmpeg."""
+    suffix = {"wav": ".wav", "mp3": ".mp3"}[fmt]
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+        path = f.name
+    try:
+        cmd = ["ffmpeg", "-y", "-f", "lavfi",
+               "-i", "sine=frequency=440:duration=2", "-ar", "16000"]
+        if fmt == "mp3":
+            cmd += ["-b:a", "64k"]
+        cmd += [path]
+        subprocess.run(cmd, capture_output=True, check=True)
+        with open(path, "rb") as fh:
+            return fh.read()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+@pytest.fixture(scope="module")
+def wav_bytes() -> bytes:
+    return _gen_tone("wav")
+
+
+@pytest.fixture(scope="module")
+def mp3_bytes() -> bytes:
+    return _gen_tone("mp3")
+
+
+class TestNonWebmSurvivesHardcodedWebmMime:
+    """Real wav/mp3 bytes labeled as audio/webm (the batch-eval scenario) must
+    still preprocess correctly — silence gate detects sound, transcode yields
+    valid ogg. Locks the #2427 mp3/wav upload path against the wrong-mime hint."""
+
+    def test_wav_silence_gate_detects_sound(self, wav_bytes):
+        db = _max_volume_db(wav_bytes, HARDCODED_MIME)
+        assert db is not None and db != float("-inf"), \
+            "silence gate false-rejected a real wav labeled webm"
+
+    def test_mp3_silence_gate_detects_sound(self, mp3_bytes):
+        db = _max_volume_db(mp3_bytes, HARDCODED_MIME)
+        assert db is not None and db != float("-inf"), \
+            "silence gate false-rejected a real mp3 labeled webm"
+
+    def test_wav_transcodes_to_valid_ogg(self, wav_bytes):
+        ogg = _transcode_to_ogg(wav_bytes, HARDCODED_MIME)
+        assert ogg is not None and ogg[:4] == b"OggS", \
+            "wav (labeled webm) failed to transcode to valid ogg"
+
+    def test_mp3_transcodes_to_valid_ogg(self, mp3_bytes):
+        ogg = _transcode_to_ogg(mp3_bytes, HARDCODED_MIME)
+        assert ogg is not None and ogg[:4] == b"OggS", \
+            "mp3 (labeled webm) failed to transcode to valid ogg"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Refs #2430

EDD 補強:mp3/wav 上傳功能讓使用者傳 mp3/wav,但 batch-eval 對每筆 hardcode `mime="audio/webm"`(testset.py:432)、upload 也把檔案一律存 `.webm` 路徑且 meta 沒存真實 content_type。

**實測驗證(2026-07-01)**:ffmpeg 會 sniff 真實 container(mime 只決定 temp 副檔名、非硬 `-f` flag),所以非 webm 檔仍正確前處理 —— silence gate 偵測到聲音(-18dB)、transcode 出有效 ogg。**結論:mp3/wav 上傳會正確轉寫,無 correctness bug;hardcode mime 只是讓原生格式多做一次 transcode(低效)。**

此 eval case(真 wav/mp3 bytes 標成 webm)鎖住該行為,若日後 wrong-mime 路徑壞掉會被抓。ffmpeg-gated(缺則 skip;CI 目前無 ffmpeg)。本機 4 passed。獨立 code-review:SHIP。

後續(非本 PR):upload 存真實 content_type + batch-eval 傳真 mime,可省掉原生格式的多餘 transcode(低效非壞)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)