### PR TITLE
chore: gitignore graphify-out/ (18M local cache) (Fixes #2468)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ issue*done.md
 # Content Evidence Gate (#2397) — re-shootable artifacts (screenshots / api payloads / logs)
 # stay local; the *.jsonl + coverage_manifest.json records ARE committed as evidence.
 qa/content-evidence/*/artifacts/
+
+# graphify architecture map — local knowledge-graph cache (18M), rebuilt on demand, not committed
+graphify-out/


### PR DESCRIPTION
## Summary
`graphify-out/` = 18M graphify 架構圖本地 cache（rebuilt on demand，per project CLAUDE.md 保持本地）。原本 untracked 且未 gitignore → 有被誤 `git add` 進 18M 的風險。加進 `.gitignore`。

純 .gitignore chore，無 code、無部署影響。Fixes #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)