### PR TITLE
fix(testset): pass real audio mime to batch-eval transcription (#2434)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -179,6 +179,7 @@ async def testset_upload(
         "lesson_id": lid,
         "version": version,
         "audio_path": audio_path,
+        "content_type": base_mime,  # 真實 MIME → batch-eval 傳真 mime,原生格式免多餘 transcode (#2434)
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -398,6 +399,8 @@ async def testset_batch_eval(
         entry_lesson = meta.get("lesson_id", "")
         entry_version = meta.get("version", "")
         audio_path = meta.get("audio_path", "")
+        # 真實 MIME(#2434);舊紀錄無此欄 → fallback webm（與上線前行為一致，ffmpeg 仍 sniff）
+        entry_mime = meta.get("content_type") or "audio/webm"
 
         base_result: dict = {
             "name": entry_name,
@@ -429,7 +432,7 @@ async def testset_batch_eval(
             # 4c. Transcribe
             transcribe_result = await transcribe_reading_audio(
                 audio_bytes=audio_bytes,
-                mime_type="audio/webm",
+                mime_type=entry_mime,  # #2434: 真實 mime（原生 wav/mp3 免多餘 transcode）
                 target_text=target_text,
                 duration_ms=None,
             )

--- a/backend/tests/test_testset_batch_eval.py
+++ b/backend/tests/test_testset_batch_eval.py
@@ -535,3 +535,49 @@ class TestAuth:
             assert resp.status_code == 401
         finally:
             app.dependency_overrides.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# (#2434) Real MIME passthrough — batch-eval passes the meta's content_type
+# (not a hardcoded "audio/webm") so native wav/mp3 skip an unnecessary
+# transcode; legacy records without content_type fall back to webm.
+# ---------------------------------------------------------------------------
+
+class TestRealMimePassthrough:
+    def _run_capture_transcribe(self, authed_client, meta):
+        bucket = _make_bucket_with_metas([meta])
+        transcribe_mock = AsyncMock(
+            return_value={"transcript": "課文內容", "method": "gemini", "reason": None}
+        )
+        eval_ret = {"match_rate": 0.9, "adjusted_match_rate": 0.9, "cpm": 100.0, "tier": 1}
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                transcribe_mock,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+        assert resp.status_code == 200, resp.text
+        return transcribe_mock
+
+    def test_real_mime_from_meta_content_type(self, authed_client):
+        """meta has content_type=audio/wav → transcribe called with that mime."""
+        meta = _sample_meta(version="correct", uid="mime0001")
+        meta["content_type"] = "audio/wav"
+        m = self._run_capture_transcribe(authed_client, meta)
+        assert m.call_count == 1
+        assert m.call_args.kwargs["mime_type"] == "audio/wav"
+
+    def test_legacy_meta_without_content_type_falls_back_to_webm(self, authed_client):
+        """Legacy record (no content_type) → transcribe called with audio/webm."""
+        meta = _sample_meta(version="correct", uid="mime0002")
+        meta.pop("content_type", None)
+        m = self._run_capture_transcribe(authed_client, meta)
+        assert m.call_count == 1
+        assert m.call_args.kwargs["mime_type"] == "audio/webm"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2434

## 修什麼
batch-eval 對每筆 hardcode `mime_type="audio/webm"`,原生 wav/mp3 上傳被當 webm → 多做一次不必要 transcode(ffmpeg sniff 真格式所以正確,只浪費)。

## 改法(向後相容)
- upload meta 存真實 `content_type`(已驗過的 base_mime,屬 5 值白名單)
- batch-eval 讀 `meta.get("content_type") or "audio/webm"` 傳真 mime;**舊紀錄無此欄 → fallback webm,行為不變**

## 鎖
- `TestRealMimePassthrough`:meta content_type=audio/wav → transcribe 收 audio/wav;舊紀錄 → audio/webm
- **mutation-verified**:改回 hardcode webm → real-mime 測試變紅
- 全 testset 34 tests pass;**資安 review:SECURE-SHIP**(entry_mime 受上傳白名單+magic-byte 約束,只當靜態 lookup key,無 injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)