### PR TITLE
docs(meeting): 2026-07-03 週五議程 + 貢獻紀錄 + 實習生技能樹 (Related to #2456)

### DIFF
--- a/docs/meetings/2026-07-03-agenda.md
+++ b/docs/meetings/2026-07-03-agenda.md
@@ -1,0 +1,78 @@
+# 會議議程 2026-07-03（五）
+
+> 週區間 6/29~7/3 ｜ **7/1 launch 已過** → 本次＝post-launch 狀態盤點 + 收尾分工
+>
+> 資料來源：gh PR/issue 實查（非記憶）
+
+## 參與者
+- Young @Youngger9765（lead dev）
+- 方大哥 @Shinjou（product owner）
+- 靖杭 @if-else-master、啟翔 @stgst（intern）
+
+---
+
+## 一、本週重點工作（merged PRs）
+
+### Young — 後端安全/正確性 + 學習流程 + testset，全上 prod
+| PR | 項目 | 說明 |
+|----|------|------|
+| #2452 | fail-closed grader + 跨組織 RBAC + STT + 理解評分 | 造句不再 auto-pass；OMO 斷路器不卡死；跨組織個資隔離；朗讀長文不截斷 |
+| #2453 | 學習步驟動態對應學習單 | nav 跟每課紙本學習單 section 順序排（5/1 主軸）|
+| #2454 | 清 dead code | Cursor review 指出的無用函式 |
+| #2431~2435 | testset 上傳 magic-bytes 驗證 + TDD/EDD + real-mime | 擋偽造 MIME、鎖轉寫前處理 |
+| #2438 | testset recordings 限 system_admin/org_admin | 權限收斂 |
+| #2444 | LoginPage render-smoke | mount 安全網 |
+| releases | #2436/2439/2442/2445/2447/2455 staging→prod 同步 | |
+
+### 靖杭 @if-else-master（3 PR）
+| PR | 項目 | 說明 |
+|----|------|------|
+| #2411 | 快速登入「登入朗讀測試頁面」按鈕（#2410）| LoginPage 便利入口 |
+| #2427 | record.html mp3/wav 上傳途徑 + 返回鈕（#2426）| 錄音頁擴充（4 輪 review 才過）|
+| #2429 | npm run dev esbuild/optimizeDeps 降級錯誤修復（#2428）| vite.config，獨立診斷 build 問題 |
+
+### 啟翔 @stgst
+- 本週無 merged PR；主力在 QA 七課（見 section 五）
+
+---
+
+## 二、7/1 launch 後狀態（已上 prod，verified 200）
+- **後端 fail-closed**：造句驗證/OMO 批改錯誤時不誤放行學生；OMO 斷路器改 30s half-open（不再永久卡死）
+- **跨組織 RBAC 隔離**（個資法 §20）：org_admin 看不到別組資料、看得到自己組 school-scoped 學生；system_admin 全域
+- **朗讀 STT**：長文轉寫不再靜默截斷降級
+- **學習步驟動態對應學習單**：nav 跟學習單排（重點表→聚光燈，修正舊反序）
+- **testset**：上傳 magic-bytes 驗證 + recordings 限 admin
+- prod 驗：backend `/api/health` + frontend 皆 200
+
+> ⚠️ **nav 動態對應學習單只做了自動測試（單元 + E2E），純「真人肉眼看 stepper 呈現」還沒**——已上 prod，請方大哥/教授逐課看一眼 nav 順序確認（見待討論 3）
+
+---
+
+## 三、待討論議題
+1. **#2388 聚光燈 6 課內容缺口** — 需人工補源 DOCX 素材（5 文言 + G4-L14，源檔本身沒料）→ 誰補、何時
+2. **#2382 聚光燈 spotlight_v2 全 151 課 rollout + 老師盤點 SOP** — 排程與分工
+3. **學習步驟動態對應學習單 nav 視覺驗收** — 已上 prod，請方大哥/教授逐課確認 nav 順序；若哪課怪，revert 一個 commit 即回舊 default（風險可控）
+4. **朗讀測試集收集進度** — 靖杭上週規劃的分配/記名/驗證 + 5 人×30 課≈150 課覆蓋，目前進度？貢獻者招募狀況？
+
+---
+
+## 五、實習生進度快照
+
+### 靖杭 @if-else-master
+- 本週 merged：#2411、#2427、#2429
+- Open PR：**#2449**（管理員側邊欄「朗讀測試集」入口，#2448）
+- 下週建議聚焦：完成 #2449 + 推進測試集收集執行
+
+### 啟翔 @stgst
+- 本週無 merged PR；QA 任務進行中：**#2425**（聚光燈+重點表+七課 QA）、**#2200**（全平台 UX 導航七課）、**#2153**（教授 demo 七課人工驗收）
+- 下週建議聚焦：完成七課 QA 驗收、逐項回報 pass/fail
+
+---
+
+## 七、Action Items
+| # | 項目 | Owner | 截止 |
+|---|------|-------|------|
+| 1 | #2388 六課內容缺口補 DOCX 素材 | Young / 方大哥 | 會中定 |
+| 2 | nav 動態對應學習單逐課視覺確認（prod）| 方大哥 / 教授 | 7/3 會後 |
+| 3 | 測試集收集執行（5 人×30 課）| 靖杭 | 進行中 |
+| 4 | 七課 QA 驗收逐項回報 | 啟翔 | 下週 |

--- a/docs/meetings/team-contributions.md
+++ b/docs/meetings/team-contributions.md
@@ -8,6 +8,23 @@
 
 ---
 
+## 6/29 ~ 7/3
+
+| 人 | 狀態 | Issue / 項目 | 做了什麼 |
+|----|------|-------------|---------|
+| Young | ✅ | PR #2452 fail-closed + 跨組織 RBAC + STT + 理解 (#2450) | 造句不 auto-pass、OMO 斷路器不卡死、跨組織個資隔離、朗讀長文不截斷 |
+| Young | ✅ | PR #2453 學習步驟動態對應學習單 (#2451) | nav 跟每課學習單 section 順序排（5/1 主軸）|
+| Young | ✅ | PR #2431~2435 testset 上傳 magic-bytes + TDD/EDD | 擋偽造 MIME、real-mime、鎖轉寫前處理 |
+| Young | ✅ | PR #2438 testset recordings 限 admin (#2437) | 權限收斂 |
+| Young | ✅ | PR #2444 LoginPage render-smoke (#2443) | mount 安全網 |
+| Young | ✅ | PR #2454 清 dead code (#2450) | Cursor review 指出的無用函式；全批上 prod |
+| 靖杭 | ✅ | PR #2411 快速登入朗讀測試頁按鈕 (#2410) | LoginPage 便利入口 |
+| 靖杭 | ✅ | PR #2427 record.html mp3/wav 上傳途徑 (#2426) | 錄音頁擴充 + 返回鈕（4 輪 review）|
+| 靖杭 | ✅ | PR #2429 npm run dev esbuild 降級修復 (#2428) | vite.config 獨立診斷 build 問題 |
+| 啟翔 | ⏳ | QA 七課 (#2425 #2200 #2153) | 本週無 PR，做聚光燈/重點表/UX 導航七課 QA 驗收 |
+
+---
+
 ## 6/22 ~ 6/25
 
 | 人 | 狀態 | Issue / 項目 | 做了什麼 |

--- a/frontend/public/intern-training/interns/raymond.json
+++ b/frontend/public/intern-training/interns/raymond.json
@@ -3,7 +3,7 @@
   "github": "if-else-master",
   "email": "78069313+if-else-master@users.noreply.github.com",
   "startDate": "2026-03-02",
-  "lastReview": "2026-06-25",
+  "lastReview": "2026-07-03",
   "skills": {
     "1": {
       "level": 4,
@@ -69,7 +69,7 @@
       "maxLevel": 5
     },
     "4": {
-      "level": 2,
+      "level": 3,
       "history": [
         {
           "date": "2026-03-02",
@@ -80,6 +80,11 @@
           "date": "2026-03-10",
           "level": 2,
           "reason": "PR #314 處理本地 DB 連線問題，本地開發環境已跑通"
+        },
+        {
+          "date": "2026-07-03",
+          "level": 3,
+          "reason": "PR #2429 — 獨立診斷並修復 npm run dev 的 esbuild/optimizeDeps target 降級錯誤(vite.config)，0 review round 一次過，展現獨立 build 環境除錯"
         }
       ],
       "maxLevel": 5
@@ -138,6 +143,16 @@
           "date": "2026-03-13",
           "level": 5,
           "reason": "獨立完成語音輸入/輸出功能"
+        },
+        {
+          "date": "2026-07-03",
+          "level": 5,
+          "reason": "PR #2411 — LoginPage 新增快速登入朗讀測試頁按鈕(#2410)"
+        },
+        {
+          "date": "2026-07-03",
+          "level": 5,
+          "reason": "PR #2427 — record.html 新增 mp3/wav 上傳途徑+返回鈕(#2426)，4 輪 review 才過"
         }
       ]
     },

--- a/frontend/public/intern-training/interns/xiung.json
+++ b/frontend/public/intern-training/interns/xiung.json
@@ -3,7 +3,7 @@
   "github": "stgst",
   "email": "steven19790906@gmail.com",
   "startDate": "2026-03-06",
-  "lastReview": "2026-06-25",
+  "lastReview": "2026-07-03",
   "skills": {
     "1": {
       "level": 3,


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Related to #2456。週五(7/3)會議 4 份文件，資料全部 gh 實查（verify-first，非記憶）。

- `docs/meetings/2026-07-03-agenda.md` — post-launch(7/1 已過)狀態盤點 + 待討論(聚光燈內容缺口/spotlight_v2 rollout/nav 視覺驗收/測試集收集) + action items
- `docs/meetings/team-contributions.md` — 插入 6/29~7/3 週區段
- `raymond.json`(靖杭) — lastReview 7/3 + 3 個 merged PR 的 evidence-based 更新（dev-env skill bump：獨立診斷 vite/esbuild build 問題）
- `xiung.json`(啟翔) — lastReview 7/3（本週無 merged PR，主力在七課 QA）

JSON 已 `jq` 驗證通過。**請 Young 確認後 admin merge**（不自動 merge）。