### PR TITLE
release: staging to main — testset magic-bytes hardening + TDD/EDD + real-mime + login refactor

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -179,6 +179,7 @@ async def testset_upload(
         "lesson_id": lid,
         "version": version,
         "audio_path": audio_path,
+        "content_type": base_mime,  # 真實 MIME → batch-eval 傳真 mime,原生格式免多餘 transcode (#2434)
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -398,6 +399,8 @@ async def testset_batch_eval(
         entry_lesson = meta.get("lesson_id", "")
         entry_version = meta.get("version", "")
         audio_path = meta.get("audio_path", "")
+        # 真實 MIME(#2434);舊紀錄無此欄 → fallback webm（與上線前行為一致，ffmpeg 仍 sniff）
+        entry_mime = meta.get("content_type") or "audio/webm"
 
         base_result: dict = {
             "name": entry_name,
@@ -429,7 +432,7 @@ async def testset_batch_eval(
             # 4c. Transcribe
             transcribe_result = await transcribe_reading_audio(
                 audio_bytes=audio_bytes,
-                mime_type="audio/webm",
+                mime_type=entry_mime,  # #2434: 真實 mime（原生 wav/mp3 免多餘 transcode）
                 target_text=target_text,
                 duration_ms=None,
             )

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -66,6 +66,25 @@ def _slug(name: str) -> str:
     return (s.strip("_") or "anon")[:40]
 
 
+def _audio_bytes_match_declared_mime(data: bytes, declared_mime: str) -> bool:
+    """Verify leading magic bytes match client-declared MIME (anti spoofing)."""
+    if not data:
+        return False
+    if declared_mime == "audio/wav":
+        return len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE"
+    if declared_mime == "audio/mpeg":
+        if data[:3] == b"ID3":
+            return True
+        return len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0
+    if declared_mime == "audio/webm":
+        return data[:4] == b"\x1a\x45\xdf\xa3"
+    if declared_mime == "audio/ogg":
+        return data[:4] == b"OggS"
+    if declared_mime == "audio/mp4":
+        return len(data) >= 12 and data[4:8] == b"ftyp"
+    return False
+
+
 def _resolve_target_text(lesson_id: str) -> str | None:
     """Return full_text for lesson_id (numeric int or code string like 'G6-L22').
 
@@ -140,7 +159,9 @@ async def testset_upload(
     if len(audio_bytes) == 0:
         raise HTTPException(400, "empty audio")
     if len(audio_bytes) > _MAX_AUDIO_BYTES:
-        raise HTTPException(413, "audio too large (max 15MB)")
+        raise HTTPException(413, "audio too large (max 8MB)")
+    if not _audio_bytes_match_declared_mime(audio_bytes, base_mime):
+        raise HTTPException(400, "audio content does not match declared type")
 
     bucket = _get_gcs_bucket()
     if bucket is None:
@@ -233,6 +254,11 @@ def testset_recordings():
     公開（Young 2026-06-21：不需登入即顯示貢獻者暱稱/數量）。暱稱為自選暱稱、
     朗讀公開課文，非敏感 PII；list.html 現況表不登入就能看到誰貢獻了哪幾課。
     （此前曾 admin/teacher → 任何登入者 → 現全公開。）
+
+    DECISION NEEDED — auth: 此 endpoint 日後應改為 require_role(system_admin, org_admin)，
+    但 frontend/public/testset-7f3a91c4/dashboard.html 目前無登入/token 機制；
+    現階段加 require_role 會 403 並讓 admin 無法看錄音清單。須先讓 dashboard 接上
+    auth flow 再鎖 endpoint；在此之前維持公開、勿在此加 require_role。
     """
     bucket = _get_gcs_bucket()
     if bucket is None:

--- a/backend/tests/test_testset_batch_eval.py
+++ b/backend/tests/test_testset_batch_eval.py
@@ -535,3 +535,49 @@ class TestAuth:
             assert resp.status_code == 401
         finally:
             app.dependency_overrides.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# (#2434) Real MIME passthrough — batch-eval passes the meta's content_type
+# (not a hardcoded "audio/webm") so native wav/mp3 skip an unnecessary
+# transcode; legacy records without content_type fall back to webm.
+# ---------------------------------------------------------------------------
+
+class TestRealMimePassthrough:
+    def _run_capture_transcribe(self, authed_client, meta):
+        bucket = _make_bucket_with_metas([meta])
+        transcribe_mock = AsyncMock(
+            return_value={"transcript": "課文內容", "method": "gemini", "reason": None}
+        )
+        eval_ret = {"match_rate": 0.9, "adjusted_match_rate": 0.9, "cpm": 100.0, "tier": 1}
+        with (
+            patch("app.routes.testset._get_gcs_bucket", return_value=bucket),
+            patch(
+                "app.services.reading_transcription_service.transcribe_reading_audio",
+                transcribe_mock,
+            ),
+            patch(
+                "app.services.reading_evaluation_service.evaluate_reading_with_ai",
+                new_callable=AsyncMock,
+                return_value=eval_ret,
+            ),
+        ):
+            resp = authed_client.post("/api/testset/batch-eval")
+        assert resp.status_code == 200, resp.text
+        return transcribe_mock
+
+    def test_real_mime_from_meta_content_type(self, authed_client):
+        """meta has content_type=audio/wav → transcribe called with that mime."""
+        meta = _sample_meta(version="correct", uid="mime0001")
+        meta["content_type"] = "audio/wav"
+        m = self._run_capture_transcribe(authed_client, meta)
+        assert m.call_count == 1
+        assert m.call_args.kwargs["mime_type"] == "audio/wav"
+
+    def test_legacy_meta_without_content_type_falls_back_to_webm(self, authed_client):
+        """Legacy record (no content_type) → transcribe called with audio/webm."""
+        meta = _sample_meta(version="correct", uid="mime0002")
+        meta.pop("content_type", None)
+        m = self._run_capture_transcribe(authed_client, meta)
+        assert m.call_count == 1
+        assert m.call_args.kwargs["mime_type"] == "audio/webm"

--- a/backend/tests/test_testset_upload_formats_edd.py
+++ b/backend/tests/test_testset_upload_formats_edd.py
@@ -1,0 +1,102 @@
+"""EDD lock: #2427 added mp3/wav upload — verify those formats survive the
+reading-transcription preprocessing.
+
+Why this exists (eval derived from the real shipped scenario, not eval-first):
+- #2427 lets contributors upload mp3/wav (previously only webm recordings).
+- upload stores every file under a hardcoded `.webm` path and does NOT record
+  the real content_type in meta (testset.py:174-183).
+- batch-eval therefore calls transcribe_reading_audio(..., mime_type="audio/webm")
+  hardcoded (testset.py:432) for EVERY recording, including mp3/wav.
+
+Empirically verified 2026-07-01: ffmpeg sniffs the real container (the mime only
+picks a temp-file extension, never a hard `-f` input flag), so non-webm bytes
+labeled "audio/webm" still work:
+  - _max_volume_db(wav/mp3, "audio/webm") detects real volume → silence gate OK
+  - _transcode_to_ogg(wav/mp3, "audio/webm") yields valid Ogg/Opus → Gemini gets
+    ogg labeled audio/ogg (service line 354) → transcribes fine.
+
+Net finding: mp3/wav uploads transcribe correctly. The hardcoded mime is a minor
+inefficiency (natively-supported wav/mp3 get an unnecessary transcode), NOT a
+correctness bug. This test catches a regression if a future change to the
+wrong-mime path breaks these formats (e.g. switching ffmpeg to a hard `-f` flag).
+
+ffmpeg required — skips if absent (CI currently installs no ffmpeg; runs locally
+and in any prod-like image where the silence gate already depends on ffmpeg).
+
+Run: cd backend && python -m pytest tests/test_testset_upload_formats_edd.py -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.services.reading_transcription_service import _max_volume_db, _transcode_to_ogg
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not installed"
+)
+
+# The mime batch-eval actually passes for every recording (testset.py:432).
+HARDCODED_MIME = "audio/webm"
+
+
+def _gen_tone(fmt: str) -> bytes:
+    """Generate a 2s 440Hz tone in the given real format via ffmpeg."""
+    suffix = {"wav": ".wav", "mp3": ".mp3"}[fmt]
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+        path = f.name
+    try:
+        cmd = ["ffmpeg", "-y", "-f", "lavfi",
+               "-i", "sine=frequency=440:duration=2", "-ar", "16000"]
+        if fmt == "mp3":
+            cmd += ["-b:a", "64k"]
+        cmd += [path]
+        subprocess.run(cmd, capture_output=True, check=True)
+        with open(path, "rb") as fh:
+            return fh.read()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+@pytest.fixture(scope="module")
+def wav_bytes() -> bytes:
+    return _gen_tone("wav")
+
+
+@pytest.fixture(scope="module")
+def mp3_bytes() -> bytes:
+    return _gen_tone("mp3")
+
+
+class TestNonWebmSurvivesHardcodedWebmMime:
+    """Real wav/mp3 bytes labeled as audio/webm (the batch-eval scenario) must
+    still preprocess correctly — silence gate detects sound, transcode yields
+    valid ogg. Locks the #2427 mp3/wav upload path against the wrong-mime hint."""
+
+    def test_wav_silence_gate_detects_sound(self, wav_bytes):
+        db = _max_volume_db(wav_bytes, HARDCODED_MIME)
+        assert db is not None and db != float("-inf"), \
+            "silence gate false-rejected a real wav labeled webm"
+
+    def test_mp3_silence_gate_detects_sound(self, mp3_bytes):
+        db = _max_volume_db(mp3_bytes, HARDCODED_MIME)
+        assert db is not None and db != float("-inf"), \
+            "silence gate false-rejected a real mp3 labeled webm"
+
+    def test_wav_transcodes_to_valid_ogg(self, wav_bytes):
+        ogg = _transcode_to_ogg(wav_bytes, HARDCODED_MIME)
+        assert ogg is not None and ogg[:4] == b"OggS", \
+            "wav (labeled webm) failed to transcode to valid ogg"
+
+    def test_mp3_transcodes_to_valid_ogg(self, mp3_bytes):
+        ogg = _transcode_to_ogg(mp3_bytes, HARDCODED_MIME)
+        assert ogg is not None and ogg[:4] == b"OggS", \
+            "mp3 (labeled webm) failed to transcode to valid ogg"

--- a/backend/tests/test_testset_upload_magic_bytes.py
+++ b/backend/tests/test_testset_upload_magic_bytes.py
@@ -1,0 +1,51 @@
+"""Regression lock for testset upload magic-bytes validation.
+
+Bug (verified 2026-06-30 against staging): POST /testset/upload trusted only the
+client-supplied content_type form field, so a non-audio file relabelled as
+audio/wav (spoofed MIME) was accepted and stored in GCS, polluting the training
+manifest. Fix added `_audio_bytes_match_declared_mime` which inspects the actual
+leading bytes; the upload route now raises 400 when bytes don't match the
+declared MIME.
+
+This test locks the function's behavior (deterministic, no mocks). The route
+call site (`if not _audio_bytes_match_declared_mime(...): raise HTTPException(400)`)
+is verified by reading testset.py.
+
+Run:
+    cd backend && python -m pytest tests/test_testset_upload_magic_bytes.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.routes.testset import _audio_bytes_match_declared_mime as match
+
+
+@pytest.mark.parametrize(
+    "data,mime,expected",
+    [
+        # real headers accepted
+        (b"RIFF\x24\x00\x00\x00WAVEfmt ", "audio/wav", True),
+        (b"ID3\x03\x00\x00\x00", "audio/mpeg", True),          # MP3 ID3 tag
+        (b"\xff\xfb\x90\x00", "audio/mpeg", True),              # MP3 frame sync
+        (b"\x1a\x45\xdf\xa3rest", "audio/webm", True),          # WebM EBML
+        (b"OggS\x00\x02\x00\x00", "audio/ogg", True),           # Ogg container
+        (b"\x00\x00\x00\x18ftypM4A ", "audio/mp4", True),       # ISO BMFF / M4A
+        # THE BUG: spoofed non-audio relabelled as audio must be rejected
+        (b"this is not audio at all", "audio/wav", False),
+        (b"this is not audio at all", "audio/mpeg", False),
+        (b"<html>nope</html>", "audio/webm", False),
+        (b"this is not audio", "audio/ogg", False),
+        (b"this is not audio", "audio/mp4", False),
+        # empty / truncated rejected
+        (b"", "audio/wav", False),
+        (b"RIFF", "audio/wav", False),                          # too short for WAVE check
+    ],
+)
+def test_magic_bytes_match(data, mime, expected):
+    assert match(data, mime) is expected

--- a/backend/tests/test_testset_upload_route.py
+++ b/backend/tests/test_testset_upload_route.py
@@ -1,0 +1,93 @@
+"""Route-level integration TDD for POST /api/testset/upload magic-bytes wiring.
+
+Companion to test_testset_upload_magic_bytes.py (which unit-tests the pure
+_audio_bytes_match_declared_mime function). That unit test does NOT lock the
+WIRING: if someone deletes the `if not _audio_bytes_match_declared_mime(...):
+raise 400` call site in the route, the unit test stays green while the spoof
+bug returns. This file closes that gap by driving the real HTTP route.
+
+GCS is mocked so the happy path is reachable — that makes the spoof lock
+precise: with the check present a spoof gets 400; if the check were removed the
+spoof would reach the (mocked) bucket and return 200. The test asserts 400, so
+removing the wiring fails the test.
+
+Run:
+    cd backend && python -m pytest tests/test_testset_upload_route.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+# Public endpoint — no auth override needed.
+client = TestClient(app, raise_server_exceptions=False)
+
+# Real RIFF/WAVE header (>=12 bytes, RIFF at 0, WAVE at 8) — passes magic-bytes.
+REAL_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 20
+SPOOF = b"this is not audio at all, just text pretending to be audio"
+
+
+def _mock_bucket() -> MagicMock:
+    """Bucket whose blob().upload_from_string() succeeds silently."""
+    bucket = MagicMock()
+    blob = MagicMock()
+    blob.upload_from_string.return_value = None
+    bucket.blob.return_value = blob
+    return bucket
+
+
+def _post(audio_bytes: bytes, mime: str, lesson_id: str = "1", version: str = "correct"):
+    return client.post(
+        "/api/testset/upload",
+        data={"contributor_name": "QA-route", "lesson_id": lesson_id, "version": version},
+        files={"audio": (f"x.{mime.split('/')[-1]}", audio_bytes, mime)},
+    )
+
+
+class TestMagicBytesWiring:
+    """The critical lock: spoofed content must be rejected by the ROUTE, not just
+    the pure function. GCS mocked so a removed check would otherwise 200."""
+
+    def test_spoof_wav_rejected_400(self):
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(SPOOF, "audio/wav")
+        assert resp.status_code == 400, resp.text
+        assert "does not match declared type" in resp.json()["detail"]
+
+    def test_spoof_ogg_rejected_400(self):
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(SPOOF, "audio/ogg")
+        assert resp.status_code == 400, resp.text
+        assert "does not match declared type" in resp.json()["detail"]
+
+    def test_real_wav_accepted_200(self):
+        """Valid audio is NOT false-rejected and flows through the route to storage."""
+        bucket = _mock_bucket()
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            resp = _post(REAL_WAV, "audio/wav")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["path"].endswith(".webm")
+        # storage actually invoked (audio blob + meta blob)
+        assert bucket.blob.call_count >= 2
+
+    def test_unsupported_mime_rejected_415(self):
+        """deny-by-default at the MIME whitelist layer (before magic-bytes)."""
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(REAL_WAV, "text/plain")
+        assert resp.status_code == 415, resp.text
+
+    def test_gcs_down_fails_closed_503(self):
+        """Real audio but bucket unavailable → fail-closed 503, never silent pass."""
+        with patch("app.routes.testset._get_gcs_bucket", return_value=None):
+            resp = _post(REAL_WAV, "audio/wav")
+        assert resp.status_code == 503, resp.text

--- a/frontend/public/presentation/reading-pipeline.html
+++ b/frontend/public/presentation/reading-pipeline.html
@@ -402,14 +402,27 @@
 </div>
 <script>
 /* ===== Tab switching ===== */
+function activatePane(id){
+  var btn=document.querySelector('.tab[data-pane="'+id+'"]');
+  var pane=document.getElementById(id);
+  if(!btn||!pane) return false;
+  document.querySelectorAll('.tab').forEach(function(b){b.classList.remove('active')});
+  document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
+  btn.classList.add('active');
+  pane.classList.add('active');
+  return true;
+}
 document.querySelectorAll('.tab').forEach(function(btn){
-  btn.addEventListener('click',function(){
-    document.querySelectorAll('.tab').forEach(function(b){b.classList.remove('active')});
-    document.querySelectorAll('.pane').forEach(function(p){p.classList.remove('active')});
-    btn.classList.add('active');
-    document.getElementById(btn.dataset.pane).classList.add('active');
-  });
+  btn.addEventListener('click',function(){ activatePane(btn.dataset.pane); });
 });
+// 支援用 URL hash 直接開到指定分頁（例：record.html 返回時帶 #testset 回到「④ 測試集」）
+function activatePaneFromHash(){
+  // 淨化 hash（只留英數/底線/連字號）再進 querySelector，避免惡意/畸形 hash 拋 DOMException
+  var id=(location.hash||'').replace('#','').replace(/[^a-z0-9_-]/gi,'');
+  if(id) activatePane(id);
+}
+activatePaneFromHash();
+window.addEventListener('hashchange',activatePaneFromHash);
 
 // ===== Arch animations =====
 function startTypingAnim() {

--- a/frontend/public/testset-7f3a91c4/record.html
+++ b/frontend/public/testset-7f3a91c4/record.html
@@ -34,6 +34,11 @@
   .btn-rec.recording{background:#7f1d1d}
   .btn-up{background:var(--purple);color:#fff;width:100%}
   .btn:disabled{opacity:.4;cursor:not-allowed}
+  /* 上傳音檔途徑（與錄音二選一）*/
+  .or-sep{display:flex;align-items:center;gap:10px;color:var(--muted);font-size:.8rem;margin:12px 0}
+  .or-sep::before,.or-sep::after{content:"";flex:1;height:1px;background:var(--line)}
+  .btn-file{display:block;width:100%;padding:12px;border:1px dashed var(--purple);border-radius:10px;background:var(--chip);color:var(--purple);font-weight:600;text-align:center;cursor:pointer}
+  .btn-file:hover{background:#e6dffb}
   audio{width:100%}
   /* 播放器 + 右側小重錄鈕同列（重錄縮小、不被誤觸）*/
   .player-row{display:flex;align-items:center;gap:8px;margin-top:10px}
@@ -65,6 +70,7 @@
 </head>
 <body>
 <div class="wrap">
+  <a class="back" id="backLink" href="../presentation/reading-pipeline.html#testset">← 返回測試集</a>
   <h1>朗讀錄音貢獻</h1>
   <p class="sub">幫 LingoLeap 蒐集真人朗讀，用於訓練與驗證 AI 朗讀評分。謝謝你！</p>
 
@@ -90,12 +96,17 @@
 
       <!-- 錄音 -->
       <div class="card" id="rec-card">
-        <div class="step">② 照著念 + 錄音</div>
+        <div class="step">② 照著念 + 錄音，或上傳音檔</div>
         <div class="vtabs">
           <div class="vtab sel" data-v="correct" onclick="selVersion('correct')">正確版<span class="hint">盡量念正確</span></div>
           <div class="vtab" data-v="error" onclick="selVersion('error')">刻意錯誤版<span class="hint">故意念錯幾個字</span></div>
         </div>
         <button class="btn btn-rec" id="recBtn" onclick="toggleRec()">● 開始錄音</button>
+        <!-- 上傳既有音檔（mp3/wav）— 與錄音二選一，後續流程一致 -->
+        <div class="or-sep">或</div>
+        <label class="btn-file">📁 選擇 mp3 / wav 檔
+          <input type="file" id="fileInput" accept="audio/mpeg,audio/wav,.mp3,.wav" hidden onchange="onFileSelected(event)">
+        </label>
         <div class="player-row" id="playerRow" style="display:none">
           <audio id="player" controls></audio>
           <button class="btn-rerec" id="reRecBtn" onclick="reRecord()" title="重新錄音">↻ 重錄</button>
@@ -129,14 +140,19 @@ var API=apiBase();
 function qs(key){
   return new URLSearchParams(location.search).get(key);
 }
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 
 var lessonId=qs('lesson')||'';
+
+// 「返回測試集」直接走 <a href> 到 reading-pipeline.html#testset（④ 測試集 分頁）。
+// record.html 是用 target="_blank" 從測試集頁開的新分頁，故用導頁而非 history.back()。
 var VERSIONS=[{k:'correct',n:'正確版'},{k:'error',n:'錯誤版'}];
 var cur={version:'correct'};
 var NAME_KEY='testset_name';
 var done=JSON.parse(localStorage.getItem('testset_done_v2_'+lessonId)||'{}');
 var doneUrls={correct:null,error:null};  // server 簽名播放 URL（聽取用，10 分鐘有效）
 var mediaRec=null,chunks=[],blob=null;
+var blobSource=null;  // 'rec' = 錄音；'file' = 上傳檔 — 決定「重錄/重選」鈕行為與標籤
 
 /* ── 進度：server-truth（換裝置/清快取仍讀得回，localStorage 只當快取） ── */
 async function loadProgress(){
@@ -216,12 +232,48 @@ function selVersion(v){
 }
 
 function resetRec(){
-  blob=null;
+  blob=null; blobSource=null;
   var p=document.getElementById('player'); p.src='';
   document.getElementById('playerRow').style.display='none';
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='';
+  var fi=document.getElementById('fileInput'); if(fi) fi.value='';  // 讓同一檔可重新選取
+  var rr=document.getElementById('reRecBtn'); if(rr){ rr.textContent='↻ 重錄'; rr.title='重新錄音'; }
   var b=document.getElementById('recBtn'); b.style.display=''; b.classList.remove('recording'); b.textContent='● 開始錄音';
+}
+
+/* ── 上傳既有音檔（mp3/wav）── 與錄音共用同一條 upload() 流程 ── */
+var MAX_AUDIO_BYTES=8*1024*1024;  // 與後端 /api/testset/upload 上限一致
+function onFileSelected(ev){
+  var f=ev.target.files&&ev.target.files[0];
+  if(!f) return;
+  // 錄音進行中不接受選檔，避免 blob 被錄音 onstop 覆寫（競爭）
+  if(mediaRec&&mediaRec.state==='recording'){
+    document.getElementById('status').innerHTML='<span class="err">錄音進行中，請先停止錄音再上傳檔案</span>';
+    ev.target.value=''; return;
+  }
+  var nm=(f.name||'').toLowerCase();
+  var isWav=f.type.indexOf('wav')>-1||nm.slice(-4)==='.wav';
+  var isMp3=f.type.indexOf('mpeg')>-1||f.type.indexOf('mp3')>-1||nm.slice(-4)==='.mp3';
+  if(!isWav&&!isMp3){
+    document.getElementById('status').innerHTML='<span class="err">只接受 mp3 或 wav 檔</span>';
+    ev.target.value=''; return;
+  }
+  if(f.size>MAX_AUDIO_BYTES){
+    document.getElementById('status').innerHTML='<span class="err">檔案超過 8MB，請改用較短的音檔</span>';
+    ev.target.value=''; return;
+  }
+  // 正規化 content-type 為後端白名單接受的 MIME（避免 audio/x-wav 之類被擋）
+  var mime=isWav?'audio/wav':'audio/mpeg';
+  blob=new Blob([f],{type:mime}); blobSource='file';
+  // 收起大錄音鈕、顯示播放器預覽 + 開放上傳（與錄完一段後同樣的 UI 狀態）
+  var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
+  document.getElementById('playerRow').style.display='flex';
+  document.getElementById('recBtn').style.display='none';
+  // 來源是檔案 → 小鈕改為「重選」語意（避免「重錄」誤導去開麥克風）
+  var rr=document.getElementById('reRecBtn'); if(rr){ rr.textContent='↻ 重選'; rr.title='重新選擇檔案'; }
+  document.getElementById('upBtn').disabled=false;
+  document.getElementById('status').innerHTML='<span style="color:var(--muted)">已選擇檔案：'+esc(f.name)+'，可上傳</span>';
 }
 
 async function toggleRec(){
@@ -232,7 +284,7 @@ async function toggleRec(){
     chunks=[]; mediaRec=new MediaRecorder(stream);
     mediaRec.ondataavailable=function(e){ if(e.data.size>0) chunks.push(e.data); };
     mediaRec.onstop=function(){
-      blob=new Blob(chunks,{type:'audio/webm'});
+      blob=new Blob(chunks,{type:'audio/webm'}); blobSource='rec';
       var p=document.getElementById('player'); p.src=URL.createObjectURL(blob);
       // 完成：收起大錄音鈕，改顯示「播放器 + 右側小重錄鈕」（避免誤觸重錄）
       document.getElementById('playerRow').style.display='flex';
@@ -252,8 +304,13 @@ async function toggleRec(){
   }
 }
 
-// 重錄：先確認再捨棄目前這段（小鈕在播放器右邊，避免誤觸）
+// 「重錄/重選」：依目前來源決定行為，避免上傳檔時誤開麥克風
 function reRecord(){
+  if(blobSource==='file'){
+    // 來源是上傳檔 → 回到可錄音或重新選檔的狀態，不直接開麥克風
+    resetRec();
+    return;
+  }
   if(!confirm('確定要重錄嗎？目前這段會被捨棄。')) return;
   toggleRec();
 }
@@ -271,11 +328,13 @@ async function upload(){
   localStorage.setItem(NAME_KEY,name);
   document.getElementById('upBtn').disabled=true;
   document.getElementById('status').innerHTML='<span style="color:var(--muted)">上傳中…</span>';
+  // 副檔名跟著實際內容走（錄音=webm；上傳檔=mp3/wav），content-type 由 blob.type 帶出
+  var ext=(blob.type.indexOf('wav')>-1)?'wav':((blob.type.indexOf('mpeg')>-1||blob.type.indexOf('mp3')>-1)?'mp3':'webm');
   var fd=new FormData();
   fd.append('contributor_name',name);
   fd.append('lesson_id',lessonId);
   fd.append('version',cur.version);
-  fd.append('audio',blob,lessonId+'_'+cur.version+'.webm');
+  fd.append('audio',blob,lessonId+'_'+cur.version+'.'+ext);
   try{
     var r=await fetch(API+'/api/testset/upload',{method:'POST',body:fd});
     if(!r.ok){ throw new Error('HTTP '+r.status); }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -69,6 +69,43 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
     }
   };
 
+  /**
+   * Shared quick-login (demo) handler. Logs in with the given demo credentials
+   * (real login — token + session, same as the form), then redirects.
+   * @param redirectTo  override target. When `external` is true the target is a
+   *   static page outside the SPA router (e.g. /presentation/*.html) and must be
+   *   reached via window.location, not react-router navigate().
+   */
+  const quickLogin = async (
+    demoEmail: string,
+    demoPw: string,
+    redirectTo?: { path: string; external?: boolean },
+  ) => {
+    setError('');
+    setIsSubmitting(true);
+    try {
+      const result = await login(demoEmail, demoPw);
+      if (result.mustChangePassword) {
+        navigate('/change-password', { replace: true });
+      } else if (redirectTo?.external) {
+        window.location.href = redirectTo.path;
+      } else {
+        navigate(redirectTo?.path ?? from, { replace: true });
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setError(err.message);
+      } else {
+        setError('登入失敗，請稍後再試');
+      }
+      // Only reset on failure: on success the component unmounts after redirect,
+      // so resetting in a finally block would be a no-op (and could warn on an
+      // unmounted component). The form's handleSubmit uses finally because it
+      // never redirects on the same path.
+      setIsSubmitting(false);
+    }
+  };
+
   const handleGoogleCredential = async (credential: string) => {
     setError('');
     setIsSubmitting(true);
@@ -220,25 +257,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
                   key={acc.email}
                   type="button"
                   disabled={isSubmitting}
-                  onClick={async () => {
-                    setError('');
-                    setIsSubmitting(true);
-                    try {
-                      const result = await login(acc.email, acc.pw);
-                      if (result.mustChangePassword) {
-                        navigate('/change-password', { replace: true });
-                      } else {
-                        navigate(from, { replace: true });
-                      }
-                    } catch (err) {
-                      if (err instanceof AuthError) {
-                        setError(err.message);
-                      } else {
-                        setError('登入失敗');
-                      }
-                      setIsSubmitting(false);
-                    }
-                  }}
+                  onClick={() => quickLogin(acc.email, acc.pw)}
                   className={`border rounded-lg px-2 py-2.5 text-center transition-colors cursor-pointer disabled:opacity-50 ${acc.color}`}
                 >
                   <div className="text-xs font-bold">{acc.label}</div>
@@ -246,6 +265,24 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
                 </button>
               ))}
             </div>
+
+            {/* Reading-test shortcut: real student login, then jump straight to
+                the (hidden) reading-pipeline test page. #2410 */}
+            <button
+              type="button"
+              disabled={isSubmitting}
+              onClick={() =>
+                quickLogin(
+                  import.meta.env.VITE_DEMO_STUDENT_EMAIL ?? '',
+                  import.meta.env.VITE_DEMO_STUDENT_PW ?? '',
+                  { path: '/presentation/reading-pipeline.html', external: true },
+                )
+              }
+              className="mt-2 w-full flex items-center justify-center gap-2 border rounded-lg px-2 py-2.5 text-xs font-bold transition-colors cursor-pointer disabled:opacity-50 bg-purple-50 border-purple-200 text-purple-700 hover:bg-purple-100"
+            >
+              <span className="material-symbols-outlined text-sm">record_voice_over</span>
+              登入朗讀測試頁面
+            </button>
           </div>
         )}
       </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,16 @@ export default defineConfig({
   build: {
     target: 'esnext',
   },
+  // Match the dev dependency pre-bundle target to the build target. Vite's
+  // default optimizeDeps target includes safari14, which makes esbuild attempt
+  // a destructuring down-level it can't do ("Transforming destructuring ... is
+  // not supported yet") on deps like date-fns / d3-array / @floating-ui,
+  // crashing `npm run dev`. esnext skips that lowering entirely. (#2428)
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
> owner-acknowledged 由 Claude AI 代發（非 Young 本人），Young 指示 staging→main 同步

Staging → main 同步。7 commits:

testset upload 資安+品質(本 session,全測過):
- magic-bytes hardening — 驗 5 型真實檔頭 + deny-by-default(真環境 curl spoof→400 驗過)
- route-level TDD lock — mutation-verified
- EDD lock — mp3/wav 過得了轉寫前處理(ffmpeg 實測)
- real-mime fix — batch-eval 傳真 mime,原生格式免多餘 transcode(資安 review SECURE-SHIP)
- record.html mp3/wav 上傳 + 返回鈕(e2e 驗過)
- vite optimizeDeps esnext 修 dev esbuild crash

login:
- quick-login 重構(靖杭)— 把既有 demo 鈕抽共用 helper + 加 reading-test 用。用真登入非 bypass;prod 本來就有 demo 鈕,無新曝露

全部已在 staging 真環境 QA 過。

🤖 Generated with Claude Code