### PR TITLE
release: staging to main — testset TDD coverage + CI (#2440)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,9 @@ jobs:
           cd backend
           pip install -r requirements.txt
 
+      - name: Install ffmpeg (testset transcode + silence-gate tests)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Run characterization tests (refactor safety gate)
         run: |
           cd backend
@@ -35,6 +38,17 @@ jobs:
             tests/test_characterization_tts_normalization.py \
             tests/test_characterization_tts_cache.py \
             tests/test_rate_limiting.py
+        env:
+          DATABASE_URL: sqlite://
+          TTS_PROVIDER: google
+          AZURE_SPEECH_KEY: ""
+          AZURE_SPEECH_REGION: eastus
+          JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
+
+      - name: Run testset tests (upload security + auth + eval)
+        run: |
+          cd backend
+          python -m pytest --tb=short -q tests/test_testset_*.py
         env:
           DATABASE_URL: sqlite://
           TTS_PROVIDER: google

--- a/backend/tests/test_testset_recordings_auth.py
+++ b/backend/tests/test_testset_recordings_auth.py
@@ -70,12 +70,14 @@ def setup_db():
             db.add(Role(**rd))
     db.commit()
     # persist user rows (FK target for UserRole)
-    db.add_all([_fresh_user(1, "admin_u"), _fresh_user(2, "pleb_u")])
+    db.add_all([_fresh_user(1, "admin_u"), _fresh_user(2, "pleb_u"), _fresh_user(3, "orgadmin_u")])
     db.commit()
     sa = db.query(Role).filter(Role.name == "system_admin").first()
     st = db.query(Role).filter(Role.name == "student").first()
+    oa = db.query(Role).filter(Role.name == "org_admin").first()
     db.add(UserRole(user_id=1, role_id=sa.id, scope_type="platform", scope_id=None))
     db.add(UserRole(user_id=2, role_id=st.id, scope_type="school", scope_id="1"))
+    db.add(UserRole(user_id=3, role_id=oa.id, scope_type="organization", scope_id="1"))
     db.commit()
     db.close()
     yield
@@ -116,6 +118,18 @@ def test_non_admin_returns_403():
 def test_system_admin_returns_200():
     """system_admin → 200 (GCS mocked)."""
     app.dependency_overrides[get_current_user] = lambda: _fresh_user(1, "admin_u")
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_bucket()):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.get("/api/testset/recordings?lesson_id=1&version=correct")
+        assert r.status_code == 200, r.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_org_admin_returns_200():
+    """org_admin (the other allowed role) → 200 (GCS mocked)."""
+    app.dependency_overrides[get_current_user] = lambda: _fresh_user(3, "orgadmin_u")
     try:
         with patch("app.routes.testset._get_gcs_bucket", return_value=_bucket()):
             with TestClient(app, raise_server_exceptions=False) as c:

--- a/backend/tests/test_testset_upload_formats_edd.py
+++ b/backend/tests/test_testset_upload_formats_edd.py
@@ -20,8 +20,8 @@ inefficiency (natively-supported wav/mp3 get an unnecessary transcode), NOT a
 correctness bug. This test catches a regression if a future change to the
 wrong-mime path breaks these formats (e.g. switching ffmpeg to a hard `-f` flag).
 
-ffmpeg required — skips if absent (CI currently installs no ffmpeg; runs locally
-and in any prod-like image where the silence gate already depends on ffmpeg).
+ffmpeg required — the CI pytest job installs ffmpeg (#2440), so this runs in CI;
+skips only where ffmpeg is genuinely absent (e.g. a minimal local shell).
 
 Run: cd backend && python -m pytest tests/test_testset_upload_formats_edd.py -v
 """

--- a/backend/tests/test_testset_upload_route.py
+++ b/backend/tests/test_testset_upload_route.py
@@ -91,3 +91,64 @@ class TestMagicBytesWiring:
         with patch("app.routes.testset._get_gcs_bucket", return_value=None):
             resp = _post(REAL_WAV, "audio/wav")
         assert resp.status_code == 503, resp.text
+
+
+class TestUploadValidation:
+    """Remaining upload validation branches — incl. the lesson_id whitelist
+    (path-injection guard, security #2304)."""
+
+    def test_lesson_id_path_injection_rejected_400(self):
+        """lesson_id outside [A-Za-z0-9_-] whitelist (path traversal) → 400."""
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(REAL_WAV, "audio/wav", lesson_id="../../etc/passwd")
+        assert resp.status_code == 400, resp.text
+        assert "lesson_id" in resp.json()["detail"]
+
+    def test_empty_audio_rejected_400(self):
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(b"", "audio/wav")
+        assert resp.status_code == 400, resp.text
+        assert "empty" in resp.json()["detail"]
+
+    def test_oversize_rejected_413(self):
+        """Size cap fires before magic-bytes (patch cap small to keep payload tiny)."""
+        with patch("app.routes.testset._MAX_AUDIO_BYTES", 8), \
+             patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(REAL_WAV, "audio/wav")  # 32 bytes > 8
+        assert resp.status_code == 413, resp.text
+
+    def test_bad_version_rejected_400(self):
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = _post(REAL_WAV, "audio/wav", version="bogus")
+        assert resp.status_code == 400, resp.text
+        assert "version" in resp.json()["detail"]
+
+    def test_blank_contributor_rejected_400(self):
+        with patch("app.routes.testset._get_gcs_bucket", return_value=_mock_bucket()):
+            resp = client.post(
+                "/api/testset/upload",
+                data={"contributor_name": "  ", "lesson_id": "1", "version": "correct"},
+                files={"audio": ("x.wav", REAL_WAV, "audio/wav")},
+            )
+        assert resp.status_code == 400, resp.text
+        assert "required" in resp.json()["detail"]
+
+
+class TestUploadWritesContentType:
+    """#2434 write side: upload persists the real content_type into meta so
+    batch-eval can pass the true mime (read side locked in test_testset_batch_eval)."""
+
+    def test_meta_records_content_type(self):
+        bucket = MagicMock()
+        blob = MagicMock()
+        bucket.blob.return_value = blob
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            resp = _post(REAL_WAV, "audio/wav")
+        assert resp.status_code == 200, resp.text
+        # the meta upload is the call whose first positional arg is a JSON string
+        meta_jsons = [
+            c.args[0]
+            for c in blob.upload_from_string.call_args_list
+            if c.args and isinstance(c.args[0], str)
+        ]
+        assert any('"content_type": "audio/wav"' in j for j in meta_jsons), meta_jsons


### PR DESCRIPTION
> owner-acknowledged Claude AI 代發,Young 指示同步。test/CI-only(無 prod runtime 影響):testset tests 進 CI + ffmpeg + upload validation/auth/content_type 測試補齊。🤖