### PR TITLE
release: staging to main — re-gate testset recordings to admin (#2437)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 
-from ..auth.dependencies import get_current_user
+from ..auth.dependencies import get_current_user, require_role
 from ..models.user import User
 from ..services.audio_upload_service import (
     _get_gcs_bucket,
@@ -248,18 +248,19 @@ def testset_progress(name: str = "", lesson: str = ""):
     }
 
 
-@router.get("/testset/recordings")
+@router.get(
+    "/testset/recordings",
+    dependencies=[require_role("system_admin", "org_admin")],
+)
 def testset_recordings():
     """owner list UI 用：列出已收的所有錄音 meta + 10 分鐘播放 signed URL。
 
-    公開（Young 2026-06-21：不需登入即顯示貢獻者暱稱/數量）。暱稱為自選暱稱、
-    朗讀公開課文，非敏感 PII；list.html 現況表不登入就能看到誰貢獻了哪幾課。
-    （此前曾 admin/teacher → 任何登入者 → 現全公開。）
-
-    DECISION NEEDED — auth: 此 endpoint 日後應改為 require_role(system_admin, org_admin)，
-    但 frontend/public/testset-7f3a91c4/dashboard.html 目前無登入/token 機制；
-    現階段加 require_role 會 403 並讓 admin 無法看錄音清單。須先讓 dashboard 接上
-    auth flow 再鎖 endpoint；在此之前維持公開、勿在此加 require_role。
+    Auth: **平台級 admin（system_admin / org_admin）才可看**（#2437, Young 選 C）。
+    錄音是跨校跨課的平台級訓練資料 + signed 播放 URL（可聽真人朗讀）＝ 隱私敏感，
+    收回公開。唯一 caller 是 owner dashboard `collect-status-9f2a7c4e.html`，已送
+    `Authorization: Bearer <lingoleap_token>`；未登入/非 admin → 401/403，該頁顯示登入 banner。
+    公開頁 index.html / record.html 不呼叫此端點，故 re-gate 不影響貢獻者流程。
+    （歷史：admin/teacher → 任何登入者 → 2026-06-21 全公開 → 2026-07-01 收回 system_admin/org_admin。）
     """
     bucket = _get_gcs_bucket()
     if bucket is None:

--- a/backend/tests/test_testset_recordings_auth.py
+++ b/backend/tests/test_testset_recordings_auth.py
@@ -1,0 +1,125 @@
+"""Auth regression lock for GET /api/testset/recordings (#2437).
+
+recordings was re-gated from public to require_role("system_admin", "org_admin")
+(Young chose the tightest bar — testset recordings are platform-level data +
+signed playback URLs = privacy sensitive). This locks the three access states:
+  - no auth             -> 401
+  - logged-in non-admin -> 403
+  - system_admin        -> 200 (GCS mocked)
+
+Run: cd backend && python -m pytest tests/test_testset_recordings_auth.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.dependencies import get_current_user
+
+engine = create_engine(
+    "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+)
+
+
+@event.listens_for(engine, "connect")
+def _pragma(conn, _):
+    cur = conn.cursor(); cur.execute("PRAGMA foreign_keys=ON"); cur.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _fresh_user(uid: int, uname: str) -> User:
+    """A transient (never session-bound) User — safe to return from the
+    get_current_user override without triggering a detached-instance refresh.
+    require_role only reads .id, then queries UserRole by that id."""
+    return User(id=uid, username=uname, name=uname, email=f"{uname}@x.com", password_hash="x")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    for rd in [
+        {"name": "student", "display_name": "Student", "scope_level": "school"},
+        {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+        {"name": "org_admin", "display_name": "Org Admin", "scope_level": "organization"},
+    ]:
+        if not db.query(Role).filter(Role.name == rd["name"]).first():
+            db.add(Role(**rd))
+    db.commit()
+    # persist user rows (FK target for UserRole)
+    db.add_all([_fresh_user(1, "admin_u"), _fresh_user(2, "pleb_u")])
+    db.commit()
+    sa = db.query(Role).filter(Role.name == "system_admin").first()
+    st = db.query(Role).filter(Role.name == "student").first()
+    db.add(UserRole(user_id=1, role_id=sa.id, scope_type="platform", scope_id=None))
+    db.add(UserRole(user_id=2, role_id=st.id, scope_type="school", scope_id="1"))
+    db.commit()
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _wire_db():
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.clear()
+
+
+def _bucket():
+    b = MagicMock()
+    b.list_blobs.return_value = iter([])
+    return b
+
+
+def test_no_auth_returns_401():
+    """No token → require_role's get_current_user raises 401."""
+    with TestClient(app, raise_server_exceptions=False) as c:
+        r = c.get("/api/testset/recordings?lesson_id=1&version=correct")
+    assert r.status_code == 401, r.text
+
+
+def test_non_admin_returns_403():
+    """Logged-in student (no admin role) → 403."""
+    app.dependency_overrides[get_current_user] = lambda: _fresh_user(2, "pleb_u")
+    try:
+        with TestClient(app, raise_server_exceptions=False) as c:
+            r = c.get("/api/testset/recordings?lesson_id=1&version=correct")
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_system_admin_returns_200():
+    """system_admin → 200 (GCS mocked)."""
+    app.dependency_overrides[get_current_user] = lambda: _fresh_user(1, "admin_u")
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_bucket()):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.get("/api/testset/recordings?lesson_id=1&version=correct")
+        assert r.status_code == 200, r.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
+++ b/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
@@ -66,7 +66,7 @@
   <p class="sub">每篇課文各需「正確版 + 刻意錯誤版」— 複製各課分享連結傳給貢獻者錄音</p>
 
   <div id="authBanner" class="auth-banner" style="display:none">
-    錄音明細需要教師/管理員登入才能查看。<a href="/login">前往登入 →</a>
+    錄音明細需要管理員（system_admin / org_admin）登入才能查看。<a href="/login">前往登入 →</a>
     <br><small>各課的「複製連結」功能無需登入，可直接分享給貢獻者。</small>
   </div>
 
@@ -170,7 +170,7 @@ async function load(){
     return;
   }
 
-  // 2. recordings — 公開端點（Young 2026-06-21：不登入也顯示貢獻者暱稱/數量）
+  // 2. recordings — 需 system_admin/org_admin（#2437）；未登入/非 admin → 顯示登入 banner
   var recs=[];
   var authOk=false;
   try{
@@ -181,6 +181,8 @@ async function load(){
       var j2=await r2.json();
       recs=j2.recordings||[];
       authOk=true;
+    }else if(r2.status===401||r2.status===403){
+      document.getElementById('authBanner').style.display='block';
     }
   }catch(e){
     // recordings optional


### PR DESCRIPTION
> owner-acknowledged 由 Claude AI 代發，Young 指示 staging→main 同步

recordings re-gate to require_role(system_admin, org_admin) — 隱私收回。staging 真環境驗過(no-token→401)。零公開破壞(只 collect-status 打 recordings)。test 鎖 401/403/200 + mutation-verified + 資安 review SECURE-SHIP。

🤖 Generated with Claude Code