### PR TITLE
fix(backend): fail-closed grader + cross-org RBAC + reading STT + comprehension (#2450)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ cd backend && pip install -r requirements.txt && uvicorn app.main:app --reload  
 ## QA / 測試登入（重要 — 不要再說「卡登入牆/要帳號」）
 
 **`/login` 頁面直接有一鍵登入按鈕（懶人登入），QA 完全不需要真帳號或密碼。**
-所有環境（staging / preview / prod）的 `/login` 都有三顆 demo 登入鈕：
+⚠️ 僅 **staging / preview** 有 demo 登入鈕（`VITE_SHOW_DEMO_LOGIN=true`）；**production 已停用**（`deploy.yml` 設 `VITE_SHOW_DEMO_LOGIN=false`，按鈕 tree-shake 掉，verified 2026-07-02）。所以 QA 用 **staging** 一鍵登入，別在 prod /login 找 demo 鈕：
 
 | 按鈕 | 角色 | 用途 |
 |------|------|------|
@@ -295,7 +295,8 @@ private/omo-real-samples/2026-05-18-batch-results/
 | `backend/app/services/dictionary_service.py` | 字典查詢服務 |
 | `backend/app/services/input_sanitizer.py` | 輸入消毒 |
 | `backend/app/routes/` | API 路由（140+ endpoints：auth, classrooms, assignments, learning, teacher, gamification, parents, dictionary, feedback, jobs, privacy） |
-| `backend/data/lessons/` | 課文 YAML 來源檔（57 篇） |
+| `backend/data/curriculum/` | 現行課程 SOT（**158 課** + `manifest.yml` 158 entries，verified 2026-07-02） |
+| `backend/data/lessons/` | legacy 課文 YAML 來源檔（57 篇，舊；現行看 `data/curriculum/`） |
 
 ## 簡報資料（公開，不需登入）
 
@@ -308,3 +309,8 @@ private/omo-real-samples/2026-05-18-batch-results/
 ## 參考專案
 
 方大哥的原始實作：`github.com/Shinjou/lingoleap-ai-reading-tutor`（唯讀參考，不修改）
+
+## 架構地圖（graphify）
+
+`graphify-out/graph.json`（gitignored，本地）— 問「架構/誰呼叫誰/改這會動到誰/資料流」時**優先讀圖**（`/graphify query "..."` 或直接讀 JSON），不要冷 grep 全 repo
+code 大改後重建：`graphify . --update`｜批次腳本：job repo `scripts/build-repo-graphs.sh`

--- a/backend/app/auth/policies.py
+++ b/backend/app/auth/policies.py
@@ -15,7 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def is_admin(user_id: int, db: Session) -> bool:
-    """Return True if user has system_admin or org_admin role."""
+    """Return True if user has system_admin or org_admin role.
+
+    NOTE: this includes org_admin, so it must NOT be used as a *global* bypass in
+    contexts that require organization-scope isolation (cross-org reads). Using it
+    that way lets an org_admin skip org-scoping and read other orgs' data (個資法
+    §20 violation). For a global bypass, use ``is_system_admin`` and let org_admin
+    fall through to the org-scope check.
+    """
     return (
         db.query(UserRole)
         .join(Role)
@@ -23,6 +30,24 @@ def is_admin(user_id: int, db: Session) -> bool:
             UserRole.user_id == user_id,
             UserRole.is_active == True,
             Role.name.in_(["system_admin", "org_admin"]),
+        )
+        .first()
+    ) is not None
+
+
+def is_system_admin(user_id: int, db: Session) -> bool:
+    """Return True only if the user has an active system_admin role.
+
+    Use this (not ``is_admin``) for the global bypass in org-scope-sensitive
+    checks: system_admin sees everything, org_admin must stay within its org.
+    """
+    return (
+        db.query(UserRole)
+        .join(Role)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            Role.name == "system_admin",
         )
         .first()
     ) is not None

--- a/backend/app/auth/policies.py
+++ b/backend/app/auth/policies.py
@@ -8,7 +8,7 @@ import logging
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from ..models.school import Classroom, ClassroomStudent, ClassroomTeacher
+from ..models.school import Classroom, ClassroomStudent, ClassroomTeacher, School
 from ..models.user import Role, User, UserRole
 
 logger = logging.getLogger(__name__)
@@ -51,6 +51,49 @@ def is_system_admin(user_id: int, db: Session) -> bool:
         )
         .first()
     ) is not None
+
+
+def resolve_user_org_ids(user_id: int, db: Session) -> set[str]:
+    """Resolve ALL organization ids a user belongs to (as a set of str org ids).
+
+    Handles the production scoping model: students/teachers carry a SCHOOL-scoped
+    UserRole (scope_type="school", scope_id=str(school.id)), NOT a direct org role,
+    so their org is derived via School.organization_id. org_admin/org_owner carry
+    org-scoped roles (scope_type="organization"), resolved directly. Returns the
+    union of both.
+
+    Using only org-scoped roles (the old approach) wrongly returned an empty set
+    for a real school-scoped student, which over-restricted org_admins out of
+    their OWN org's data. Always resolve through school→org for correctness.
+    """
+    org_ids: set[str] = set()
+    school_ids: set[int] = set()
+    rows = (
+        db.query(UserRole.scope_type, UserRole.scope_id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            UserRole.scope_id.isnot(None),
+        )
+        .all()
+    )
+    for scope_type, scope_id in rows:
+        if scope_type == "organization":
+            org_ids.add(str(scope_id))
+        elif scope_type == "school":
+            try:
+                school_ids.add(int(scope_id))
+            except (TypeError, ValueError):
+                continue
+    if school_ids:
+        schools = (
+            db.query(School.organization_id)
+            .filter(School.id.in_(school_ids), School.organization_id.isnot(None))
+            .all()
+        )
+        for (org_id,) in schools:
+            org_ids.add(str(org_id))
+    return org_ids
 
 
 def require_classroom_owner(classroom: Classroom, user: User, db: Session) -> None:

--- a/backend/app/dependencies/tenant.py
+++ b/backend/app/dependencies/tenant.py
@@ -129,6 +129,39 @@ def _check_org_admin(user: User, org_id: str, db: Session) -> None:
     )
 
 
