### PR TITLE
feat(testset): 錄音明細表每列加垃圾桶可刪除錄音（貢獻者隨錄音刪、仍有其他錄音則保留）(#2465)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -300,6 +300,57 @@ def testset_recordings():
     return {"ok": True, "count": len(out), "recordings": out}
 
 
+@router.delete(
+    "/testset/recordings",
+    dependencies=[require_role("system_admin", "org_admin")],
+)
+def testset_delete_recording(
+    audio_path: str = Query(..., description="要刪除錄音的 .webm 完整 GCS 路徑"),
+):
+    """刪除單筆錄音（admin only）：刪同 stem 的 .webm + .json + .eval.json（#2465）。
+
+    Auth 與 GET /testset/recordings 相同（system_admin / org_admin）—— 錄音是平台級
+    敏感資料，刪除更不可逆，故用最緊的 gate。
+
+    貢獻者不是獨立儲存實體，只是每筆錄音 meta 的 contributor_name 欄位；刪掉這筆
+    錄音該筆貢獻者屬性即隨之消失。若該貢獻者尚有其他錄音（各自獨立 blob），其貢獻
+    資訊自然保留 —— 不需額外的貢獻者刪除邏輯。
+    """
+    # path 驗證：必須落在 test-dataset/ prefix 底下且為 .webm，擋 traversal / 跨 prefix / 絕對路徑
+    path = (audio_path or "").strip()
+    if not path.startswith(f"{_PREFIX}/") or not path.endswith(".webm") or ".." in path:
+        raise HTTPException(400, "invalid audio_path")
+
+    bucket = _get_gcs_bucket()
+    if bucket is None:
+        # fail-closed: storage unavailable
+        raise HTTPException(503, "storage temporarily unavailable")
+
+    base = path[: -len(".webm")]
+    # 同一筆錄音的三個 blob 共用 stem（.eval.json 跑分後才有，可能不存在）
+    targets = [path, base + ".json", base + ".eval.json"]
+
+    deleted: list[str] = []
+    audio_existed = False
+    try:
+        for t in targets:
+            blob = bucket.blob(t)
+            if blob.exists():
+                blob.delete()
+                deleted.append(t)
+                if t == path:
+                    audio_existed = True
+    except Exception as exc:  # never leak internals; fail-closed
+        logger.warning("testset delete failed: path=%s err=%s", path, exc)
+        raise HTTPException(503, "delete failed, please retry")
+
+    if not audio_existed:
+        raise HTTPException(404, "recording not found")
+
+    logger.info("testset delete OK: %s (removed %d blobs)", path, len(deleted))
+    return {"ok": True, "deleted": deleted}
+
+
 @router.post("/testset/batch-eval")
 async def testset_batch_eval(
     current_user: User = Depends(get_current_user),

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -306,6 +306,7 @@ def testset_recordings():
 )
 def testset_delete_recording(
     audio_path: str = Query(..., description="要刪除錄音的 .webm 完整 GCS 路徑"),
+    current_user: User = Depends(get_current_user),
 ):
     """刪除單筆錄音（admin only）：刪同 stem 的 .webm + .json + .eval.json（#2465）。
 
@@ -347,7 +348,11 @@ def testset_delete_recording(
     if not audio_existed:
         raise HTTPException(404, "recording not found")
 
-    logger.info("testset delete OK: %s (removed %d blobs)", path, len(deleted))
+    # 不可逆破壞性操作 → 記錄執行的 admin（誰刪的），方便日後追查（#2466 review）
+    logger.info(
+        "testset delete OK: %s (removed %d blobs) by user_id=%s",
+        path, len(deleted), getattr(current_user, "id", None),
+    )
     return {"ok": True, "deleted": deleted}
 
 

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -328,8 +328,12 @@ def testset_delete_recording(
         raise HTTPException(503, "storage temporarily unavailable")
 
     base = path[: -len(".webm")]
-    # 同一筆錄音的三個 blob 共用 stem（.eval.json 跑分後才有，可能不存在）
-    targets = [path, base + ".json", base + ".eval.json"]
+    # 同一筆錄音的三個 blob 共用 stem（.eval.json 跑分後才有，可能不存在）。
+    # 順序關鍵（#2466 review, P0）：先刪 sidecar（.json/.eval.json）、.webm 最後刪。
+    # 中途失敗最多留一個「列表看不到」的 orphan .webm（無害 storage leak），列表狀態
+    # 永遠一致；且重試 DELETE 仍能清掉殘留的 .webm。反過來（.webm 先刪）中途失敗會留下
+    # 指向已刪音檔的 ghost .json，列表壞掉且再也刪不掉。
+    targets = [base + ".json", base + ".eval.json", path]
 
     deleted: list[str] = []
     audio_existed = False

--- a/backend/tests/test_testset_delete_route.py
+++ b/backend/tests/test_testset_delete_route.py
@@ -229,3 +229,58 @@ def test_only_target_stem_deleted_other_contributor_untouched():
         assert bucket.existing == {other, other_json}  # 另一貢獻者完整保留
     finally:
         _clear_user()
+
+
+class _RaiseOnDeleteBucket(_FakeBucket):
+    """指定某個 blob 的 delete() 拋錯，模擬刪除中途 storage 失敗。"""
+
+    def __init__(self, existing: set[str], raise_on: str):
+        super().__init__(existing)
+        self.raise_on = raise_on
+
+    def blob(self, name: str):
+        parent = self
+
+        class _Blob:
+            def exists(self):
+                return name in parent.existing
+
+            def delete(self):
+                if name == parent.raise_on:
+                    raise RuntimeError("simulated GCS delete failure")
+                parent.existing.discard(name)
+                parent.deleted.append(name)
+
+        return _Blob()
+
+
+def test_sidecar_delete_failure_keeps_webm_and_returns_503():
+    """中途失敗（.json delete 拋錯）→ 503，且 .webm 未被刪（#2466 P0）。
+
+    刪除順序刻意為 sidecar 先、.webm 最後：sidecar 刪一半失敗時，不可取代的音檔仍在，
+    列表狀態一致、可重試清除；不會留下指向已刪音檔、又刪不掉的 ghost .json。
+    """
+    _as_admin()
+    bucket = _RaiseOnDeleteBucket(
+        {VALID, STEM + ".json", STEM + ".eval.json"}, raise_on=STEM + ".json"
+    )
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 503, r.text
+        assert VALID in bucket.existing  # .webm 仍在（未被刪）→ 可重試，不變 ghost
+    finally:
+        _clear_user()
+
+
+def test_storage_unavailable_returns_503():
+    """_get_gcs_bucket 回 None（storage 不可用）→ fail-closed 503。"""
+    _as_admin()
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=None):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 503, r.text
+    finally:
+        _clear_user()

--- a/backend/tests/test_testset_delete_route.py
+++ b/backend/tests/test_testset_delete_route.py
@@ -1,0 +1,231 @@
+"""DELETE /api/testset/recordings — 刪除單筆錄音（#2465）。
+
+錄音明細表每列可刪；貢獻者非獨立實體 → 刪掉一筆錄音該筆貢獻者屬性隨之消失，
+若該貢獻者尚有其他錄音則其貢獻自然保留（各自獨立 blob，本 route 只碰目標 stem）。
+
+鎖定：
+  - no auth             -> 401
+  - logged-in non-admin -> 403
+  - system_admin / org_admin -> 200 + 刪 .webm/.json/.eval.json
+  - .eval.json 不存在   -> 只刪存在的兩個，仍 200
+  - 目標音檔不存在      -> 404
+  - 非法路徑（traversal / 跨 prefix / 非 .webm） -> 400
+  - 只刪目標 stem，不動其他貢獻者的 blob
+
+Run: cd backend && python -m pytest tests/test_testset_delete_route.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.dependencies import get_current_user
+
+engine = create_engine(
+    "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+)
+
+
+@event.listens_for(engine, "connect")
+def _pragma(conn, _):
+    cur = conn.cursor(); cur.execute("PRAGMA foreign_keys=ON"); cur.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _fresh_user(uid: int, uname: str) -> User:
+    return User(id=uid, username=uname, name=uname, email=f"{uname}@x.com", password_hash="x")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    for rd in [
+        {"name": "student", "display_name": "Student", "scope_level": "school"},
+        {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+        {"name": "org_admin", "display_name": "Org Admin", "scope_level": "organization"},
+    ]:
+        if not db.query(Role).filter(Role.name == rd["name"]).first():
+            db.add(Role(**rd))
+    db.commit()
+    db.add_all([_fresh_user(1, "admin_u"), _fresh_user(2, "pleb_u"), _fresh_user(3, "orgadmin_u")])
+    db.commit()
+    sa = db.query(Role).filter(Role.name == "system_admin").first()
+    st = db.query(Role).filter(Role.name == "student").first()
+    oa = db.query(Role).filter(Role.name == "org_admin").first()
+    db.add(UserRole(user_id=1, role_id=sa.id, scope_type="platform", scope_id=None))
+    db.add(UserRole(user_id=2, role_id=st.id, scope_type="school", scope_id="1"))
+    db.add(UserRole(user_id=3, role_id=oa.id, scope_type="organization", scope_id="1"))
+    db.commit()
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _wire_db():
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.clear()
+
+
+class _FakeBucket:
+    """記憶體模擬 GCS bucket：記存在的 blob 路徑，記錄 delete 呼叫。"""
+
+    def __init__(self, existing: set[str]):
+        self.existing = set(existing)
+        self.deleted: list[str] = []
+
+    def blob(self, name: str):
+        parent = self
+
+        class _Blob:
+            def exists(self):
+                return name in parent.existing
+
+            def delete(self):
+                parent.existing.discard(name)
+                parent.deleted.append(name)
+
+        return _Blob()
+
+
+VALID = "test-dataset/wang/lesson1/correct-abc12345.webm"
+STEM = "test-dataset/wang/lesson1/correct-abc12345"
+
+
+def _as_admin(uid=1, uname="admin_u"):
+    app.dependency_overrides[get_current_user] = lambda: _fresh_user(uid, uname)
+
+
+def _clear_user():
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_no_auth_returns_401():
+    with TestClient(app, raise_server_exceptions=False) as c:
+        r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+    assert r.status_code == 401, r.text
+
+
+def test_non_admin_returns_403():
+    _as_admin(2, "pleb_u")
+    try:
+        with TestClient(app, raise_server_exceptions=False) as c:
+            r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 403, r.text
+    finally:
+        _clear_user()
+
+
+def test_admin_deletes_all_three_blobs():
+    _as_admin()
+    bucket = _FakeBucket({VALID, STEM + ".json", STEM + ".eval.json"})
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 200, r.text
+        assert set(r.json()["deleted"]) == {VALID, STEM + ".json", STEM + ".eval.json"}
+        assert bucket.existing == set()
+    finally:
+        _clear_user()
+
+
+def test_org_admin_allowed():
+    _as_admin(3, "orgadmin_u")
+    bucket = _FakeBucket({VALID, STEM + ".json"})
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 200, r.text
+    finally:
+        _clear_user()
+
+
+def test_missing_eval_json_still_ok():
+    """.eval.json 未跑分 → 不存在，只刪 .webm + .json，仍 200。"""
+    _as_admin()
+    bucket = _FakeBucket({VALID, STEM + ".json"})
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 200, r.text
+        assert set(r.json()["deleted"]) == {VALID, STEM + ".json"}
+    finally:
+        _clear_user()
+
+
+def test_audio_not_found_returns_404():
+    _as_admin()
+    bucket = _FakeBucket(set())  # 目標音檔不存在
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 404, r.text
+    finally:
+        _clear_user()
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "test-dataset/wang/lesson1/correct-abc12345.json",   # 非 .webm
+        "../../etc/passwd",                                   # traversal
+        "test-dataset/../secret/x.webm",                      # traversal 進 prefix 後跳出
+        "other-prefix/x.webm",                                # 跨 prefix
+        "/absolute/x.webm",                                   # 絕對路徑
+    ],
+)
+def test_invalid_path_returns_400(bad):
+    _as_admin()
+    bucket = _FakeBucket({VALID})
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete("/api/testset/recordings", params={"audio_path": bad})
+        assert r.status_code == 400, r.text
+    finally:
+        _clear_user()
+
+
+def test_only_target_stem_deleted_other_contributor_untouched():
+    """刪某貢獻者一筆錄音，不動另一貢獻者的 blob（貢獻者資訊隨各自錄音保留）。"""
+    _as_admin()
+    other = "test-dataset/lee/lesson1/correct-zzz99999.webm"
+    other_json = "test-dataset/lee/lesson1/correct-zzz99999.json"
+    bucket = _FakeBucket({VALID, STEM + ".json", other, other_json})
+    try:
+        with patch("app.routes.testset._get_gcs_bucket", return_value=bucket):
+            with TestClient(app, raise_server_exceptions=False) as c:
+                r = c.delete(f"/api/testset/recordings?audio_path={VALID}")
+        assert r.status_code == 200, r.text
+        assert bucket.existing == {other, other_json}  # 另一貢獻者完整保留
+    finally:
+        _clear_user()

--- a/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
+++ b/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
@@ -160,7 +160,12 @@ function toggleDetail(id){
 
 /* ── 刪除單筆錄音（admin only）：DELETE /api/testset/recordings → reload ──
    錄音跟貢獻者綁一起：刪這筆該貢獻者屬性隨之消失；若他還有其他錄音，貢獻資訊自動保留。 */
-async function deleteRecording(btn, audioPath, title, versionName, contributor){
+async function deleteRecording(btn){
+  // 值一律從 data-* 讀（純字串，非 JS 原始碼）→ 不受信任的 contributor 也不會被當程式執行
+  var audioPath=btn.dataset.audio||'';
+  var title=btn.dataset.title||'';
+  var versionName=btn.dataset.version||'';
+  var contributor=btn.dataset.contrib||'';
   var msg='確定刪除這筆錄音？\n\n課文：'+title+'\n版本：'+versionName+'\n貢獻者：'+contributor+
     '\n\n此操作無法復原，該貢獻者若無其他錄音將一併從清單消失。';
   if(!confirm(msg)) return;
@@ -284,16 +289,25 @@ async function load(){
       allRecs.forEach(function(m){
         var vn=m.version==='correct'?'正確版':'錯誤版';
         var t=(m.created_at||'').replace('T',' ').slice(0,16);
-        // 刪除鈕帶課文/版本/貢獻者 → 由 deleteRecording 組確認訊息（避免 inline JS 字串含換行）
+        // 刪除鈕：不受信任的自由文字（contributor_name 來自無登入上傳，只 .strip()）一律走
+        // data-* 屬性，由 deleteRecording 用 this.dataset 當純字串讀 —— 不塞進可執行的 inline
+        // JS 字串，避免瀏覽器 decode attribute 後字串逃逸的 XSS（#2466 review）。
         var canDel=!!m.audio_path;
-        var delArgs="'"+esc(m.audio_path)+"','"+esc(s.title)+"','"+vn+"','"+esc(m.contributor_name||'—')+"'";
+        var delBtn=canDel
+          ?'<button class="del-btn" title="刪除此錄音"'+
+            ' data-audio="'+esc(m.audio_path)+'"'+
+            ' data-title="'+esc(s.title)+'"'+
+            ' data-version="'+esc(vn)+'"'+
+            ' data-contrib="'+esc(m.contributor_name||'—')+'"'+
+            ' onclick="deleteRecording(this)">🗑</button>'
+          :'<span class="muted">—</span>';
         h+='<tr>'+
           '<td>'+vn+'</td>'+
           '<td>'+esc(m.contributor_name)+'</td>'+
           '<td>'+esc(m.grade)+'</td>'+
           '<td class="muted">'+esc(t)+'</td>'+
           '<td>'+(m.play_url?'<audio controls preload="none" src="'+esc(m.play_url)+'"></audio>':'<span class="muted">—</span>')+'</td>'+
-          '<td>'+(canDel?'<button class="del-btn" title="刪除此錄音" onclick="deleteRecording(this,'+delArgs+')">🗑</button>':'<span class="muted">—</span>')+'</td>'+
+          '<td>'+delBtn+'</td>'+
           '</tr>';
       });
       h+='</tbody></table></div></td></tr>';

--- a/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
+++ b/frontend/public/testset-7f3a91c4/collect-status-9f2a7c4e.html
@@ -58,6 +58,9 @@
   .ai-score .ok{color:#15803d;font-weight:700}
   .ai-score .lo{color:#b45309;font-weight:700}
   .ai-score .anom{color:var(--red,#dc2626);font-weight:700}
+  .del-btn{background:#fff;border:1px solid var(--red,#dc2626);color:var(--red,#dc2626);border-radius:6px;padding:3px 9px;font:inherit;font-size:.82rem;cursor:pointer;line-height:1}
+  .del-btn:hover{background:#fee2e2}
+  .del-btn:disabled{opacity:.5;cursor:not-allowed}
 </style>
 </head>
 <body>
@@ -153,6 +156,28 @@ function toggleDetail(id){
   row.style.display=shown?'none':'table-row';
   var btn=document.querySelector('[data-expand="'+id+'"]');
   if(btn) btn.textContent=shown?'展開 ▼':'收起 ▲';
+}
+
+/* ── 刪除單筆錄音（admin only）：DELETE /api/testset/recordings → reload ──
+   錄音跟貢獻者綁一起：刪這筆該貢獻者屬性隨之消失；若他還有其他錄音，貢獻資訊自動保留。 */
+async function deleteRecording(btn, audioPath, title, versionName, contributor){
+  var msg='確定刪除這筆錄音？\n\n課文：'+title+'\n版本：'+versionName+'\n貢獻者：'+contributor+
+    '\n\n此操作無法復原，該貢獻者若無其他錄音將一併從清單消失。';
+  if(!confirm(msg)) return;
+  var token=localStorage.getItem('lingoleap_token');
+  if(!token){ alert('登入已過期，請重新登入後再刪除。'); return; }
+  btn.disabled=true;
+  var orig=btn.textContent; btn.textContent='刪除中…';
+  try{
+    var r=await fetch(API+'/api/testset/recordings?audio_path='+encodeURIComponent(audioPath),
+      {method:'DELETE',headers:{'Authorization':'Bearer '+token}});
+    if(r.status===401||r.status===403){ alert('權限不足或登入已過期，請重新登入後再試。'); btn.disabled=false; btn.textContent=orig; return; }
+    if(!r.ok) throw new Error('HTTP '+r.status);
+    await load();  // 重算統計 + pill + 明細；貢獻者若無其他錄音自動消失
+  }catch(e){
+    alert('刪除失敗：'+e.message);
+    btn.disabled=false; btn.textContent=orig;
+  }
 }
 
 /* ── load ── */
@@ -254,17 +279,21 @@ async function load(){
     if(hasDetail){
       h+='<tr class="detail-row" id="det-'+esc(id)+'"><td colspan="7"><div class="detail-inner">'+
         '<table class="det-table"><thead><tr>'+
-        '<th>版本</th><th>貢獻者</th><th>年級</th><th>時間</th><th>播放</th>'+
+        '<th>版本</th><th>貢獻者</th><th>年級</th><th>時間</th><th>播放</th><th>操作</th>'+
         '</tr></thead><tbody>';
       allRecs.forEach(function(m){
         var vn=m.version==='correct'?'正確版':'錯誤版';
         var t=(m.created_at||'').replace('T',' ').slice(0,16);
+        // 刪除鈕帶課文/版本/貢獻者 → 由 deleteRecording 組確認訊息（避免 inline JS 字串含換行）
+        var canDel=!!m.audio_path;
+        var delArgs="'"+esc(m.audio_path)+"','"+esc(s.title)+"','"+vn+"','"+esc(m.contributor_name||'—')+"'";
         h+='<tr>'+
           '<td>'+vn+'</td>'+
           '<td>'+esc(m.contributor_name)+'</td>'+
           '<td>'+esc(m.grade)+'</td>'+
           '<td class="muted">'+esc(t)+'</td>'+
           '<td>'+(m.play_url?'<audio controls preload="none" src="'+esc(m.play_url)+'"></audio>':'<span class="muted">—</span>')+'</td>'+
+          '<td>'+(canDel?'<button class="del-btn" title="刪除此錄音" onclick="deleteRecording(this,'+delArgs+')">🗑</button>':'<span class="muted">—</span>')+'</td>'+
           '</tr>';
       });
       h+='</tbody></table></div></td></tr>';


### PR DESCRIPTION
## 需求（#2465）

朗讀測試集現況表（`reading-pipeline.html#testset` → 內嵌 `collect-status-9f2a7c4e.html`），每篇課文「展開」後的錄音明細表，每列加一顆 🗑 可刪除該筆錄音。錄音跟貢獻者綁在一起刪；但該貢獻者若還有其他錄音，貢獻資訊要保留。

## 關鍵設計：貢獻者非獨立實體

「貢獻者」不是獨立儲存的紀錄，只是每筆錄音 `.json` metadata 內的 `contributor_name` 欄位（上方「貢獻者數」= distinct name 計數）。所以「錄音跟著貢獻者刪、還有其他錄音就保留」的語意**由資料模型天然滿足**——刪掉一筆錄音的 blob，該筆貢獻者屬性就一起消失；只有當某貢獻者「最後一筆」錄音被刪，他才會從清單/統計消失。**不需額外的貢獻者刪除邏輯**。

## 改動

### 後端 — `DELETE /api/testset/recordings`
- Auth：與 `GET /testset/recordings` 相同 gate `require_role("system_admin", "org_admin")`（錄音是平台級敏感資料、刪除不可逆，用最緊的 bar）。
- 入參 `audio_path`（`.webm` 完整路徑），刪除同 stem 的 3 個 blob：`.webm` + `.json` + `.eval.json`（`.eval.json` 未跑分時不存在則略過）。
- **Path traversal 防護**：必須 `test-dataset/` 開頭 + `.webm` 結尾 + 無 `..`，否則 400。
- Fail-closed：storage 不可用 503、目標音檔不存在 404。

### 前端 — `collect-status-9f2a7c4e.html`
- 明細表新增「操作」欄，每列 🗑。
- 點擊 → `confirm()` 二次確認（顯示課文 / 版本 / 貢獻者，避免誤刪）→ 帶 admin token 呼叫 DELETE → 成功後 `load()` 重算「總錄音數 / 已覆蓋格 / 貢獻者數」+ pill + 明細。
- 401/403/失敗 → alert、不動 UI。只有 admin 登入才看得到明細，故 🗑 天然只對 admin 出現。

## 測試

- 後端 `test_testset_delete_route.py` **12 passed**：no-auth 401 / non-admin 403 / system_admin+org_admin 200 / 3-blob 刪除 / `.eval.json` 缺失仍 200 / 404 / 非法路徑（traversal、跨 prefix、非 webm、絕對路徑）400 / 只刪目標 stem 不動其他貢獻者。
- testset 全套 **56 passed**（無回歸）。
- 前端 inline JS `node --check` 通過（靜態 HTML，非 tsx，不觸發 vitest/eslint gate）。
- specs registry freshness 綠（testset 無對應 spec module）。

## 驗收條件

- [x] admin 明細每列有 🗑，confirm 後 3 blob（含 .eval.json）被刪
- [x] 刪除後統計 / pill 正確更新（reload）
- [x] 刪某貢獻者唯一一筆 → 貢獻者消失；刪其中一筆（尚有其他）→ 貢獻者保留、數字 -1
- [x] 非 admin / 未登入 → 401/403，看不到 🗑
- [x] path traversal / 跨 prefix 被拒
- [ ] preview 部署後 QA（admin 登入 → 展開 → 刪一筆 → 驗統計更新 + console 乾淨）

## 備註

刪除**不可復原**（GCS blob 直接刪），故前端一定 confirm 二次確認。純新增功能，不動既有上傳/跑分流程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
