### PR TITLE
fix(content-gate): audit img.filename not synthetic block.asset — kills 4 false figure gaps (#2459)

### DIFF
--- a/backend/data/curriculum_qa/content_known_gaps.yaml
+++ b/backend/data/curriculum_qa/content_known_gaps.yaml
@@ -90,21 +90,20 @@ story-structure:
   # 多文本課的第二/三篇 slot — 重點表內容在 primary slot (G7-L23)
   - {lesson_code: G7-L31, reason: multi_text_secondary}
 
-# Figure-asset gaps: story references a synthetic figN.png / tableN.json name
-# that was never uploaded to GCS (the real per-page assets G7-L28-NN.jpg DO
-# exist). honest gap = the figure reference points at missing content.
+# Figure-asset gaps.
+# #2459: the gate previously ALSO audited the synthetic spotlight_v2
+# blocks[].asset name (figN.png) which the frontend never fetches — it renders
+# from story.images[].filename via buildImageSrc. That produced FALSE gaps on
+# lessons whose real per-page image (G7-L28-08.jpg …) is uploaded and rendering.
+# The gate now audits story.images[].filename only; G7-L28/L29/L30/G9-L9 were
+# verified pass (real images 200 in GCS) and removed from this list.
 # NOTE: FIGURE_BLACKLIST_HIT (placeholder served) 應優先補真圖；若確認源頭沒有
 # 真圖可供上傳，允許以 figure_missing 誠實標記缺口，不得用 placeholder 假裝通過。
 figure:
-  # story 引用合成的 figN.png / tableN.json 名稱，GCS 沒上傳該檔（真實 per-page
-  # 資產如 G5-L24-25-10.png 存在，但 story 指向不存在的 figN 名）。誠實標 gap，
-  # 真解是修 story figure reference 指向真實檔名 / 上傳對應 figN。
+  # Remaining = genuine gaps: story.images[].filename points at a name absent
+  # from GCS (real fix = correct the figure reference / upload the real asset).
   - {lesson_code: G6-L8,    reason: figure_missing}
-  - {lesson_code: G9-L9,    reason: figure_asset_not_uploaded}
-  - {lesson_code: G7-L28,   reason: figure_asset_not_uploaded}
-  - {lesson_code: G7-L29,   reason: figure_asset_not_uploaded}
-  - {lesson_code: G7-L30,   reason: figure_asset_not_uploaded}
-  - {lesson_code: G5-L24,   reason: figure_asset_not_uploaded}  # fig10.png 未上傳
-  - {lesson_code: G8-L7,    reason: figure_asset_not_uploaded}  # G8-L9 dir, fig10.png
+  - {lesson_code: G5-L24,   reason: figure_asset_not_uploaded}  # story → fig10.png (404); real source asset TBD by content owner (#2458)
+  - {lesson_code: G8-L7,    reason: figure_asset_not_uploaded}  # story → fig10.png (404); G8-L9 dir (#2458)
   - {lesson_code: G8-L8,    reason: figure_missing}             # G8-L6b only has placeholder fig1.png in G8-L8 dir
   - {lesson_code: G8-L6b,   reason: figure_missing}             # source figure is placeholder-only (no authentic asset)

--- a/backend/specs/test_content_evidence_gate_spec.py
+++ b/backend/specs/test_content_evidence_gate_spec.py
@@ -137,3 +137,86 @@ class TestKnownGaps:
             gate.gcs_md5_hex = orig_md5
             gate.figure_assets_from_story = orig_assets
         gate._KNOWN_GAPS = None
+
+
+class TestFigureAssetsFromStory:
+    """#2459 — the gate must audit ONLY the figure filenames the FRONTEND
+    actually fetches (story.images[].filename via buildImageSrc), never the
+    synthetic spotlight_v2 blocks[].asset name (figN.png). block.asset is used
+    frontend-side only to derive the figure label; it is never uploaded to GCS
+    under that name, so auditing it produced false 404 gaps on lessons whose
+    real image is present and rendering (G7-L28/L29/L30/G9-L9)."""
+
+    def test_audits_img_filename_not_synthetic_block_asset(self):
+        story = {
+            "id": 1,
+            "spotlight_v2": {
+                "blocks": [{"type": "figure", "asset": "fig1.png", "bind_paragraph": "圖一"}]
+            },
+            "images": [
+                {"filename": "images/G7-L28/G7-L28-08.jpg", "figure_label": "圖一"}
+            ],
+        }
+        assets = gate.figure_assets_from_story(story)
+        # The real, fetched filename is audited...
+        assert "G7-L28-08.jpg" in assets
+        # ...and the synthetic block.asset name is NOT (it 404s in GCS → false gap).
+        assert "fig1.png" not in assets
+        assert assets == ["G7-L28-08.jpg"]
+
+    def test_synthetic_block_asset_alone_yields_no_audit_target(self):
+        # A figure block with a synthetic asset but no backing image must not
+        # inject figN.png into the audit set (frontend renders a placeholder,
+        # it never fetches figN.png).
+        story = {
+            "id": 2,
+            "spotlight_v2": {"blocks": [{"type": "figure", "asset": "fig10.png"}]},
+            "images": [],
+        }
+        assert gate.figure_assets_from_story(story) == []
+
+    def test_skips_non_image_table_json(self):
+        # G7-L30's API-served images[] carries table*.json entries (tables
+        # mis-modeled as figures). Those are not rendered as <img> and must not
+        # be audited as figures.
+        story = {
+            "id": 3,
+            "spotlight_v2": {"blocks": []},
+            "images": [
+                {"filename": "images/G7-L30/G7-L30-06.png"},
+                {"filename": "table1.json"},
+                {"filename": "table2.json"},
+            ],
+        }
+        assert gate.figure_assets_from_story(story) == ["G7-L30-06.png"]
+
+    def test_audits_unusual_real_image_extensions_fail_closed(self):
+        # Denylist (not allowlist): a real figure with a non-standard docx
+        # extraction extension (.x-emf / .svg) must STILL be audited against
+        # GCS, never silently skipped — otherwise a future broken figure in
+        # that format would pass invisibly (#2459 review). Only .json tables skip.
+        story = {
+            "id": 5,
+            "spotlight_v2": {"blocks": []},
+            "images": [
+                {"filename": "images/G9-L7/G9-L7-03.x-emf"},
+                {"filename": "images/G5-L5/G5-L5-02.svg"},
+                {"filename": "notes.json"},
+            ],
+        }
+        assert gate.figure_assets_from_story(story) == [
+            "G9-L7-03.x-emf",
+            "G5-L5-02.svg",
+        ]
+
+    def test_collects_all_real_image_filenames_deduped(self):
+        story = {
+            "id": 4,
+            "spotlight_v2": {"blocks": []},
+            "images": [
+                {"filename": "images/G9-L9/G9-L9-02.jpg"},
+                {"filename": "images/G9-L9/G9-L9-04.png"},
+                {"filename": "images/G9-L9/G9-L9-02.jpg"},  # dup basename
+            ],
+        }
+        assert gate.figure_assets_from_story(story) == ["G9-L9-02.jpg", "G9-L9-04.png"]

--- a/frontend/src/components/reading-spotlight/__tests__/BlockSequenceRenderer.figure.test.tsx
+++ b/frontend/src/components/reading-spotlight/__tests__/BlockSequenceRenderer.figure.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BlockSequenceRenderer from '../BlockSequenceRenderer';
+import type { SpotlightV2, Story } from '../../../types';
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+vi.mock('../../../services/learningApi', () => ({
+  validateStrategyAnswer: vi.fn(),
+}));
+
+// FigureCard stub exposes the resolved `src` so the test can assert exactly
+// which filename the frontend fetches. buildImageSrc mirrors the real URL
+// shape (basename under the lesson dir) without hitting the network.
+vi.mock('../../reading-steps/GraphicTextImageStrip', () => ({
+  FigureCard: ({ src }: { src: string }) => <img data-testid="figure-img" src={src} alt="fig" />,
+  buildImageSrc: (filename: string, code: string) =>
+    `https://gcs/${code}/${filename.split('/').pop()}`,
+}));
+
+// A figure block whose synthetic `asset` (fig1.png) only encodes the LABEL
+// (圖一). The real image the frontend must fetch is images[].filename.
+const FIGURE_FIXTURE: SpotlightV2 = {
+  lesson: 'G7-L28',
+  strategy_name: '圖文整合',
+  strategy_type: 'graphic_text',
+  blocks: [{ type: 'figure', asset: 'fig1.png', bind_paragraph: '圖一' }],
+};
+
+const STORY: Story = {
+  id: '1234',
+  title: '巴斯德的鵝頸瓶',
+  content: ['課文段落'],
+  level: 7,
+  thumbnail: '',
+  category: 'Daily',
+  filename: '',
+  lesson_code: 'G7-L28',
+  images: [
+    {
+      filename: 'images/G7-L28/G7-L28-08.jpg',
+      size_bytes: 1,
+      image_hash: 'h',
+      content_type: 'image/jpeg',
+      figure_label: '圖一',
+    },
+  ],
+};
+
+describe('BlockSequenceRenderer figure src contract (#2459)', () => {
+  it('builds the figure src from images[].filename, never the synthetic block.asset', () => {
+    render(<BlockSequenceRenderer spotlight={FIGURE_FIXTURE} story={STORY} />);
+    const img = screen.getByTestId('figure-img') as HTMLImageElement;
+    // Frontend fetches the REAL image filename...
+    expect(img.getAttribute('src')).toBe('https://gcs/G7-L28/G7-L28-08.jpg');
+    expect(img.getAttribute('src')).toContain('G7-L28-08.jpg');
+    // ...and NEVER the synthetic figN.png asset (that name 404s in GCS — the
+    // content-evidence gate must audit the same filename, not block.asset).
+    expect(img.getAttribute('src')).not.toContain('fig1.png');
+  });
+});

--- a/scripts/content_evidence_gate.py
+++ b/scripts/content_evidence_gate.py
@@ -373,28 +373,39 @@ def normalize_gcs_lesson_code(lesson_code: str) -> str:
     return parsed
 
 
+# Non-figure data refs that can appear in images[]: tables mis-modeled as
+# figures carry a .json referent (e.g. G7-L30 table1.json). Those are never
+# rendered as <img>, so they are not figure assets. Everything else in images[]
+# IS audited — a DENYLIST (not an image-extension allowlist) keeps the audit
+# fail-closed: an unexpected real figure format from docx extraction (.x-emf /
+# .svg) is still checked against GCS rather than silently skipped (#2459 review).
+_NON_FIGURE_FILENAME_EXTS = (".json",)
+
+
 def figure_assets_from_story(story: dict[str, Any]) -> list[str]:
-    """Collect figure asset basenames from spotlight_v2 blocks (+ images[])."""
+    """Collect the figure image basenames the FRONTEND actually fetches.
+
+    The frontend (BlockSequenceRenderer.renderFigure) builds every figure src
+    from ``story.images[].filename`` via ``buildImageSrc``; the synthetic
+    ``spotlight_v2.blocks[].asset`` name (figN.png) is used only to derive the
+    figure label and is not the filename the frontend requests. Auditing
+    block.asset produced false 404 gaps on lessons whose real image is present
+    and rendering (#2459). Audit ``images[].filename`` only, skipping non-figure
+    data refs (table*.json mis-modeled as figures); any real image extension —
+    including vector formats — is still audited (fail-closed, no silent skip).
+    """
     out: list[str] = []
     seen: set[str] = set()
-    sv2 = story.get("spotlight_v2") or {}
-    for block in sv2.get("blocks") or []:
-        if block.get("type") != "figure":
-            continue
-        asset = (block.get("asset") or "").strip()
-        if asset:
-            base = asset.split("/")[-1]
-            if base not in seen:
-                seen.add(base)
-                out.append(base)
-    # images[] derived from figure assets — covers catalog gap-fill path.
     for img in story.get("images") or []:
         fn = (img.get("filename") or "").strip()
-        if fn:
-            base = fn.split("/")[-1]
-            if base not in seen:
-                seen.add(base)
-                out.append(base)
+        if not fn:
+            continue
+        base = fn.split("/")[-1]
+        if base.lower().endswith(_NON_FIGURE_FILENAME_EXTS):
+            continue  # table*.json etc. — not a rendered figure asset
+        if base not in seen:
+            seen.add(base)
+            out.append(base)
     return out
 
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 問題（#2459）
`scripts/content_evidence_gate.py` 的 figure 稽核從 **合成的** `spotlight_v2.blocks[].asset`（`figN.png`）收集要驗的檔名。但前端 `BlockSequenceRenderer.renderFigure` 渲染圖是用 `story.images[].filename`（經 `buildImageSrc`），**從不 fetch `block.asset`**（那名字只拿來推導「圖N」label）。稽核那個合成名 → HEAD 到 GCS 根本沒上傳的物件 → 真圖已上傳且正常 render 的課被誤標成缺口。

## 實測（prod GCS 逐張）
| 課 | 修前 | 修後 |
|----|------|------|
| G7-L28 / L29 / L30 / G9-L9 | `unknown`（合成 figN 404）| **`pass`**（真圖 200）|
| G5-L24 / G8-L7 | `unknown` | `unknown`（真缺口，`fig10.png` 404 → 內容 owner #2458）|

## 修法
- `figure_assets_from_story` 只稽核 `story.images[].filename`（對齊前端 fetch 契約）
- 用 **denylist（`.json`）** 跳過被誤建成 figure 的 `table*.json`（G7-L30），其餘一律稽核 → **fail-closed**：docx 抽出的 `.x-emf`/`.svg` 等真圖格式仍會被驗，不靜默跳過（採納對抗式 review 建議）
- `content_known_gaps.yaml`：移除 4 個已驗證的假缺口；G5-L24/G8-L7 保留為真缺口

## TDD（vitest + pytest 都做到位）
- **pytest** `TestFigureAssetsFromStory`（5 tests，RED→GREEN）：只稽核 img.filename、不注入合成 block.asset、跳過 table*.json、非常規真圖格式仍稽核
- **vitest** `BlockSequenceRenderer.figure.test.tsx`：鎖前端 figure src 來自 img.filename、絕不用 block.asset（兩側不再 diverge）

## 驗證
- pytest gate spec 15/15 ✓
- vitest smoke + figure 契約 + BlockSequenceRenderer 22/22 ✓（38 個 pre-existing 失敗是既有 debt，CI 只 gate smoke）
- eslint 0 errors ✓
- `bash specs/run-ci.sh` = PASS ✓
- 真 staging API + prod GCS 逐課 QA（見上表）✓
- 對抗式 critic review：APPROVE（其唯一 concern 已在本 PR 修掉）

Fixes #2459