+def get_owned_resource_or_403(
+    db: Session,
+    model: Any,
+    resource_id: Any,
+    user_id: int,
+    *,
+    not_found_detail: str = "Not found",
+    forbidden_detail: str = "Forbidden",
+    owner_attr: str = "teacher_id",
+) -> Any:
+    """Load a row by id and assert the caller owns it, else raise.
+
+    Consolidates the "fetch by id → 404 if missing → 403 if not mine" guard that
+    was duplicated inline across teacher-owned-resource handlers.
+
+    Behavior is kept byte-identical to the inline guards it replaces:
+      - 404 if no row with ``resource_id`` exists
+      - 403 if ``getattr(row, owner_attr)`` != ``user_id``
+      - returns the ORM row otherwise
+
+    NOTE: intentionally has NO system_admin bypass. The call sites this replaces
+    (teacher instruction update/delete) grant access strictly to the owning
+    teacher; adding an admin bypass here would silently widen access. If a caller
+    needs admin bypass, it must opt in explicitly at the call site.
+    """
+    obj = db.query(model).filter(model.id == resource_id).first()
+    if obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+    if getattr(obj, owner_attr) != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=forbidden_detail)
+    return obj
+
+
 def _check_classroom_access(user: User, classroom_id: int, db: Session) -> Classroom:
     """Verify the user can access the given classroom.
 

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -9,10 +9,12 @@ Endpoints:
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, joinedload
 
 from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
-from ..auth.policies import is_system_admin
+from ..auth.policies import is_system_admin, resolve_user_org_ids
+from ..models.school import School
 from ..database import get_db
 from ..models.feedback import Feedback
 from ..models.user import User, UserRole
@@ -82,20 +84,37 @@ def _get_feedback_org_scope_filter(current_user: User, db: Session):
     if is_system_admin(current_user.id, db):
         return None  # no restriction (org_admin falls through to org-scope filter)
 
-    caller_org_ids = get_user_org_ids(current_user) or []
+    caller_org_ids = resolve_user_org_ids(current_user.id, db)
     if not caller_org_ids:
         # org_admin with no org scope → sees nothing
         return Feedback.id.in_([])
 
-    # Subquery: user_ids whose org scope overlaps with caller's orgs.
-    # Use .scalar_subquery() to avoid SAWarning when used inside .in_().
+    # Submitters in the caller's org(s): via a direct org-scoped role OR a
+    # school-scoped role whose school is in the org (production model, where
+    # students/teachers are school-scoped). Use .scalar_subquery() to avoid a
+    # SAWarning when used inside .in_().
+    caller_school_ids = [
+        str(sid)
+        for (sid,) in db.query(School.id)
+        .filter(School.organization_id.in_(caller_org_ids))
+        .all()
+    ]
+    scope_predicates = [
+        and_(
+            UserRole.scope_type == "organization",
+            UserRole.scope_id.in_(list(caller_org_ids)),
+        )
+    ]
+    if caller_school_ids:
+        scope_predicates.append(
+            and_(
+                UserRole.scope_type == "school",
+                UserRole.scope_id.in_(caller_school_ids),
+            )
+        )
     submitter_ids_subq = (
         db.query(UserRole.user_id)
-        .filter(
-            UserRole.is_active == True,
-            UserRole.scope_type == "organization",
-            UserRole.scope_id.in_(caller_org_ids),
-        )
+        .filter(UserRole.is_active == True, or_(*scope_predicates))
         .scalar_subquery()
     )
     return Feedback.user_id.in_(submitter_ids_subq)
@@ -175,27 +194,13 @@ def update_feedback_status(
             detail=f"Feedback #{feedback_id} not found",
         )
 
-    # Scope check: org_admin may only modify feedback from their org's users
+    # Scope check: org_admin may only modify feedback from their org's users.
+    # Resolve submitter org via school->org (production model). Fail closed if the
+    # caller has no org or the submitter is outside it.
     if not is_system_admin(current_user.id, db):
-        caller_org_ids = set(get_user_org_ids(current_user) or [])
-        if caller_org_ids:
-            # Check if the feedback submitter belongs to any of caller's orgs
-            submitter_in_org = (
-                db.query(UserRole)
-                .filter(
-                    UserRole.user_id == feedback.user_id,
-                    UserRole.is_active == True,
-                    UserRole.scope_type == "organization",
-                    UserRole.scope_id.in_(caller_org_ids),
-                )
-                .first()
-            )
-            if not submitter_in_org:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Not authorized to modify this feedback",
-                )
-        else:
+        caller_org_ids = resolve_user_org_ids(current_user.id, db)
+        submitter_org_ids = resolve_user_org_ids(feedback.user_id, db)
+        if not (caller_org_ids & submitter_org_ids):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not authorized to modify this feedback",

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
 from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
-from ..auth.policies import is_admin
+from ..auth.policies import is_system_admin
 from ..database import get_db
 from ..models.feedback import Feedback
 from ..models.user import User, UserRole
@@ -79,8 +79,8 @@ def _get_feedback_org_scope_filter(current_user: User, db: Session):
 
     Feedback has no direct org FK, so we join via the submitter's UserRole.
     """
-    if is_admin(current_user.id, db):
-        return None  # no restriction
+    if is_system_admin(current_user.id, db):
+        return None  # no restriction (org_admin falls through to org-scope filter)
 
     caller_org_ids = get_user_org_ids(current_user) or []
     if not caller_org_ids:
@@ -176,7 +176,7 @@ def update_feedback_status(
         )
 
     # Scope check: org_admin may only modify feedback from their org's users
-    if not is_admin(current_user.id, db):
+    if not is_system_admin(current_user.id, db):
         caller_org_ids = set(get_user_org_ids(current_user) or [])
         if caller_org_ids:
             # Check if the feedback submitter belongs to any of caller's orgs

--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user, get_user_org_ids
-from ..auth.policies import is_system_admin
+from ..auth.policies import is_system_admin, resolve_user_org_ids
 from ..database import get_db
 from ..models.school import Classroom, ClassroomStudent, School
 from ..models.user import User, UserRole
@@ -104,10 +104,12 @@ def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
     if is_system_admin(current_user.id, db):
         return
 
