### PR TITLE
feat(learning): 學習步驟動態對應學習單 — nav follows each lesson's worksheet order (#2451)

### DIFF
--- a/frontend/src/config/stepConfig.test.ts
+++ b/frontend/src/config/stepConfig.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { stepSequenceFromWorksheet, resolveActiveSteps } from './stepConfig';
+
+// The authoritative per-lesson worksheet section order, straight from a real
+// lesson YAML (backend/data/lessons/L43.yml worksheet_section_order).
+const L43_WORKSHEET = [
+  { number: '一', name: '讀全文-做記號', type: 'reading_annotation' },
+  { number: '二', name: '逐段朗讀', type: 'tutor' },
+  { number: '三', name: '全文朗讀', type: 'full_reading' },
+  { number: '四', name: '詞語理解', type: 'vocab_definition' },
+  { number: '五', name: '語詞應用', type: 'vocab_application' },
+  { number: '六', name: '文章重點表', type: 'story_structure' },
+  { number: '七', name: '閱讀聚光燈', type: 'reading_strategy' },
+  { number: '八', name: '閱讀理解', type: 'comprehension' },
+  { number: '九', name: '語詞複習', type: 'vocab_word_search' },
+  { number: '十', name: '知識補給站', type: 'knowledge_station' },
+  { number: '十一', name: '報告', type: 'report' },
+];
+
+describe('stepSequenceFromWorksheet — 學習步驟動態對應學習單', () => {
+  it('maps section type (underscore) → step id (hyphen) and prepends intro', () => {
+    expect(stepSequenceFromWorksheet(L43_WORKSHEET)).toEqual([
+      'intro',
+      'reading-annotation',
+      'tutor',
+      'full-reading',
+      'vocab-definition',
+      'vocab-application',
+      'story-structure', // worksheet 六 — 文章重點表
+      'reading-strategy', // worksheet 七 — 閱讀聚光燈 (AFTER 重點表)
+      'comprehension',
+      'vocab-word-search',
+      'knowledge-station',
+      'report',
+    ]);
+  });
+
+  it('follows the worksheet order, which DIFFERS from the flat DEFAULT', () => {
+    // DEFAULT_STEP_SEQUENCE orders reading-strategy BEFORE story-structure;
+    // the paper worksheet is the opposite. The nav must follow the paper.
+    const seq = stepSequenceFromWorksheet(L43_WORKSHEET)!;
+    expect(seq.indexOf('story-structure')).toBeLessThan(seq.indexOf('reading-strategy'));
+    const ids = resolveActiveSteps(seq).map((s) => s.id);
+    expect(ids.indexOf('story-structure')).toBeLessThan(ids.indexOf('reading-strategy'));
+  });
+
+  it('returns null for empty/missing worksheet → caller falls back to DEFAULT', () => {
+    expect(stepSequenceFromWorksheet(null)).toBeNull();
+    expect(stepSequenceFromWorksheet(undefined)).toBeNull();
+    expect(stepSequenceFromWorksheet([])).toBeNull();
+  });
+
+  it('skips unknown section types and never double-adds intro', () => {
+    expect(
+      stepSequenceFromWorksheet([
+        { number: '一', name: 'X', type: 'bogus_type' },
+        { number: '二', name: '閱讀理解', type: 'comprehension' },
+      ]),
+    ).toEqual(['intro', 'comprehension']);
+  });
+});

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -340,6 +340,36 @@ export function resolveActiveSteps(lessonStepSequence?: string[] | null): StepCo
     .filter((s): s is StepConfig => !!s && s.enabled);
 }
 
+/**
+ * Derive a per-lesson step sequence from the printed worksheet's section order.
+ *
+ * Each lesson YAML carries `worksheet_section_order`: the AUTHORITATIVE ordered
+ * list of the paper 學習單 sections, e.g.
+ *   [{number:'一', name:'讀全文-做記號', type:'reading_annotation'}, ...]
+ * The section `type` (underscored) maps 1:1 to a STEP_REGISTRY id (hyphenated),
+ * so this makes the online step flow follow each lesson's ACTUAL worksheet order
+ * — the 5/1 "學習步驟動態對應學習單" requirement — instead of the flat
+ * DEFAULT_STEP_SEQUENCE (which e.g. orders 文章重點表/閱讀聚光燈 opposite to the paper).
+ *
+ * 'intro' is prepended (the online flow always opens with it; the paper starts
+ * at 讀全文). Unknown types are skipped here; disabled steps are dropped later by
+ * resolveActiveSteps. Returns null when there is no worksheet order so callers
+ * fall back to DEFAULT_STEP_SEQUENCE.
+ */
+export function stepSequenceFromWorksheet(
+  worksheet?: Array<{ number?: string; name?: string; type?: string }> | null,
+): string[] | null {
+  if (!worksheet || worksheet.length === 0) return null;
+  const ids: string[] = ['intro'];
+  for (const section of worksheet) {
+    const type = section?.type;
+    if (!type) continue;
+    const id = type.replace(/_/g, '-'); // reading_annotation → reading-annotation
+    if (STEP_REGISTRY[id] && !ids.includes(id)) ids.push(id);
+  }
+  return ids.length > 1 ? ids : null;
+}
+
 // ---------------------------------------------------------------------------
 // Derived lookup maps — computed once from STEP_CONFIG so consumers don't
 // need to re-derive them.  Import these instead of building your own maps.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,6 +13,7 @@
 
 import type { Story } from '../types';
 import { API_BASE } from './apiConfig';
+import { stepSequenceFromWorksheet } from '../config/stepConfig';
 
 const inFlightStoryById = new Map<string, Promise<Story>>();
 
@@ -172,7 +173,13 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     videoLinks: detail.video_links ?? undefined,
     strategyExercise: detail.strategy_exercise ?? undefined,
     spotlightV2: detail.spotlight_v2 ?? undefined,
-    stepSequence: detail.step_sequence ?? undefined,
+    // Step order source of truth: an explicit YAML step_sequence wins; otherwise
+    // derive the sequence from the printed worksheet's section order so the online
+    // flow matches each lesson's actual 學習單 (5/1「學習步驟動態對應學習單」).
+    stepSequence:
+      detail.step_sequence
+      ?? stepSequenceFromWorksheet(detail.worksheet_section_order)
+      ?? undefined,
     worksheetSectionOrder: detail.worksheet_section_order ?? undefined,
     worksheetIntro: detail.worksheet_intro ?? undefined,
     lessonIntro: detail.lesson_intro ?? undefined,


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2451. The 5/1 professor-review theme「學習步驟動態對應學習單」.

## Change
`stepSequenceFromWorksheet()` derives each lesson's step order from its printed-worksheet `worksheet_section_order` (206 lessons carry it; each section `type` maps 1:1 to a step id). The Story mapping uses it when no explicit `step_sequence` — so the online nav follows the paper order (e.g. 文章重點表 before 閱讀聚光燈) instead of the flat default.

## Verification
- converter unit tests (type→id mapping + worksheet order) — 4 tests
- render-smoke 14 passed; lint 0 errors

## ⚠️ Before prod
Reorders the nav for ~206 lessons. Unit-tested, but the **visual reorder is NOT yet human-QA'd**. Staging is for exactly this team review — **needs professor/PM visual sign-off (per-lesson nav order) before promoting to production.** Split from the security PR (#2452) so its prod gate stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)