### PR TITLE
test(frontend): cover LoginPage in render-smoke (#2443)

### DIFF
--- a/frontend/src/__smoke__/render-smoke.test.tsx
+++ b/frontend/src/__smoke__/render-smoke.test.tsx
@@ -105,6 +105,7 @@ import ComprehensionChat from '../components/reading-steps/ComprehensionChat';
 import VocabWordSearch from '../components/reading-steps/VocabWordSearch';
 import KnowledgeStation from '../components/reading-steps/KnowledgeStation';
 import AssessmentReport from '../components/reading-steps/AssessmentReport';
+import LoginPage from '../pages/LoginPage';
 
 // ── Minimal fixtures ─────────────────────────────────────────────────────────
 
@@ -352,5 +353,15 @@ describe('render-smoke: 12 step components mount without TDZ ReferenceError (#22
 describe('render-smoke: LiveTutorControls — TDZ guard for stopPlaybackSync (#2279)', () => {
   it('LiveTutorControls', () => {
     mountGuard('LiveTutorControls', <LiveTutorControls {...LIVE_TUTOR_CONTROLS_PROPS} />);
+  });
+});
+
+// LoginPage is the only React (src/) component this session touched — #2410 added
+// the quick-login handler. The testset upload UI is static public/ HTML (verified
+// via real-browser e2e, not vitest-testable). This locks LoginPage against a
+// #2279-style mount/TDZ crash.
+describe('render-smoke: LoginPage — quick-login handler mounts without TDZ (#2410)', () => {
+  it('LoginPage', () => {
+    mountGuard('LoginPage', <LoginPage onSwitchToRegister={vi.fn()} />);
   });
 });


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2443

**VITEST 缺口**:render-smoke(#2289 render-safety Gate ①)只鎖 12 reading-step + LiveTutorControls,**沒 LoginPage**。PR 2410 quick-login handler 動了 auth 元件的 login 流程 = #2279-style mount/TDZ 白屏最該鎖處,卻無 vitest。

- testset 上傳 UI(record.html/collect-status.html)= public/ 靜態 HTML → vitest 測不到,走真瀏覽器 e2e 驗
- 唯一 React src/ 元件 = LoginPage → 補進 render-smoke
- render-smoke 13→14 tests,LoginPage mount 無 TDZ;lint 0 errors

這 PR frontend-checks CI 會跑 lint + render-smoke(含新 LoginPage)。

🤖 Generated with Claude Code