-    # org_admin / org_owner: must share at least one org with the student
-    caller_org_ids = set(get_user_org_ids(current_user) or [])
+    # org_admin / org_owner: must share at least one org with the student.
+    # Resolve via school->org so school-scoped students (the production model,
+    # where students carry scope_type="school") are matched to their org_admin.
+    caller_org_ids = resolve_user_org_ids(current_user.id, db)
     if caller_org_ids:
-        student_org_ids = _get_user_org_ids_from_db(student_id, db)
+        student_org_ids = resolve_user_org_ids(student_id, db)
         if caller_org_ids & student_org_ids:
             return
 

--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user, get_user_org_ids
-from ..auth.policies import is_admin
+from ..auth.policies import is_system_admin
 from ..database import get_db
 from ..models.school import Classroom, ClassroomStudent, School
 from ..models.user import User, UserRole
@@ -100,8 +100,8 @@ def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
     if is_teacher:
         return
 
-    # system_admin bypasses all scope checks
-    if is_admin(current_user.id, db):
+    # system_admin bypasses all scope checks (org_admin must stay org-scoped below)
+    if is_system_admin(current_user.id, db):
         return
 
     # org_admin / org_owner: must share at least one org with the student
@@ -203,8 +203,8 @@ def get_leaderboard(
         is not None
     )
     if not is_teacher and not is_student:
-        # system_admin bypasses all scope checks
-        if is_admin(current_user.id, db):
+        # system_admin bypasses all scope checks (org_admin must stay org-scoped below)
+        if is_system_admin(current_user.id, db):
             pass  # allowed
         else:
             # org_admin / org_owner: classroom's school must belong to caller's org

--- a/backend/app/routes/learning/learning_strategy.py
+++ b/backend/app/routes/learning/learning_strategy.py
@@ -11,8 +11,12 @@ LLM hardening rules applied (llm-endpoint-hardening skill):
   - Auth: Depends(get_current_user)
   - Input cap: question max 1000, student_answer max 500 (Pydantic Field constraints)
   - Output cap: max_output_tokens=1024 (set in validate_strategy_answer)
-  - Fail-closed: on AI error return is_correct=true + neutral 已記錄 feedback so the
-    student is never blocked by an AI outage (the step is non-gating)
+  - Fail-OPEN (intentional): on AI error return is_correct=true + neutral 已記錄
+    feedback so the student is never blocked by an AI outage. This is safe ONLY
+    because this spotlight step is non-gating and its is_correct is never persisted
+    as a score or used to unlock progress. If this step ever becomes gating/scored,
+    switch to fail-closed (is_correct=false) — auto-passing on error would then be
+    a real bug (platform invariant: never auto-pass a graded step on AI failure).
 """
 
 import logging
@@ -63,7 +67,8 @@ async def validate_strategy(
 
     Lenient grading (七八成對 = 正向回饋). Returns encouraging feedback plus a
     gentle hint when off-track. Rate limited: 10 requests per minute per user.
-    Fail-closed: never blocks the student on an AI outage.
+    Fail-OPEN (intentional, non-gating): never blocks the student on an AI outage
+    — safe only because is_correct is not persisted as a score here.
     """
     start_time = time.monotonic()
     try:
@@ -76,7 +81,9 @@ async def validate_strategy(
         )
     except Exception as e:
         logger.error("validate_strategy error: %s", e)
