### PR TITLE
feat(admin): 側邊欄新增「朗讀測試集」入口 (#2448)

### DIFF
--- a/frontend/src/pages/admin/AdminTreeSidebar.tsx
+++ b/frontend/src/pages/admin/AdminTreeSidebar.tsx
@@ -153,6 +153,17 @@ const AdminTreeSidebar: React.FC<AdminTreeSidebarProps> = ({ selectedNode, onSel
         >
           <UsersIcon />
         </button>
+
+        {/* 朗讀測試集 — 外部集成板（新分頁），與完整側邊欄入口一致 (#2448) */}
+        <a
+          href="/presentation/reading-pipeline.html#testset"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1.5 mt-1 rounded-md transition-colors cursor-pointer text-gray-400 hover:bg-gray-100 hover:text-gray-600 flex items-center justify-center"
+          title="朗讀測試集（錄音 + AI 跑分現況）"
+        >
+          <span className="text-sm" aria-hidden="true">🎙</span>
+        </a>
       </div>
     );
   }

--- a/frontend/src/pages/admin/AdminTreeSidebar.tsx
+++ b/frontend/src/pages/admin/AdminTreeSidebar.tsx
@@ -32,6 +32,9 @@ export type TreeNodeSelection =
 
 type TreeNodeType = TreeNodeSelection['type'];
 
+/** 朗讀測試集集成板（外部靜態頁）— 收合/展開兩處入口共用，避免路徑各硬編一次 (#2448) */
+export const READING_TESTSET_URL = '/presentation/reading-pipeline.html#testset';
+
 interface AdminTreeSidebarProps {
   selectedNode: TreeNodeSelection | null;
   onSelectNode: (node: TreeNodeSelection | null) => void;
@@ -156,9 +159,10 @@ const AdminTreeSidebar: React.FC<AdminTreeSidebarProps> = ({ selectedNode, onSel
 
         {/* 朗讀測試集 — 外部集成板（新分頁），與完整側邊欄入口一致 (#2448) */}
         <a
-          href="/presentation/reading-pipeline.html#testset"
+          href={READING_TESTSET_URL}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label="朗讀測試集"
           className="p-1.5 mt-1 rounded-md transition-colors cursor-pointer text-gray-400 hover:bg-gray-100 hover:text-gray-600 flex items-center justify-center"
           title="朗讀測試集（錄音 + AI 跑分現況）"
         >

--- a/frontend/src/pages/admin/components/AdminTreeActions.tsx
+++ b/frontend/src/pages/admin/components/AdminTreeActions.tsx
@@ -88,6 +88,18 @@ const AdminTreeActions: React.FC<AdminTreeActionsProps> = ({ selectedNode, onSel
         </span>
       </button>
 
+      {/* 朗讀測試集 — 外部集成板（新分頁）。同源開啟，admin 的 token 讓 recordings 直接載入 (#2448) */}
+      <a
+        href="/presentation/reading-pipeline.html#testset"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 w-full px-3 py-2.5 text-left transition-colors cursor-pointer text-gray-500 hover:bg-gray-50 hover:text-gray-700"
+        title="朗讀測試集 — 錄音收集 + AI 跑分現況（新分頁開啟）"
+      >
+        <span className="text-sm shrink-0 w-4 text-center" aria-hidden="true">🎙</span>
+        <span className="text-sm">朗讀測試集</span>
+      </a>
+
       {/* Roles */}
       <button
         onClick={() => onSelectNode({ type: 'roles', id: 'roles' })}

--- a/frontend/src/pages/admin/components/AdminTreeActions.tsx
+++ b/frontend/src/pages/admin/components/AdminTreeActions.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { ShieldIcon, UsersIcon } from '../../../components/icons';
 import { StoriesIcon, TtsAuditIcon, StructureLabIcon } from './AdminTreeIcons';
-import type { TreeNodeSelection } from '../AdminTreeSidebar';
+import { READING_TESTSET_URL, type TreeNodeSelection } from '../AdminTreeSidebar';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -90,7 +90,7 @@ const AdminTreeActions: React.FC<AdminTreeActionsProps> = ({ selectedNode, onSel
 
       {/* 朗讀測試集 — 外部集成板（新分頁）。同源開啟，admin 的 token 讓 recordings 直接載入 (#2448) */}
       <a
-        href="/presentation/reading-pipeline.html#testset"
+        href={READING_TESTSET_URL}
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center gap-2 w-full px-3 py-2.5 text-left transition-colors cursor-pointer text-gray-500 hover:bg-gray-50 hover:text-gray-700"


### PR DESCRIPTION
## 目的

Fixes #2448。自 #2437 起 `/api/testset/recordings` 只放行 `system_admin` / `org_admin`，導致要看朗讀測試集（錄音收集 + AI 跑分現況）只能**手動貼隱藏網址**。本 PR 在管理員頁面加一個入口，一鍵開啟。

## 改動（`frontend/src/pages/admin/`）

- **`AdminTreeActions.tsx`（完整側邊欄底部工具區）**：新增「🎙 朗讀測試集」外部連結（`<a target="_blank" rel="noopener">` → `/presentation/reading-pipeline.html#testset`），樣式比照現有工具鈕（課文管理 / TTS 稽核 / 重點表 QA…）。
- **`AdminTreeSidebar.tsx`（收合 icon 模式）**：加對應 icon-only 入口，兩種模式一致。

## 為什麼放 /admin 且用連結

- `/admin` 本就**只對 `system_admin` / `org_admin` 開放** → 看得到入口者 = 有權限看資料者，與 #2437 完全一致。
- 同網域新分頁開啟 → admin 已登入的 `lingoleap_token` 在 localStorage，collect-status（iframe）自動帶上 → 錄音清單 + 跑分**直接載入、免再登入**。
- 純前端連結：**無新 API、無新 route、無後端改動**，不動 #2437 權限設計。

## Frontend Render-Safety Verification (ui-pr-verify)

- tsc：✅ AdminTree 檔無型別錯誤
- ESLint：✅ 0 errors（22 個皆 pre-existing warnings）
- vitest smoke：✅ 13/13（本機 14 passed）
- admin 元件測試：✅ **80 passed**（含 `AdminTreeSidebar.test.tsx`）
- Preview 實機 console：⬜ 待 preview 部署後在 `/admin` 驗（補留言）

## 嚴重性

🟢 低 — admin 便利性入口，不改權限、不改資料。

Fixes #2448