-        # Fail-closed toward the student: record the answer, don't block progress.
+        # Fail-OPEN (intentional, non-gating step): record the answer, don't block
+        # progress on an AI outage. Safe only because is_correct is not persisted
+        # as a score here — see module docstring.
         return ValidateStrategyResponse(
             is_correct=True,
             feedback="已記錄你的答案，做得好！",

--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -251,7 +251,10 @@ async def validate_sentence(
     )
 
     return ValidateSentenceResponse(
-        is_correct=result.get("is_correct", True),
+        # Fail closed: if the grader omits the verdict, do NOT auto-pass the
+        # student. A missing is_correct means an ambiguous/malformed response,
+        # which must default to False (never mark a sentence correct by default).
+        is_correct=result.get("is_correct", False),
         feedback=result.get("feedback", "做得好！"),
         suggestion=result.get("suggestion", ""),
     )

--- a/backend/app/routes/teacher/teacher_instructions.py
+++ b/backend/app/routes/teacher/teacher_instructions.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user
 from ...database import get_db
-from ...dependencies.tenant import _check_classroom_access
+from ...dependencies.tenant import _check_classroom_access, get_owned_resource_or_403
 from ...models.school import Classroom, ClassroomStudent
 from ...models.teacher_instruction import TeacherInstruction
 from ...models.user import User
@@ -181,15 +181,11 @@ def update_instruction(
     db: Session = Depends(get_db),
 ):
     """Update an instruction. Only the teacher who created it can update."""
-    instruction = (
-        db.query(TeacherInstruction)
-        .filter(TeacherInstruction.id == instruction_id)
-        .first()
+    instruction = get_owned_resource_or_403(
+        db, TeacherInstruction, instruction_id, current_user.id,
+        not_found_detail="Instruction not found",
+        forbidden_detail="Not your instruction",
     )
-    if not instruction:
-        raise HTTPException(status_code=404, detail="Instruction not found")
-    if instruction.teacher_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not your instruction")
 
     # Validate instruction_type if provided
     if payload.instruction_type is not None and payload.instruction_type not in VALID_INSTRUCTION_TYPES:
@@ -223,15 +219,11 @@ def delete_instruction(
     db: Session = Depends(get_db),
 ):
     """Soft-delete an instruction by setting is_active = False."""
-    instruction = (
-        db.query(TeacherInstruction)
-        .filter(TeacherInstruction.id == instruction_id)
-        .first()
+    instruction = get_owned_resource_or_403(
+        db, TeacherInstruction, instruction_id, current_user.id,
+        not_found_detail="Instruction not found",
+        forbidden_detail="Not your instruction",
     )
-    if not instruction:
-        raise HTTPException(status_code=404, detail="Instruction not found")
-    if instruction.teacher_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not your instruction")
 
     instruction.is_active = False
     db.commit()

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -3,11 +3,13 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
-from ..auth.policies import is_system_admin
+from ..auth.policies import is_system_admin, resolve_user_org_ids
+from ..models.school import School
 from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
@@ -190,22 +192,39 @@ def list_users(
     query = db.query(User)
 
     # Scope restriction: org_admin may only see users within their org(s).
-    # system_admin (get_user_org_ids returns None) skips this filter.
-    # org_admin is NOT global — it must fall through and be org-scoped.
+    # system_admin bypasses; org_admin is NOT global — it must be org-scoped.
     if not is_system_admin(current_user.id, db):
-        caller_org_ids = get_user_org_ids(current_user)  # list[str], never None here
+        caller_org_ids = resolve_user_org_ids(current_user.id, db)
         if not caller_org_ids:
             # org_admin with no org scope → see nothing
             return UserListResponse(items=[], total=0)
-        # Keep only users who have at least one active org-scoped role
-        # matching one of the caller's orgs.
+        # Keep users who belong to one of the caller's orgs — via a direct
+        # org-scoped role OR a school-scoped role whose school is in the org
+        # (students/teachers are school-scoped in the production model).
+        caller_school_ids = [
+            str(sid)
+            for (sid,) in db.query(School.id)
+            .filter(School.organization_id.in_(caller_org_ids))
+            .all()
+        ]
+        scope_predicates = [
+            and_(
+                UserRole.scope_type == "organization",
+                UserRole.scope_id.in_(list(caller_org_ids)),
+            )
+        ]
+        if caller_school_ids:
+            scope_predicates.append(
+                and_(
+                    UserRole.scope_type == "school",
+                    UserRole.scope_id.in_(caller_school_ids),
+                )
+            )
         query = query.filter(
             User.id.in_(
-                db.query(UserRole.user_id)
-                .filter(
+                db.query(UserRole.user_id).filter(
                     UserRole.is_active == True,
-                    UserRole.scope_type == "organization",
-                    UserRole.scope_id.in_(caller_org_ids),
+                    or_(*scope_predicates),
                 )
             )
         )
@@ -267,13 +286,10 @@ def get_user_detail(
         raise HTTPException(status_code=404, detail="User not found")
 
     # Scope check for org_admin: target user must share at least one org with caller.
+    # Resolve via school->org so school-scoped targets (production model) match.
     if not is_system_admin(current_user.id, db):
-        caller_org_ids = set(get_user_org_ids(current_user) or [])
-        target_org_ids = {
-            ur.scope_id
-            for ur in user.user_roles
-            if ur.is_active and ur.scope_type == "organization" and ur.scope_id
-        }
+        caller_org_ids = resolve_user_org_ids(current_user.id, db)
+        target_org_ids = resolve_user_org_ids(user.id, db)
         if not (caller_org_ids & target_org_ids):
             raise HTTPException(
                 status_code=403,

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
-from ..auth.policies import is_admin
+from ..auth.policies import is_system_admin
 from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
@@ -191,7 +191,8 @@ def list_users(
 
     # Scope restriction: org_admin may only see users within their org(s).
     # system_admin (get_user_org_ids returns None) skips this filter.
-    if not is_admin(current_user.id, db):
+    # org_admin is NOT global — it must fall through and be org-scoped.
+    if not is_system_admin(current_user.id, db):
         caller_org_ids = get_user_org_ids(current_user)  # list[str], never None here
         if not caller_org_ids:
             # org_admin with no org scope → see nothing
@@ -266,7 +267,7 @@ def get_user_detail(
         raise HTTPException(status_code=404, detail="User not found")
 
     # Scope check for org_admin: target user must share at least one org with caller.
-    if not is_admin(current_user.id, db):
+    if not is_system_admin(current_user.id, db):
         caller_org_ids = set(get_user_org_ids(current_user) or [])
         target_org_ids = {
             ur.scope_id

--- a/backend/app/services/ai_comprehension.py
+++ b/backend/app/services/ai_comprehension.py
@@ -192,6 +192,30 @@ COMPREHENSION_SCORE_SCHEMA = {
 }
 
 
+def _apply_clamping(result: dict) -> dict:
+    """Clamp comprehension scores to [0,100] and fill missing values sensibly.
+
+    - literal/inferential/evaluative: missing → 50 (neutral mid-point, NEVER 0 —
+      a missing sub-score means the layer wasn't assessed or the AI omitted it,
+      and 0 would unfairly penalise the student for an AI failure).
+    - comprehension_score (overall): if the model omitted it, DERIVE it from the
+      sub-scores using the documented weighting (字面 30% + 推論 40% + 評鑑 30%)
+      instead of a flat 50 — faithful to the sub-scores when they exist. In the
+      all-missing case the subs are 50, so this still yields the neutral 50.
+    """
+    for key in ("literal_score", "inferential_score", "evaluative_score"):
+        result[key] = max(0.0, min(100.0, float(result.get(key, 50))))
+    overall = result.get("comprehension_score")
+    if overall is None:
+        overall = (
+            0.3 * result["literal_score"]
+            + 0.4 * result["inferential_score"]
+            + 0.3 * result["evaluative_score"]
+        )
+    result["comprehension_score"] = round(max(0.0, min(100.0, float(overall))), 1)
+    return result
+
+
 async def evaluate_comprehension(
     dialogue_turns: list[dict],
     story_context: dict,
@@ -252,9 +276,4 @@ async def evaluate_comprehension(
         task="comprehension_score",
     )
 
-    # Clamp scores to 0-100 range
-    for key in ("comprehension_score", "literal_score", "inferential_score", "evaluative_score"):
-        val = result.get(key, 50)
-        result[key] = max(0, min(100, float(val)))
-
-    return result
+    return _apply_clamping(result)

--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -25,6 +25,7 @@ Extracted helpers (issue #1879):
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -36,9 +37,38 @@ from .omo_crop_upload import _crop_and_upload, _crop_and_upload_answer_image  # 
 
 logger = logging.getLogger(__name__)
 
-# Circuit breaker state (module-level singleton, per-process)
+# Circuit breaker state (module-level singleton, per-process).
+# Time-based half-open: after THRESHOLD consecutive errors the breaker fast-fails,
+# but only until COOLDOWN_SECONDS elapse. After that a probe call is allowed
+# through so a recovered Vertex AI can reset the breaker — otherwise 3 transient
+# errors would wedge grading OFF until the Cloud Run instance restarts, because
+# the success-reset lives *after* the Gemini call the guard was blocking.
 _consecutive_errors = 0
+_circuit_open_until = 0.0  # monotonic deadline; breaker is open while now < this
 _CIRCUIT_BREAKER_THRESHOLD = 3
+_CIRCUIT_BREAKER_COOLDOWN_SECONDS = 30.0
+
+
+def _breaker_is_open() -> bool:
+    """True while the breaker is tripped AND still inside its cooldown window."""
+    return (
+        _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD
+        and time.monotonic() < _circuit_open_until
+    )
+
+
+def _record_grader_error() -> None:
+    """Count one failure and (re)arm the cooldown window."""
+    global _consecutive_errors, _circuit_open_until
+    _consecutive_errors += 1
+    _circuit_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN_SECONDS
+
+
+def _reset_grader_breaker() -> None:
+    """Clear breaker state after a successful (or mock) grade."""
+    global _consecutive_errors, _circuit_open_until
+    _consecutive_errors = 0
+    _circuit_open_until = 0.0
 
 
 @dataclass
@@ -86,11 +116,11 @@ async def grade_worksheet_images(
     Raises:
         RuntimeError: If circuit breaker threshold is reached (3 consecutive errors).
     """
-    global _consecutive_errors
-
-    if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
+    if _breaker_is_open():
+        retry_in = max(0.0, _circuit_open_until - time.monotonic())
         raise RuntimeError(
-            f"OMO grader circuit breaker open after {_CIRCUIT_BREAKER_THRESHOLD} consecutive errors"
+            f"OMO grader circuit breaker open after {_CIRCUIT_BREAKER_THRESHOLD} "
+            f"consecutive errors; retry in {retry_in:.0f}s"
         )
 
     questions = _build_question_schema(lesson)
@@ -106,7 +136,7 @@ async def grade_worksheet_images(
         from google.genai import types as genai_types
     except ImportError:
         logger.warning("google-genai not available — returning mock grades for local dev")
-        _consecutive_errors = 0
+        _reset_grader_breaker()
         return _mock_grades(questions, attempt_id)
 
     _grader_model, _grader_location = get_model_for_task("omo_grader")
@@ -171,13 +201,13 @@ async def grade_worksheet_images(
             timeout=120,  # #1717: thinking enabled — give it room (was 60)
         )
     except asyncio.TimeoutError:
-        _consecutive_errors += 1
-        logger.error("OMO grader timeout after 60s (consecutive_errors=%d)", _consecutive_errors)
+        _record_grader_error()
+        logger.error("OMO grader timeout after 120s (consecutive_errors=%d)", _consecutive_errors)
         if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
             raise RuntimeError("OMO grader circuit breaker opened")
         return []
     except Exception as exc:
-        _consecutive_errors += 1
+        _record_grader_error()
         logger.error("OMO grader Gemini call failed: %s (consecutive_errors=%d)", exc, _consecutive_errors)
         if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
             raise RuntimeError("OMO grader circuit breaker opened")
@@ -193,14 +223,14 @@ async def grade_worksheet_images(
         if not isinstance(items, list):
             raise ValueError(f"Expected list, got {type(items)}")
     except Exception as exc:
-        _consecutive_errors += 1
+        _record_grader_error()
         logger.error("OMO grader JSON parse failed: %s (consecutive_errors=%d)", exc, _consecutive_errors)
         if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
             raise RuntimeError("OMO grader circuit breaker opened")
         return []
 
     # Reset circuit breaker on success
-    _consecutive_errors = 0
+    _reset_grader_breaker()
 
     # Lookup table: question_id → full question dict (for validation + scoring)
     qmap = {q["id"]: q for q in questions}

--- a/backend/app/services/reading_transcription_service.py
+++ b/backend/app/services/reading_transcription_service.py
@@ -86,6 +86,7 @@ _REASON_EMPTY     = "empty"
 _REASON_ERROR     = "error"
 _REASON_HALLUCINATION = "hallucination"  # Issue #2321 — Gemini hallucinated hint text
 _REASON_SILENT = "silent"                # Issue #2368 — deterministic no-speech energy gate
+_REASON_TRUNCATED = "truncated"          # output hit MAX_TOKENS → transcript JSON cut off
 
 # Issue #2368 — server-side silence / energy gate.
 # Gemini parrots the FULL reference text on silent / no-speech audio (it is given
@@ -122,6 +123,19 @@ def _strip_cjk_punctuation(text: str) -> str:
     """
     import re
     return re.sub(r'[\s　、-〿＀-￯‘-‟。，！？；：、─—…「」『』（）]', '', text)
+
+
+def _transcription_max_tokens(target_text: str) -> int:
+    """Size the transcription output budget to the reading length.
+
+    The response is JSON {transcript, reasoning} where transcript ≈ the full
+    reading (target_text up to ~3000 chars). A hardcoded 1024 truncated long
+    readings → the JSON was cut off → JSONDecodeError → silent generic-error
+    fallback (student had to re-read). Scale to the target length (≈2 output
+    tokens per CJK char) plus a buffer for the reasoning field, clamped to a
+    safe ceiling so cost/latency stay bounded.
+    """
+    return max(1024, min(8192, len(target_text or "") * 2 + 512))
 
 
 def _is_hallucination_transcript(transcript: str, target_text: str) -> bool:
@@ -410,7 +424,7 @@ async def transcribe_reading_audio(
                     system_instruction=system_prompt,
                     response_mime_type="application/json",
                     response_schema=response_schema,
-                    max_output_tokens=1024,
+                    max_output_tokens=_transcription_max_tokens(target_text),
                     temperature=0.1,  # low temp for transcription accuracy
                     thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
                     automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
@@ -422,6 +436,31 @@ async def transcribe_reading_audio(
         )
 
         _check_safety_filter(response)
+
+        # Explicit MAX_TOKENS detection: a truncated response yields cut-off JSON
+        # that would otherwise raise JSONDecodeError below and degrade to a
+        # generic-error fallback with no signal that the token budget was the
+        # cause. Surface it as its own reason (the dynamic budget above makes this
+        # rare). Fail-safe: never score against a partial transcript.
+        _finish_reason = ""
+        try:
+            if response.candidates:
+                _finish_reason = str(response.candidates[0].finish_reason)
+        except Exception:
+            _finish_reason = ""
+        if "MAX_TOKENS" in _finish_reason:
+            logger.warning(
+                "Reading transcription fallback — MAX_TOKENS truncation: duration_ms=%s target_len=%d",
+                duration_ms,
+                len(target_text),
+                extra={
+                    "event": "reading_transcribe_fallback",
+                    "reason": _REASON_TRUNCATED,
+                    "duration_ms": duration_ms,
+                    "target_len": len(target_text),
+                },
+            )
+            return {"transcript": None, "method": "fallback", "reason": _REASON_TRUNCATED}
 
         import json as _json
         raw = response.text

--- a/backend/specs/test_comprehension_grading_spec.py
+++ b/backend/specs/test_comprehension_grading_spec.py
@@ -32,15 +32,11 @@ def _import_schema():
 
 
 # ---------------------------------------------------------------------------
-# The clamping logic extracted verbatim from ai_comprehension.py L256-258.
+# Import the REAL clamping helper from production (was a hand-copy before) so
+# these contracts test the actual code path used by evaluate_comprehension().
 # ---------------------------------------------------------------------------
 
-def _apply_clamping(result: dict) -> dict:
-    """Mirror of the production score-clamping loop in evaluate_comprehension()."""
-    for key in ("comprehension_score", "literal_score", "inferential_score", "evaluative_score"):
-        val = result.get(key, 50)
-        result[key] = max(0, min(100, float(val)))
-    return result
+from app.services.ai_comprehension import _apply_clamping  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +165,20 @@ def test_clamping_missing_key_default_is_not_zero():
     result = _apply_clamping({})
     for key in ("comprehension_score", "literal_score", "inferential_score", "evaluative_score"):
         assert result[key] != 0.0, f"{key} default must be 50, not 0"
+
+
+def test_missing_overall_is_derived_from_subscores_not_flat_50():
+    """When the model returns sub-scores but omits comprehension_score, the overall
+    is DERIVED from the documented weighting (字面30%+推論40%+評鑑30%), not a flat 50 —
+    faithful to the sub-scores that ARE present. All-missing still yields 50."""
+    result = _apply_clamping({
+        "literal_score": 80.0,
+        "inferential_score": 60.0,
+        "evaluative_score": 40.0,
+        # comprehension_score intentionally omitted
+    })
+    assert result["comprehension_score"] == 60.0  # 0.3*80 + 0.4*60 + 0.3*40
+    assert _apply_clamping({})["comprehension_score"] == 50.0  # neutral in all-missing case
 
 
 def test_clamping_missing_key_default_is_not_100():

--- a/backend/tests/test_org_admin_scope_security.py
+++ b/backend/tests/test_org_admin_scope_security.py
@@ -37,6 +37,8 @@ from app.main import app
 from app.database import get_db
 from app.models import Base
 from app.models.user import Role, User, UserRole
+from app.models.school import School
+from app.models.organization import Organization
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +172,27 @@ def _assign_org_role(user_id: int, role_name: str, org_id: str) -> None:
     _assign_role(user_id, role_name, scope_type="organization", scope_id=org_id)
 
 
+def _create_org_and_school(org_id: str) -> int:
+    """Create an Organization(id=org_id) + a School in it. Returns the school id.
+
+    Mirrors the PRODUCTION scoping model (seed.py): students/teachers are
+    school-scoped, and their org is derived via School.organization_id — they do
+    NOT carry an org-scoped UserRole.
+    """
+    db = TestingSessionLocal()
+    try:
+        if not db.query(Organization).filter(Organization.id == org_id).first():
+            db.add(Organization(id=org_id, name=f"Org {org_id}"))
+            db.commit()
+        school = School(name=f"School {org_id}", organization_id=org_id)
+        db.add(school)
+        db.commit()
+        db.refresh(school)
+        return school.id
+    finally:
+        db.close()
+
+
 def _submit_feedback(client, token: str) -> int:
     """Submit a feedback entry and return its ID."""
     r = client.post("/api/feedback", json={
@@ -207,6 +230,11 @@ class TestOrgAdminScopeIsolation:
     @pytest.fixture(scope="class")
     def actors(self, client):
         """Create all actors once per class."""
+        # Production model: schools belong to orgs; students are SCHOOL-scoped
+        # (org derived via school->org), org_admins are org-scoped.
+        school_a_id = _create_org_and_school(self.ORG_A)
+        school_b_id = _create_org_and_school(self.ORG_B)
+
         admin_a_id, admin_a_tok = _register_login(client, "admin_a")
         _assign_org_role(admin_a_id, "org_admin", self.ORG_A)
 
@@ -214,10 +242,10 @@ class TestOrgAdminScopeIsolation:
         _assign_org_role(admin_b_id, "org_admin", self.ORG_B)
 
         student_a_id, student_a_tok = _register_login(client, "student_a")
-        _assign_org_role(student_a_id, "student", self.ORG_A)
+        _assign_role(student_a_id, "student", scope_type="school", scope_id=str(school_a_id))
 
         student_b_id, student_b_tok = _register_login(client, "student_b")
-        _assign_org_role(student_b_id, "student", self.ORG_B)
+        _assign_role(student_b_id, "student", scope_type="school", scope_id=str(school_b_id))
 
         sysadmin_id, sysadmin_tok = _register_login(client, "sysadmin")
         _assign_role(sysadmin_id, "system_admin", scope_type="platform")

--- a/backend/tests/test_ownership_helper.py
+++ b/backend/tests/test_ownership_helper.py
@@ -1,0 +1,96 @@
+"""Unit contract for get_owned_resource_or_403 (backend audit refactor 2026-07-02).
+
+Locks the shared teacher-ownership guard extracted from the duplicated inline
+checks in teacher_instructions.py. Pure logic — stubs the DB so it exercises the
+guard branches without any database. The key invariant: it must behave EXACTLY
+like the inline guards it replaced (404 missing / 403 not-owner / return owned),
+with NO system_admin bypass.
+
+Run:  cd backend && python -m pytest tests/test_ownership_helper.py -v
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.dependencies.tenant import get_owned_resource_or_403
+
+
+class _FakeQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+class _FakeDB:
+    """Minimal stand-in: db.query(Model).filter(...).first() -> result."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def query(self, model):
+        return _FakeQuery(self._result)
+
+
+class _Row:
+    def __init__(self, owner_id, other_field="teacher_id"):
+        self.id = 1
+        setattr(self, other_field, owner_id)
+
+
+class _Model:  # dummy ORM marker; helper only uses it as db.query() arg
+    id = None
+
+
+def test_returns_row_when_caller_owns_it():
+    row = _Row(owner_id=42)
+    result = get_owned_resource_or_403(
+        _FakeDB(row), _Model, 1, 42,
+        not_found_detail="nope", forbidden_detail="mine",
+    )
+    assert result is row
+
+
+def test_404_when_row_missing():
+    with pytest.raises(HTTPException) as exc:
+        get_owned_resource_or_403(
+            _FakeDB(None), _Model, 999, 42,
+            not_found_detail="Instruction not found",
+            forbidden_detail="Not your instruction",
+        )
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Instruction not found"
+
+
+def test_403_when_caller_is_not_owner():
+    row = _Row(owner_id=7)  # owned by teacher 7
+    with pytest.raises(HTTPException) as exc:
+        get_owned_resource_or_403(
+            _FakeDB(row), _Model, 1, 42,  # caller is 42
+            not_found_detail="Instruction not found",
+            forbidden_detail="Not your instruction",
+        )
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Not your instruction"
+
+
+def test_custom_owner_attr_is_respected():
+    row = _Row(owner_id=5, other_field="created_by_id")
+    result = get_owned_resource_or_403(
+        _FakeDB(row), _Model, 1, 5, owner_attr="created_by_id",
+    )
+    assert result is row
+
+
+def test_no_admin_bypass_only_owner_id_matters():
+    """The helper must NOT consult roles — a non-owner is 403 regardless of who
+    they are (the extracted guards had no system_admin bypass)."""
+    row = _Row(owner_id=7)
+    with pytest.raises(HTTPException) as exc:
+        get_owned_resource_or_403(_FakeDB(row), _Model, 1, 999)
+    assert exc.value.status_code == 403

--- a/backend/tests/test_regression_omo_grader_circuit_breaker.py
+++ b/backend/tests/test_regression_omo_grader_circuit_breaker.py
@@ -1,0 +1,76 @@
+"""Regression: OMO grader circuit breaker must NOT latch permanently open.
+
+Bug (backend audit 2026-07-02): the top-of-function guard raised RuntimeError
+whenever ``_consecutive_errors >= threshold`` — but the only success reset lives
+*after* the Gemini call, which that same guard prevents any call from reaching.
+So 3 transient Vertex errors wedged OMO grading OFF for every student on that
+Cloud Run instance until it restarted, even after Vertex recovered.
+
+Fix: time-based half-open breaker. While tripped AND within the cooldown window
+it still fast-fails; once the cooldown elapses a probe call is allowed through so
+a recovered service can reset the breaker.
+
+Run:  cd backend && python -m pytest tests/test_regression_omo_grader_circuit_breaker.py -v
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.services import omo_grader
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker_state():
+    """Isolate the module-global breaker state between tests."""
+    saved = (omo_grader._consecutive_errors, omo_grader._circuit_open_until)
+    yield
+    omo_grader._consecutive_errors, omo_grader._circuit_open_until = saved
+    # Ensure a clean slate for any later test in the session.
+    omo_grader._consecutive_errors = 0
+    omo_grader._circuit_open_until = 0.0
+
+
+@pytest.mark.asyncio
+async def test_breaker_allows_probe_after_cooldown_elapsed():
+    """Once the cooldown has elapsed, a tripped breaker must let a call through
+    (half-open probe) instead of raising forever."""
+    omo_grader._consecutive_errors = omo_grader._CIRCUIT_BREAKER_THRESHOLD
+    omo_grader._circuit_open_until = 0.0  # cooldown already elapsed
+
+    # Isolate the guard: no questions → returns [] without touching Gemini.
+    with patch.object(omo_grader, "_build_question_schema", return_value=[]):
+        result = await omo_grader.grade_worksheet_images(
+            [b"x"], ["image/png"], {"title": "t"}
+        )
+
+    assert result == [], "probe should reach the no-questions path, not hard-fail"
+
+
+@pytest.mark.asyncio
+async def test_breaker_still_blocks_during_cooldown():
+    """While tripped AND inside the cooldown window, the breaker must fast-fail."""
+    omo_grader._consecutive_errors = omo_grader._CIRCUIT_BREAKER_THRESHOLD
+    omo_grader._circuit_open_until = time.monotonic() + 60  # still cooling down
+
+    with patch.object(omo_grader, "_build_question_schema", return_value=[]):
+        with pytest.raises(RuntimeError):
+            await omo_grader.grade_worksheet_images(
+                [b"x"], ["image/png"], {"title": "t"}
+            )
+
+
+@pytest.mark.asyncio
+async def test_breaker_not_open_below_threshold():
+    """Below the error threshold the breaker never blocks, regardless of timing."""
+    omo_grader._consecutive_errors = omo_grader._CIRCUIT_BREAKER_THRESHOLD - 1
+    omo_grader._circuit_open_until = time.monotonic() + 60
+
+    with patch.object(omo_grader, "_build_question_schema", return_value=[]):
+        result = await omo_grader.grade_worksheet_images(
+            [b"x"], ["image/png"], {"title": "t"}
+        )
+
+    assert result == []

--- a/backend/tests/test_regression_reading_transcription_truncation.py
+++ b/backend/tests/test_regression_reading_transcription_truncation.py
@@ -1,0 +1,52 @@
+"""Regression: reading transcription must not truncate long readings.
+
+Bug (memory verification 2026-07-02): transcribe_reading_audio used a hardcoded
+max_output_tokens=1024. The response is JSON {transcript, reasoning} where the
+transcript ≈ the full reading (target_text up to ~3000 chars). For a long
+reading the transcript+reasoning exceeded 1024 tokens → Gemini cut the JSON off
+→ json.loads raised → the broad except degraded to a generic-error fallback
+(student had to re-read), with no signal that the token budget was the cause.
+
+Fix: size the output budget to the reading length (_transcription_max_tokens)
+and detect MAX_TOKENS truncation explicitly (_REASON_TRUNCATED).
+
+Run: cd backend && python -m pytest tests/test_regression_reading_transcription_truncation.py -v
+"""
+from __future__ import annotations
+
+from app.services import reading_transcription_service as svc
+
+
+def test_short_reading_keeps_floor_budget():
+    """Very short readings still get at least the 1024 floor."""
+    assert svc._transcription_max_tokens("你好") == 1024
+    assert svc._transcription_max_tokens("") == 1024
+
+
+def test_long_reading_gets_more_than_the_old_hardcoded_1024():
+    """A realistic full-text reading must get a budget well above the old 1024,
+    otherwise the transcript JSON truncates (the bug being fixed)."""
+    long_reading = "字" * 600  # ~600-char reading (mid-length lesson)
+    budget = svc._transcription_max_tokens(long_reading)
+    assert budget > 1024, "long readings must exceed the old hardcoded 1024 budget"
+    # ≈ 2 output tokens/char + reasoning buffer
+    assert budget >= 600 * 2
+
+
+def test_budget_is_clamped_to_ceiling():
+    """Even the longest lesson (~3000 chars) stays within a safe ceiling."""
+    huge = "字" * 5000
+    budget = svc._transcription_max_tokens(huge)
+    assert budget <= 8192
+
+
+def test_budget_monotonic_non_decreasing_with_length():
+    a = svc._transcription_max_tokens("字" * 100)
+    b = svc._transcription_max_tokens("字" * 800)
+    c = svc._transcription_max_tokens("字" * 2000)
+    assert a <= b <= c
+
+
+def test_truncated_reason_constant_exists():
+    """An explicit MAX_TOKENS fallback reason must exist (not a silent JSON error)."""
+    assert getattr(svc, "_REASON_TRUNCATED", None) == "truncated"

--- a/backend/tests/test_sentence_practice.py
+++ b/backend/tests/test_sentence_practice.py
@@ -437,6 +437,35 @@ class TestValidateSentence:
             )
         assert res.status_code == 503
 
+    def test_validate_defaults_incorrect_when_ai_omits_is_correct(self, client: TestClient):
+        """Regression: a malformed-but-successful AI response missing 'is_correct'
+        must NOT auto-pass the student.
+
+        Platform invariant (see AI service memory): on ambiguous grader output,
+        fail closed (is_correct=False). Defaulting a missing verdict to True marks
+        any sentence correct whenever Gemini drops the field — a silent auto-pass.
+        """
+        token = _create_student_and_login(client)
+        # Valid JSON, but the grader omitted the is_correct verdict field.
+        mock_result = {"feedback": "嗯，再想想看", "suggestion": "換個說法試試"}
+        with patch(
+            "app.routes.learning.learning_vocab.validate_student_sentence",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/validate",
+                json={
+                    "word": "來源",
+                    "student_sentence": "老師講述這個故事的來源。",
+                    "story_title": "課文",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        assert res.json()["is_correct"] is False, (
+            "AI response missing 'is_correct' must default to False (never auto-pass)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: copy-paste detection (#928)
@@ -467,7 +496,7 @@ class TestCopyPasteDetection:
             res = client.post(
                 "/api/learning/sentence-practice/validate",
                 json={
-                    "character": "水",
+                    "word": "水",
                     "student_sentence": "小水滴從天上掉下來",
                     "story_title": "小水滴的旅行",
                 },
@@ -491,7 +520,7 @@ class TestCopyPasteDetection:
             res = client.post(
                 "/api/learning/sentence-practice/validate",
                 json={
-                    "character": "溪",
+                    "word": "溪",
                     "student_sentence": "流進了小溪",
                     "story_title": "小水滴的旅行",
                 },
@@ -514,7 +543,7 @@ class TestCopyPasteDetection:
             res = client.post(
                 "/api/learning/sentence-practice/validate",
                 json={
-                    "character": "水",
+                    "word": "水",
                     "student_sentence": "我每天都會喝水來保持健康。",
                     "story_title": "小水滴的旅行",
                 },
@@ -536,7 +565,7 @@ class TestCopyPasteDetection:
             res = client.post(
                 "/api/learning/sentence-practice/validate",
                 json={
-                    "character": "水",
+                    "word": "水",
                     "student_sentence": "小水滴從天上掉下來",
                     "story_title": "不存在的課文",
                 },
@@ -558,7 +587,7 @@ class TestCopyPasteDetection:
             res = client.post(
                 "/api/learning/sentence-practice/validate",
                 json={
-                    "character": "水",
+                    "word": "水",
                     "student_sentence": "我喜歡在夏天喝冰水。",
                     "story_title": "小水滴的旅行",
                 },


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2450. Backend hardening batch (7 commits), all TDD-locked.

## Changes
- **fail-closed grader** — sentence-validate no longer auto-passes on malformed AI; OMO circuit breaker no longer latches permanently (30s half-open).
- **cross-org RBAC (HIGH, 個資法 §20)** — org_admin of org A could read org B students' gamification / user list+detail / feedback. Fixed via system_admin-only bypass; org resolved via school→org so school-scoped students in the caller's OWN org stay visible (no over-restriction).
- **reading STT truncation** — dynamic token budget + explicit MAX_TOKENS detection.
- **comprehension scoring** — extracted real `_apply_clamping` (was test-only copy) + derive overall from sub-scores.
- shared teacher-ownership authz guard extraction; CLAUDE.md doc corrections.

## Verification
- Full backend spec suite **736 passed / 4 xfailed**
- 18 org-isolation tests (cross-org→403 AND same-org→200 bidirectional)
- reading spec 55, comprehension spec 16, ownership-helper 5
- Reviewed by security-auditor (APPROVE) + Cursor (correction applied)

## QA focus (highest risk first)
1. Cross-org RBAC — org_admin A must be denied org B data AND still see own-org school-scoped students; system_admin still global.
2. OMO grader breaker recovers after cooldown (not permanent latch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)