### PR TITLE
test(security): OWASP WSTG blackbox 資安驗收 suite + regression gate (#2470)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,3 +55,14 @@ jobs:
           AZURE_SPEECH_KEY: ""
           AZURE_SPEECH_REGION: eastus
           JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
+
+      - name: Run security regression tests (blackbox audit gate — WSTG-mapped)
+        run: |
+          cd backend
+          python -m pytest --tb=short -q tests/security/test_dynamic_security.py
+        env:
+          DATABASE_URL: sqlite://
+          TTS_PROVIDER: google
+          AZURE_SPEECH_KEY: ""
+          AZURE_SPEECH_REGION: eastus
+          JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -314,3 +314,24 @@ def test_idor_org_admin_cannot_read_cross_org_classroom(client):
     # 正確行為：跨 org 的 org_admin 不該讀到別家班級 → 應 403
     # 目前 is_admin bypass 會回 200（漏洞）→ 本測 xfail，修好後轉綠
     assert client.get(f"/api/classrooms/{cid}", headers=_auth(tok)).status_code == 403
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="NEW-1（Cursor 盲掃，已驗證）：schools.py list_school_members/classrooms 只有 get_current_user、"
+    "無 org/school scope → 任何登入者猜 school_id 即可撈全校成員 name/email/role。"
+    "加 org/school membership 檢查後此測轉綠，移除 xfail marker。",
+)
+def test_idor_any_user_cannot_enumerate_school_members(client):
+    # 註冊教師會建立預設 school（含該教師為成員，帶 email）
+    _register_teacher(client)
+    sid = _first_school_id()
+    assert sid is not None
+
+    # 與該 school 完全無關的登入者（無任何 role）
+    outsider = _create_user(f"outsider_{uuid.uuid4().hex[:8]}@example.com")
+    tok = create_access_token(outsider)
+
+    # 正確行為：無關使用者不該讀到全校成員名冊（PII）→ 應 403
+    # 目前無授權檢查會回 200 + email（漏洞）→ 本測 xfail，修好後轉綠
+    assert client.get(f"/api/schools/{sid}/members", headers=_auth(tok)).status_code == 403

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -1,0 +1,316 @@
+"""
+黑白箱資安驗收 — 動態行為測試（in-process TestClient，全本機、免雲端、免 Vertex）。
+
+補齊 tests/security/blackbox_acceptance.sh 靜態段標 [DEFER] 的動態項：
+  - 安全標頭出現在真實回應          (A05 · WSTG-CONF-07)
+  - 未授權 / 偽造 JWT 被拒           (A07 · WSTG-ATHN)
+  - CORS 不反射未白名單 Origin       (A05 · WSTG-CONF-07)
+  - 公開上傳偽造 MIME / 路徑注入被拒 (A03 · WSTG-INPV / BUSL)
+  - IDOR：教師 B 不能讀教師 A 的班級 (A01 · WSTG-ATHZ-04)  ← 靜態段無法驗，這裡真打
+
+Run:
+    cd backend && python -m pytest tests/security/test_dynamic_security.py -v
+"""
+import base64
+import json
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.auth.jwt import create_access_token
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _pragma(dbapi_connection, connection_record):
+    cur = dbapi_connection.cursor()
+    cur.execute("PRAGMA foreign_keys=ON")
+    cur.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    from app.models.user import Role
+
+    Base.metadata.create_all(bind=engine)
+    s = TestingSessionLocal()
+    for r in SEED_ROLES:
+        s.add(Role(**r))
+    s.commit()
+    s.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _b64(d: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+
+
+def _fake_token(alg: str) -> str:
+    """Build a structurally-valid but unsigned/forged token at runtime.
+
+    Constructed from parts so no literal JWT string sits in source (avoids
+    secret-scanner false positives on obviously-fake test tokens).
+    """
+    header = _b64({"alg": alg, "typ": "JWT"})
+    body = _b64({"sub": "1"})
+    return f"{header}.{body}.forged"  # bogus signature segment
+
+
+def _register_teacher(client) -> dict:
+    u = uuid.uuid4().hex[:8]
+    email, pw = f"t_{u}@example.com", "SecurePass123!"
+    r = client.post("/api/auth/register", json={"email": email, "password": pw, "name": f"T{u}"})
+    assert r.status_code == 201, r.text
+    vt = r.json().get("verification_token")
+    if vt:
+        client.get(f"/api/auth/verify-email?token={vt}")
+    tok = client.post("/api/auth/login", json={"email": email, "password": pw}).json()["access_token"]
+    uid = client.get("/api/users/me", headers=_auth(tok)).json()["id"]
+    return {"token": tok, "user_id": uid, "email": email}
+
+
+def _first_school_id() -> int:
+    from app.models.school import School
+
+    db = TestingSessionLocal()
+    try:
+        s = db.query(School).first()
+        return s.id if s else None
+    finally:
+        db.close()
+
+
+# ── A05 · WSTG-CONF-07 安全標頭 ────────────────────────────────────────────
+def test_security_headers_present(client):
+    r = client.get("/api/health")
+    h = {k.lower(): v for k, v in r.headers.items()}
+    assert h.get("x-frame-options") == "DENY"
+    assert h.get("x-content-type-options") == "nosniff"
+    assert "content-security-policy" in h
+    assert "strict-transport-security" in h
+    assert "frame-ancestors 'none'" in h["content-security-policy"]
+
+
+# ── A07 · WSTG-ATHN 未授權 / 偽造 token ────────────────────────────────────
+def test_protected_endpoint_requires_auth(client):
+    assert client.get("/api/users/me").status_code == 401
+
+
+def test_forged_jwt_rejected(client):
+    forged = _fake_token("HS256")  # 正確 alg 但簽章是假的
+    assert client.get("/api/users/me", headers=_auth(forged)).status_code == 401
+
+
+def test_alg_none_token_rejected(client):
+    # alg=none token（無簽章）必須被拒 — 防 alg-confusion
+    none_tok = _fake_token("none")
+    assert client.get("/api/users/me", headers=_auth(none_tok)).status_code == 401
+
+
+# ── A05 · WSTG-CONF-07 CORS 不反射惡意 Origin ──────────────────────────────
+def test_cors_does_not_reflect_evil_origin(client):
+    r = client.get("/api/health", headers={"Origin": "https://evil.example"})
+    acao = r.headers.get("access-control-allow-origin")
+    assert acao != "https://evil.example"
+
+
+# ── A03 · WSTG-INPV / BUSL 公開上傳硬化 ────────────────────────────────────
+def test_upload_rejects_spoofed_mime(client):
+    # 宣稱 audio/wav 但內容不是 RIFF/WAVE → magic-bytes 不符 → 400
+    r = client.post(
+        "/api/testset/upload",
+        data={"contributor_name": "probe", "lesson_id": "G6-L22", "version": "correct"},
+        files={"audio": ("x.wav", b"not-a-real-wav-file", "audio/wav")},
+    )
+    assert r.status_code in (400, 415), r.text
+
+
+def test_upload_rejects_path_traversal_lesson_id(client):
+    r = client.post(
+        "/api/testset/upload",
+        data={"contributor_name": "probe", "lesson_id": "../../etc/passwd", "version": "correct"},
+        files={"audio": ("x.wav", b"RIFF....WAVE", "audio/wav")},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_upload_rejects_unknown_mime(client):
+    r = client.post(
+        "/api/testset/upload",
+        data={"contributor_name": "probe", "lesson_id": "G6-L22", "version": "correct"},
+        files={"audio": ("x.exe", b"MZ\x90\x00", "application/octet-stream")},
+    )
+    assert r.status_code in (400, 415), r.text
+
+
+# ── A01 · WSTG-ATHZ-04 IDOR：跨教師班級隔離 ────────────────────────────────
+def test_idor_teacher_cannot_read_other_teachers_classroom(client):
+    a = _register_teacher(client)
+    b = _register_teacher(client)
+    school_id = _first_school_id()
+    assert school_id is not None, "註冊時應已建立預設 school"
+
+    created = client.post(
+        "/api/classrooms",
+        json={"name": f"ClassA_{uuid.uuid4().hex[:6]}", "grade": 6, "school_id": school_id},
+        headers=_auth(a["token"]),
+    )
+    assert created.status_code == 201, created.text
+    cid = created.json()["id"]
+
+    # 正向控制：擁有者 A 可讀自己的班級
+    assert client.get(f"/api/classrooms/{cid}", headers=_auth(a["token"])).status_code == 200
+    # IDOR：教師 B（非擁有者/非協同/非 admin）讀 A 的班級 → 403
+    assert client.get(f"/api/classrooms/{cid}", headers=_auth(b["token"])).status_code == 403
+    # 未授權讀 → 401
+    assert client.get(f"/api/classrooms/{cid}").status_code == 401
+
+
+# ── A01 · WSTG-ATHZ-04 IDOR：跨組織資料隔離（org_admin 不得跨 org 讀）─────────
+# 直接建 User + org role + 簽 token，避開註冊時 school→org 綁定污染 org 判斷。
+def _create_user(email: str) -> int:
+    from app.models.user import User
+    from app.auth.password import hash_password
+
+    db = TestingSessionLocal()
+    try:
+        u = User(email=email, password_hash=hash_password("x"), name="X", is_active=True, email_verified=True)
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u.id
+    finally:
+        db.close()
+
+
+def _create_org(name: str) -> str:
+    from app.models.organization import Organization
+
+    db = TestingSessionLocal()
+    try:
+        o = Organization(name=name)
+        db.add(o)
+        db.commit()
+        db.refresh(o)
+        return o.id
+    finally:
+        db.close()
+
+
+def _grant_role(user_id: int, role_name: str, scope_type: str, scope_id):
+    from app.models.user import Role, UserRole
+
+    db = TestingSessionLocal()
+    try:
+        role = db.query(Role).filter(Role.name == role_name).first()
+        db.add(UserRole(user_id=user_id, role_id=role.id, scope_type=scope_type,
+                        scope_id=scope_id, is_active=True))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_idor_org_admin_cannot_read_cross_org_user(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"OrgA_{u}")
+    org_b = _create_org(f"OrgB_{u}")
+
+    admin_a = _create_user(f"orgadmin_a_{u}@example.com")
+    same_org_user = _create_user(f"member_a_{u}@example.com")   # 同 org A → 正向控制
+    cross_org_user = _create_user(f"member_b_{u}@example.com")  # org B → IDOR 標的
+    sysadmin = _create_user(f"sys_{u}@example.com")
+
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+    _grant_role(same_org_user, "org_admin", "organization", org_a)
+    _grant_role(cross_org_user, "org_admin", "organization", org_b)
+    _grant_role(sysadmin, "system_admin", "platform", None)
+
+    tok_a = create_access_token(admin_a)
+    tok_sys = create_access_token(sysadmin)
+
+    # IDOR：org_admin A 讀 org B 使用者 → 403（個資法 §20）
+    assert client.get(f"/api/users/{cross_org_user}", headers=_auth(tok_a)).status_code == 403
+    # 正向控制：org_admin A 讀同 org A 使用者 → 200
+    assert client.get(f"/api/users/{same_org_user}", headers=_auth(tok_a)).status_code == 200
+    # system_admin 全域 bypass → 讀 org B 使用者 200（確認 bypass 只限 system_admin）
+    assert client.get(f"/api/users/{cross_org_user}", headers=_auth(tok_sys)).status_code == 200
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="MED-1（對抗複審）：policies.require_classroom_member 用 is_admin（含 org_admin 無 org scope）"
+    " → 跨 org org_admin 可讀別家班級。修 policies.py 改 is_system_admin + org scope 後此測應轉綠，"
+    "屆時移除 xfail marker。",
+)
+def test_idor_org_admin_cannot_read_cross_org_classroom(client):
+    # 教師在預設 school 建一個班級
+    teacher = _register_teacher(client)
+    school_id = _first_school_id()
+    created = client.post(
+        "/api/classrooms",
+        json={"name": f"ClsB_{uuid.uuid4().hex[:6]}", "grade": 6, "school_id": school_id},
+        headers=_auth(teacher["token"]),
+    )
+    assert created.status_code == 201, created.text
+    cid = created.json()["id"]
+
+    # 另一個 org 的 org_admin（與該班 school 的 org 無關）
+    other_org = _create_org(f"OtherOrg_{uuid.uuid4().hex[:6]}")
+    outsider = _create_user(f"orgadmin_x_{uuid.uuid4().hex[:6]}@example.com")
+    _grant_role(outsider, "org_admin", "organization", other_org)
+    tok = create_access_token(outsider)
+
+    # 正確行為：跨 org 的 org_admin 不該讀到別家班級 → 應 403
+    # 目前 is_admin bypass 會回 200（漏洞）→ 本測 xfail，修好後轉綠
+    assert client.get(f"/api/classrooms/{cid}", headers=_auth(tok)).status_code == 403

--- a/docs/security/2026-07-04-blackbox-result.md
+++ b/docs/security/2026-07-04-blackbox-result.md
@@ -1,0 +1,117 @@
+# LingoLeap 黑白箱資安驗收報告 — 2026-07-04
+
+> **範圍界定（誠實，先講）**
+> - 本報告 = **我方自測 + regression lock**，依 OWASP WSTG/Top10 方法論在**本機**執行
+> - **不等於**院方/客戶官方稽核，**不等於**真人 pentester 簽名認證
+> - 綠燈 = 對映的 WSTG 條目「自測通過」，不保證通過官方稽核
+> - 全程 LOCAL：靜態 grep + Semgrep + gitleaks + in-process TestClient 動態測試 + 獨立對抗複審 agent；**未**對雲端正式站台燒錢掃描
+
+## 目前 gate 狀態：🔴 RED — 未通過（有 1 HIGH + 3 MED 待修）
+
+> 底子做得比一般案子好（認證/授權/注入/機密大面積乾淨），但獨立對抗複審抓到 **1 個真 HIGH + 3 個 MED**，修好前**不建議送官方稽核**。
+
+## 受測標的
+- Repo：`chinese-literacy-platform`（LingoLeap）— 國小/國中中文閱讀學習平台
+- 後端：FastAPI + SQLAlchemy + PostgreSQL + Vertex AI Gemini（`backend/app/`，140+ endpoints）
+- 前端：React 19 + Vite + Tailwind（`frontend/src/`）
+- 角色：學生 / 教師 / admin（system_admin / org_admin / school-scoped）
+
+## 工具鏈
+| 面向 | 工具 | 版本 | 結果 |
+|------|------|------|------|
+| 白箱靜態掃碼 | Semgrep（owasp-top-ten + python + javascript + secrets）| 1.168.0 | 0 ERROR（1 WARNING = 誤報）|
+| 機密外洩 | gitleaks（全 git 歷史 + 本機檔）| 8.30.1 | git 歷史 **0**；本機檔 4（全 gitignored）|
+| 動態行為 | FastAPI TestClient（in-process，sqlite）| — | 10 pass / 1 xfail（xfail = 鎖住 MED-1 待修）|
+| 靜態驗收 | `tests/security/blackbox_acceptance.sh` | — | **23 PASS / 5 FAIL / 2 DEFER（exit 1）** |
+| 獨立對抗複審 | `appsec-pentest-reviewer` agent（assume-guilty 白箱）| — | 1 HIGH + 3 MED + 5 LOW；大面積綠 |
+
+## 結果總覽
+- **無** SQL injection / 命令注入 / SSRF / 硬編 secret / committed secret
+- 認證底子好：JWT 演算法 pin 死、prod secret fail-closed、bcrypt cost 12、密碼重設 token 一次性無 oracle
+- 授權大面積有擋：學生資料 IDOR 三層 ownership、org scope（users/organizations）正確、角色指派限 system_admin
+- **但** 有 1 HIGH（限流全線可繞）+ 3 MED（跨 org 班級越權 / LLM 燒錢 / SSO 未驗 email_verified）待修
+
+## 🔴 待修發現（對抗複審，已逐條對 code 獨立驗證）
+
+### HIGH-1 — 所有流量限制可被偽造 X-Forwarded-For 繞過
+`WSTG-ATHN-03`（弱鎖定）/ `WSTG-BUSL-01`（反自動化）/ CWE-307, CWE-799
+- **影響**：per-IP 限流是登入暴力破解、AI 燒錢、匿名灌檔的唯一防線。攻擊者每次換一個假 `X-Forwarded-For`，計數器歸零 → 三條防線全失效。學生帳號由教師建（有預設密碼）→ 可無限猜密碼接管童帳號 + 個資。
+- **證據（三個疊加，均已驗）**：
+  - `backend/entrypoint.sh:51` — `--forwarded-allow-ips='*'`（無條件信任任何人的 XFF，官方明文警告勿用）
+  - `backend/app/main.py:263` — `ip = forwarded_for.split(",")[0]`（取最左 = 攻擊者可控；Cloud Run 把真 IP 接在後面）
+  - `backend/app/auth/rate_limiter.py:107-113` — `get_client_key` 讀 `request.state.user_id`，但**全 repo grep 證實此值從未被設定** → per-user 限流靜默退化成 per-IP
+- **修法**：(a) `--forwarded-allow-ips` 收窄可信代理範圍/hop 數；(b) 取 XFF **最右可信一跳**非 `[0]`；(c) auth dependency 解 JWT 後真的寫入 `request.state.user_id`
+- **red→green**：登入端點連打 11 次、每次不同 `X-Forwarded-For: 9.9.9.N` → 修前第 11 次仍 200/401（繞過=紅）、修後回 429（綠）；AI 端點同法
+
+### MED-1 — org_admin 可跨組織讀別家班級 / 作業 / 學生錄音
+`WSTG-ATHZ-02`（BOLA）/ CWE-639, CWE-863
+- **影響**：A 機構管理員可聽 B 機構小朋友朗讀錄音、改 B 機構作業。單機構期影響小，**多機構一上線 = 跨客戶個資外洩**。
+- **證據（同 bug 兩實作、只修一處）**：
+  - `backend/app/auth/policies.py:17-35` `is_admin()` 只比角色名（含 org_admin），**無 org scope**——docstring 自己警告勿當全域 bypass
+  - `backend/app/auth/policies.py:99-131` `require_classroom_owner/member`（org-scope 敏感情境）卻 `if is_admin(...): return`
+  - 傳播：`classrooms/helpers.py` → `assignments.py` → `teacher_audio_replay.py`（聽學生錄音）、`co_teaching.py`
+  - 正確對照：`backend/app/dependencies/tenant.py:165-235` 有把 org_admin 鎖在 `school.organization_id in user_org_admin_ids`
+- **修法**：`require_classroom_owner/member` 把 `is_admin` 換 `is_system_admin` 全域 bypass + org_admin 走 school→org scope（複用 `tenant._check_classroom_access`，砍重複實作）
+- **red→green**：已鎖 `test_idor_org_admin_cannot_read_cross_org_classroom`（現 xfail strict：斷言 403、目前回 200）；修好轉 xpass→移除 marker
+
+### MED-2 — LLM 端點可被登入者濫用燒錢
+`A04:2021` / `A10`（LLM 資源濫用）/ `WSTG-BUSL-01`
+- **證據**：
+  - `backend/app/routes/testset.py:303-311` `/testset/batch-eval` 任何登入者（含學生）可觸發、單次跑最多 30 筆 Gemini，**無** role gate、無 AI 限流
+  - `backend/app/routes/stories.py:614-619` `/stories/{id}/structure/grade` 呼叫 AI 無 AI 限流、非 cache
+  - teacher_analytics/alerts/dashboard/reports/cross_text 多個 AI 端點無 `ai_limit_*`
+  - 對照做對：`tts.py:99/161` 用真 per-user `tts_rate_limit`
+- **修法**：修好 HIGH-1（per-user key 生效）後，`batch-eval` 加 `require_role(admin/teacher)`+AI 限流；其餘 AI 端點補 `ai_limit_*`
+- **red→green**：學生 token 連打 `/testset/batch-eval` 12 次 → 修前每次跑（紅）、修後第 11 次 429/403（綠）
+
+### MED-3 — Google 登入用 email 連結帳號但未驗 `email_verified`
+`WSTG-ATHN-01` / `A07:2021` / CWE-287
+- **證據**：`backend/app/services/sso_login_service.py:53-57` 有驗 audience（綠）；但 `resolve_google_user:100-102` 直接 `filter(User.email == email)` 連結既有帳號，**全程未讀 `id_info.get("email_verified")`**（該檔 4 處 email_verified 全是註解/設定新帳號欄位，非驗 claim）
+- **現實性**：消費者 Gmail email_verified 恆 true，實際利用門檻高 → defense-in-depth，但修一行值得
+- **修法**：連結/建立帳號前 `if not id_info.get("email_verified"): raise 401`
+
+## 🟡 LOW（Hardening）
+- **LOW-1** OMO 上傳只驗 header MIME 不驗 magic bytes（`omo_upload_validator.py:42`）— 與 testset 不一致；已登入+私有 bucket，風險有限。修：比照 testset 加前導位元組
+- **LOW-2** 登入 timing 使用者列舉（`auth.py:185` user 不存在時短路不跑 bcrypt）— 修：user None 也跑 dummy bcrypt
+- **LOW-3** `is_dev` 偵測不一致：`main.py:69` 用較弱的 ENVIRONMENT 預設（docs_url + 空 JWT 警告用它），`config.py:54` 才有 K_SERVICE fail-safe；目前 `deploy.yml:76` 設 ENVIRONMENT=production 擋住 → LOW。修：main.py 統一用 `settings.is_dev`
+- **LOW-4** org_admin 可查任一使用者角色列表跨 org（`roles.py:158-190` 無 org scope）— 修：比照 `users.py:290-297`
+- **LOW-5** `/api/tts/mapping/{lesson_id}` 匿名可讀（`tts.py:188`）— 無 PII，資訊性可不修
+- **LOW-6** 本機 `backend/.env` 含實際 AZURE_SPEECH_KEY（gitignored 且從未 commit，非 git 洩漏）— 確認是否仍需/輪替
+
+## 🟢 已驗乾淨（assume-guilty 下實際驗過，附證據）
+JWT 演算法 pin（`jwt.py:25`）｜JWT prod fail-closed（`main.py:72`）｜bcrypt cost 12｜無 SQLi（全 ORM，`text()` 僅靜態）｜無命令注入（list 形式無 shell=True）｜無 SSRF（host 硬編/config）｜學生資料 IDOR 三層 ownership｜RBAC org scope（users/orgs）｜角色指派限 system_admin｜testset 公開上傳（白名單+magic bytes+8MB cap+fail-closed）｜GCS 全私有+SignBlob 10min｜無 committed secret｜security headers 齊全｜500 不洩 stack｜密碼重設 token 一次性無 oracle｜SSO audience 有驗｜CORS 具名非 wildcard｜prod docs 關｜IP 未用於授權
+
+## WSTG 覆蓋（動態實測）
+| WSTG | 檢查 | 證據 | 判定 |
+|------|------|------|------|
+| ATHN | 未授權 / 偽造 JWT / alg=none → 401 | 動態測試 3 條 | ✅ |
+| CONF-07 | 安全標頭 / CORS 不反射惡意 origin | 動態測試 | ✅ |
+| INPV/BUSL | 上傳偽造 MIME / 路徑注入 → 400 | 動態測試 3 條 | ✅ |
+| ATHZ-04 | 教師 B 不能讀教師 A 班級 | B→403 / owner→200 / 匿名→401 | ✅ |
+| ATHZ-04 | org_admin 不能跨 org 讀使用者 | 跨→403 / 同→200 / sysadmin→200 | ✅ |
+| ATHZ-02 | org_admin 不能跨 org 讀班級 | **現 xfail（回 200，MED-1）** | 🔴 待修 |
+
+## Regression Lock（怎麼重複跑）
+```bash
+# 白箱靜態全檢（含對抗複審 red→green 鎖，現 exit 1）
+./tests/security/blackbox_acceptance.sh
+RUN_SEMGREP=1 ./tests/security/blackbox_acceptance.sh    # 加 Semgrep
+
+# 動態行為 + IDOR（in-process，全本機）
+cd backend && python -m pytest tests/security/test_dynamic_security.py -v
+```
+產出檔（committed = regression lock）：
+- `tests/security/blackbox_acceptance.sh` — WSTG-mapped 靜態 gate（含 5 條待修鎖）
+- `backend/tests/security/test_dynamic_security.py` — 動態 + IDOR gate（10 pass + 1 xfail=MED-1）
+
+## 送稽核就緒度清單
+- [ ] **必修** HIGH-1：`forwarded-allow-ips` 收窄 + XFF 取信任 hop + 落實 `request.state.user_id`（header-rotation 測試紅轉綠）
+- [ ] **必修** MED-1：`require_classroom_owner/member` 改 `is_system_admin`+org scope（xfail 轉綠）
+- [ ] **建議** MED-2：`batch-eval` role gate + AI 端點補限流
+- [ ] **建議** MED-3：SSO 加 `email_verified` 檢查
+- [ ] LOW-1~6 排待辦
+- [ ] 本次為**靜態+in-process**，尚缺：staging 跑 `testssl.sh`（TLS 層）、`pip-audit`/`safety`（依賴 CVE）、關鍵繞過的動態 curl 實證
+- [ ] **需真人簽名背書上線時，這關要找真人資安顧問**——本報告是第一線自測，非最終背書
+
+## 對抗複審 verdict（已整合）
+`appsec-pentest-reviewer` agent 獨立 assume-guilty 白箱審查（221k tokens / 51 tool calls / 13.5 min），抓到主 agent 漏的 HIGH-1（entrypoint XFF）+ MED-1（policies vs tenant 兩實作只修一處）。我逐條對真實 code 驗證後全部確認為真（見上）。**教訓：最貴的洞常是「同件事兩套實作只修一套」+「防線的前提假設沒成立」（限流以為擋 IP，但 IP 本身可偽造）**——已各配 red→green 測試，看紅轉綠即可，不必讀 code。

--- a/docs/security/2026-07-04-blackbox-result.md
+++ b/docs/security/2026-07-04-blackbox-result.md
@@ -6,9 +6,11 @@
 > - 綠燈 = 對映的 WSTG 條目「自測通過」，不保證通過官方稽核
 > - 全程 LOCAL：靜態 grep + Semgrep + gitleaks + in-process TestClient 動態測試 + 獨立對抗複審 agent；**未**對雲端正式站台燒錢掃描
 
-## 目前 gate 狀態：🔴 RED — 未通過（有 1 HIGH + 3 MED 待修）
+## 目前 gate 狀態：🔴 RED — 未通過
 
-> 底子做得比一般案子好（認證/授權/注入/機密大面積乾淨），但獨立對抗複審抓到 **1 個真 HIGH + 3 個 MED**，修好前**不建議送官方稽核**。
+> 兩輪獨立對抗複審後（appsec-pentest-reviewer + Cursor 不同引擎），確認 **≈4 HIGH + 5 MED + 多個 LOW**，且核心是**系統性租戶隔離破口**（`is_admin` 被當全域 bypass + 多個 school-scoped 讀取路徑零授權）。修好前**不建議送官方稽核**。
+>
+> 認證/注入/機密底子仍好（JWT/bcrypt/ORM/無 committed secret 全綠），問題集中在**授權（tenant isolation）+ 限流信任鏈**。
 
 ## 受測標的
 - Repo：`chinese-literacy-platform`（LingoLeap）— 國小/國中中文閱讀學習平台
@@ -42,10 +44,13 @@
   - `backend/app/auth/rate_limiter.py:107-113` — `get_client_key` 讀 `request.state.user_id`，但**全 repo grep 證實此值從未被設定** → per-user 限流靜默退化成 per-IP
 - **修法**：(a) `--forwarded-allow-ips` 收窄可信代理範圍/hop 數；(b) 取 XFF **最右可信一跳**非 `[0]`；(c) auth dependency 解 JWT 後真的寫入 `request.state.user_id`
 - **red→green**：登入端點連打 11 次、每次不同 `X-Forwarded-For: 9.9.9.N` → 修前第 11 次仍 200/401（繞過=紅）、修後回 429（綠）；AI 端點同法
+- **✅ 活體 PoC 已確認（served layer）**：跑真 ASGI 中介層，limit=2 送 5 次——固定 XFF `9.9.9.9` → `[422,422,429,429,429]`（3×429，限流有效）；輪換 XFF `9.9.9.N` → `[422,422,422,422,422]`（**0×429，完全繞過**）
+- **範圍修正（Cursor）**：非「**所有**」限流——`tts_rate_limit(user_id)` 直接用 JWT user_id、不受 XFF 影響（安全）。受害的是 global middleware + 登入暴破 + AI dependency 限流三條
 
-### MED-1 — org_admin 可跨組織讀別家班級 / 作業 / 學生錄音
+### MED-1 → 升 HIGH（Cursor 論證）— `is_admin` 全域 bypass = 系統性跨組織越權
 `WSTG-ATHZ-02`（BOLA）/ CWE-639, CWE-863
-- **影響**：A 機構管理員可聽 B 機構小朋友朗讀錄音、改 B 機構作業。單機構期影響小，**多機構一上線 = 跨客戶個資外洩**。
+- **升級理由**：不是單一班級端點，是**系統性**——`is_admin()`（把 org_admin 當 system_admin）被當全域 bypass 用在 **classroom / assignment / 學生錄音 / student-sessions / semester / org-dashboard / org-points / school-regen-code** 等 8+ 路徑。含**讀 + 寫 + 學生 PII + 朗讀錄音 signed URL**。
+- **影響**：A 機構管理員可聽 B 機構小朋友朗讀錄音、讀 B 機構學生名單/email、改 B 機構作業。**多機構一上線 = 跨客戶個資外洩**。
 - **證據（同 bug 兩實作、只修一處）**：
   - `backend/app/auth/policies.py:17-35` `is_admin()` 只比角色名（含 org_admin），**無 org scope**——docstring 自己警告勿當全域 bypass
   - `backend/app/auth/policies.py:99-131` `require_classroom_owner/member`（org-scope 敏感情境）卻 `if is_admin(...): return`
@@ -69,6 +74,26 @@
 - **證據**：`backend/app/services/sso_login_service.py:53-57` 有驗 audience（綠）；但 `resolve_google_user:100-102` 直接 `filter(User.email == email)` 連結既有帳號，**全程未讀 `id_info.get("email_verified")`**（該檔 4 處 email_verified 全是註解/設定新帳號欄位，非驗 claim）
 - **現實性**：消費者 Gmail email_verified 恆 true，實際利用門檻高 → defense-in-depth，但修一行值得
 - **修法**：連結/建立帳號前 `if not id_info.get("email_verified"): raise 401`
+
+## 🔴 對抗複審新增發現（Cursor 盲掃，已逐條對 code 驗證）
+
+### NEW-1 — 任何登入者可枚舉全校成員 name/email/role（HIGH）
+`WSTG-ATHZ-04` / CWE-639
+- **證據**：`schools.py:203-231 list_school_classrooms` + `241-271 list_school_members` 只有 `Depends(get_current_user)` + 存在性檢查，**零 org/school membership 檢查、無 require_role**
+- **影響**：任何登入者（含學生）iterate `school_id` → `GET /api/schools/{id}/members` 撈全校師生 **email**。比 MED-1 更廣（任何人，非只 org_admin）
+- **red→green**：已鎖 `test_idor_any_user_cannot_enumerate_school_members`（strict xfail：無關 user 讀 members 應 403、目前 200）
+
+### NEW-2 — 任何教師可在別 org 的 school 建班（HIGH）
+`WSTG-ATHZ-02`
+- **證據**：`classroom_crud.py:51-77 create_classroom` 只 `filter(School.id==school_id)` 驗存在，**不驗 caller 對該 school 的 org membership**
+- **修法**：驗 caller 屬該 school 的 org；org_admin 限自己 org
+
+### NEW-3/4/5 — 同根 `is_admin` bypass / 缺 scope（MED）
+- **NEW-3** `organization_dashboard.py:37` + `organization_points.py`：`if not is_admin(...)` → org_admin 因 is_admin=True 直接跳過 org 檢查（has_org_role 對 org_admin 是死碼）→ 讀任意 org dashboard/points
+- **NEW-4** `semesters.py:107 _require_school_write_access` 用 `is_admin` → org_admin 對任意 school 建/改 semester；`list_school_semesters:135` 任何登入者可讀
+- **NEW-5** `schools.py:178-193 regenerate-code` 有 `require_role(org_admin)` 但**缺** org_ids 檢查（同檔 `update_school` 有）→ 跨 org 重置 join code
+
+### NEW-6 — testset recordings 對任意 org_admin 平台級跨校（LOW，已知 #2437）
 
 ## 🟡 LOW（Hardening）
 - **LOW-1** OMO 上傳只驗 header MIME 不驗 magic bytes（`omo_upload_validator.py:42`）— 與 testset 不一致；已登入+私有 bucket，風險有限。修：比照 testset 加前導位元組
@@ -113,5 +138,18 @@ cd backend && python -m pytest tests/security/test_dynamic_security.py -v
 - [ ] 本次為**靜態+in-process**，尚缺：staging 跑 `testssl.sh`（TLS 層）、`pip-audit`/`safety`（依賴 CVE）、關鍵繞過的動態 curl 實證
 - [ ] **需真人簽名背書上線時，這關要找真人資安顧問**——本報告是第一線自測，非最終背書
 
-## 對抗複審 verdict（已整合）
-`appsec-pentest-reviewer` agent 獨立 assume-guilty 白箱審查（221k tokens / 51 tool calls / 13.5 min），抓到主 agent 漏的 HIGH-1（entrypoint XFF）+ MED-1（policies vs tenant 兩實作只修一處）。我逐條對真實 code 驗證後全部確認為真（見上）。**教訓：最貴的洞常是「同件事兩套實作只修一套」+「防線的前提假設沒成立」（限流以為擋 IP，但 IP 本身可偽造）**——已各配 red→green 測試，看紅轉綠即可，不必讀 code。
+## 對抗複審 verdict（兩個獨立引擎，已整合）
+
+**輪 1 — `appsec-pentest-reviewer` agent**（Claude 系，assume-guilty 白箱，221k tokens / 51 tool calls / 13.5 min）：抓到主 agent 漏的 HIGH-1（entrypoint XFF）+ MED-1（policies vs tenant 兩實作只修一處）。我逐條對真實 code 驗證後全部確認。
+
+**輪 2 — Cursor（不同引擎，`cursor-safe-exec`，Young 在場手動觸發）**：
+- 4 條原發現**全部 CONFIRMED**
+- 修正主 agent overclaim：HIGH-1 非「所有」限流（TTS 走 JWT user_id 例外）
+- 論證 MED-1 應升 HIGH（系統性 `is_admin` 雙軌，跨讀+寫+PII+錄音）
+- **盲掃再找到 5 個新洞**（NEW-1~5），其中 NEW-1（任何人枚舉全校 email）+ NEW-2（跨校建班）severity 高於原 MED-1 單點
+- 我對 NEW-1/2/3/4 逐條讀 code 獨立驗證 = 全部為真（沒盲信 Cursor）
+
+**教訓**：
+1. 最貴的洞常是「**同件事兩套實作只修一套**」（policies.py vs tenant.py）+「**防線前提假設沒成立**」（限流以為擋 IP，但 XFF 由攻擊者填）
+2. **兩個不同引擎的對抗複審比一個強**——Cursor 抓到 appsec agent + 主 agent 都漏的 school 枚舉 IDOR。跨引擎覆審值得
+3. 根因單一：**授權沒統一走 tenant-scoped 模式** → 建議把所有 `is_admin` bypass + 無 scope 的 school-scoped 讀取，統一收斂到 `tenant.py` 的 org-scoped helper（修一次解 MED-1 + NEW-1~5）

--- a/tests/security/blackbox_acceptance.sh
+++ b/tests/security/blackbox_acceptance.sh
@@ -203,6 +203,31 @@ grep -qaE 'id_info(\.get\(|\[)["'\'']?email_verified' "$BE/services/sso_login_se
   && ok "A07 · WSTG-ATHN-01" "SSO 讀取並驗 id_info.email_verified claim" \
   || no "A07 · WSTG-ATHN-01" "MED-3: SSO 未驗 id_info 的 email_verified claim（憑未驗 email 連結帳號）" "連結前 if not id_info.get('email_verified'): raise 401"
 
+echo; echo "── Cursor 盲掃新增發現（2026-07-04；red→green 鎖）──"
+# NEW-1: 全校成員/班級列舉端點需授權（org/school scope 或 require_role）
+grep -A18 'def list_school_members' "$BE/routes/schools.py" 2>/dev/null | grep -qaE 'require_role|get_user_org_ids|resolve_user_org_ids|status_code=403' \
+  && ok "A01 · WSTG-ATHZ-04" "list_school_members 有授權/scope 檢查" \
+  || no "A01 · WSTG-ATHZ-04" "NEW-1: schools 成員列舉零授權（任何登入者撈全校 email）" "加 org/school membership 檢查"
+# NEW-2: create_classroom 需驗 caller 對該 school 的 org membership
+grep -A28 'def create_classroom' "$BE/routes/classrooms/classroom_crud.py" 2>/dev/null | grep -qaE 'get_user_org_ids|resolve_user_org_ids|organization_id|is_system_admin' \
+  && ok "A01 · WSTG-ATHZ-02" "create_classroom 有 school→org membership 檢查" \
+  || no "A01 · WSTG-ATHZ-02" "NEW-2: 任何教師可在別 org 的 school 建班（只驗 school 存在）" "驗 caller 對該 school 的 org"
+# NEW-4: semester 寫入守衛不得用 is_admin 全域 bypass
+bad4=$(python3 - "$BE/routes/semesters.py" <<'PY'
+import ast, sys
+src = open(sys.argv[1]).read()
+out = []
+for n in ast.walk(ast.parse(src)):
+    if isinstance(n, ast.FunctionDef) and n.name == "_require_school_write_access":
+        body = ast.get_source_segment(src, n) or ""
+        if "is_admin(" in body and "is_system_admin(" not in body:
+            out.append(n.name)
+print(",".join(out))
+PY
+)
+[ -z "$bad4" ] && ok "A01 · WSTG-ATHZ-02" "semester 寫入守衛未用 is_admin 全域 bypass" \
+  || no "A01 · WSTG-ATHZ-02" "NEW-4: $bad4 用 is_admin bypass → org_admin 對任意 school 建/改 semester" "改 is_system_admin + org scope"
+
 # ─────────────────────────────────────────────────────────────
 # 黑箱動態（需 BASE_URL 指向本機起好的站台；⛔ 勿指向雲端正式站燒錢）
 if [ -n "${BASE_URL:-}" ]; then

--- a/tests/security/blackbox_acceptance.sh
+++ b/tests/security/blackbox_acceptance.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# ============================================================
+# LingoLeap 黑白箱資安驗收測試（TDD / regression lock）
+#   每條 = 一條資安要求，對應 OWASP Top 10 / WSTG test ID
+#   綠(exit 0) = 交付碼符合資安門檻；紅(exit 1) = 有漏洞被重新引入
+#
+#   Stack: FastAPI + SQLAlchemy + PostgreSQL + Vertex AI Gemini / React + Vite
+#
+#   用法:
+#     ./tests/security/blackbox_acceptance.sh              # 白箱靜態全檢（無需起站，CI 友善）
+#     RUN_SEMGREP=1 ./tests/security/...sh                 # 加跑 semgrep 靜態掃碼（需網路抓 ruleset）
+#     RUN_GITLEAKS=0 ./tests/security/...sh                # 跳過 gitleaks 歷史掃描（預設跑，~30s）
+#     BASE_URL=http://localhost:8000 ./tests/security/...sh # 加測活站台（黑箱動態）；不設則跳過動態
+#
+#   ⚠️ 範圍界定（誠實）：
+#     - 本 suite = 我方自測 + regression lock，非院方/客戶官方稽核，非真人 pentester 簽名
+#     - 綠燈 = 對映的 WSTG 條目「自測通過」，不等於保證過官方稽核
+#     - 完整 IDOR/授權矩陣（學生A讀學生B / org跨讀）需活站台 + 多角色 token → 動態段（BASE_URL）
+#       未設 BASE_URL 時標 [DEFER]，靜態段只驗「授權機制存在且被引用」
+# ============================================================
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BE="$ROOT/backend/app"
+FE="$ROOT/frontend/src"
+PASS=0; FAIL=0; DEFER=0
+ok(){   PASS=$((PASS+1));  printf "  \033[32m✅ PASS\033[0m  [%s] %s\n" "$1" "$2"; }
+no(){   FAIL=$((FAIL+1));  printf "  \033[31m❌ FAIL\033[0m  [%s] %s\n" "$1" "$2"; [ -n "${3:-}" ] && echo "          → $3"; }
+skip(){ DEFER=$((DEFER+1)); printf "  \033[33m⏭  DEFER\033[0m [%s] %s\n" "$1" "$2"; [ -n "${3:-}" ] && echo "          → $3"; }
+# grep helper: count matching lines, pycache/tests excluded
+gc(){ grep -rnaE "$1" "${@:2}" 2>/dev/null | grep -vaE '__pycache__|/node_modules/' | wc -l | tr -d ' '; }
+
+[ -d "$BE" ] || { echo "找不到後端: $BE"; exit 2; }
+echo "════════ LingoLeap 黑白箱資安驗收：$ROOT ════════"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A07 身分驗證 Authentication ──"
+# ATHN-01: JWT secret 空值在 prod fail-closed（防 dev-default secret 偽造 token，postmortem 5/16）
+grep -qa 'JWT_SECRET_KEY must be set in production' "$BE/main.py" \
+  && ok "A07 · WSTG-ATHN" "JWT secret 空值時 prod fail-closed（RuntimeError）" \
+  || no "A07 · WSTG-ATHN" "prod 未擋空 JWT secret" "main.py 應 raise RuntimeError if not jwt_secret_key and not dev"
+# ATHN-02: JWT 演算法 pin 死（list 形式）→ 防 alg-confusion / none 演算法
+grep -qaE 'algorithms=\[settings\.jwt_algorithm\]' "$BE/auth/jwt.py" \
+  && ok "A07 · WSTG-ATHN" "JWT decode 演算法 pin 為單一 list（防 alg-confusion）" \
+  || no "A07 · WSTG-ATHN" "JWT decode 未 pin 演算法" "jwt.decode 必須帶 algorithms=[...]"
+# ATHN-03: 沒有停用簽章驗證（verify_signature=False）在 auth 路徑
+c=$(gc 'verify_signature["\x27]?\s*[:=]\s*False' "$BE/auth")
+[ "$c" = 0 ] && ok "A07 · WSTG-ATHN" "auth 路徑無 verify_signature=False" \
+  || no "A07 · WSTG-ATHN" "auth 有停用簽章驗證（$c 處）"
+# ATHN-04: 密碼用 bcrypt（不可逆），且 password.py 無 md5/sha1
+grep -qa 'bcrypt' "$BE/auth/password.py" && [ "$(gc '\b(md5|sha1)\b' "$BE/auth/password.py")" = 0 ] \
+  && ok "A02 · WSTG-CRYP-04" "密碼雜湊用 bcrypt（無 md5/sha1）" \
+  || no "A02 · WSTG-CRYP-04" "密碼雜湊非 bcrypt 或混用弱雜湊"
+# ATHN-05: token 帶 exp（過期驗證，pyjwt 預設 verify_exp）
+grep -qaE '"exp"' "$BE/auth/jwt.py" \
+  && ok "A07 · WSTG-ATHN" "access token 帶 exp 過期時間" \
+  || no "A07 · WSTG-ATHN" "token 未設 exp"
+# ATHN-06: get_current_user 驗 is_active（停用帳號不得通過）
+grep -qaE 'is_active == True' "$BE/auth/dependencies.py" \
+  && ok "A07 · WSTG-ATHN" "current_user 驗 is_active（停用帳號擋下）" \
+  || no "A07 · WSTG-ATHN" "current_user 未驗 is_active"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A01 存取控制 Broken Access Control（白箱：機制存在性）──"
+# ATHZ-01: 集中式授權 policies 模組存在
+[ -f "$BE/auth/policies.py" ] \
+  && ok "A01 · WSTG-ATHZ" "集中式授權 policies.py 存在" \
+  || no "A01 · WSTG-ATHZ" "缺集中授權模組（各 route 各寫易漏）"
+# ATHZ-02: is_system_admin 與 is_admin 分離（org_admin 不得當全域 bypass → 防跨 org 洩漏）
+grep -qa 'def is_system_admin' "$BE/auth/policies.py" \
+  && ok "A01 · WSTG-ATHZ" "系統管理員/組織管理員權限分離（防跨組織讀取）" \
+  || no "A01 · WSTG-ATHZ" "缺 is_system_admin 分離" "org_admin 當全域 bypass 會跨 org 洩漏個資"
+# ATHZ-03: admin seed 端點被 require_role('system_admin') 守住
+grep -qaE "require_role\([^)]*system_admin" "$BE/routes/admin_seed.py" \
+  && ok "A01 · WSTG-ATHZ" "admin seed 端點需 system_admin 角色" \
+  || no "A01 · WSTG-ATHZ" "admin seed 未 gate system_admin"
+# ATHZ-04: require_role 工廠被實際使用於路由（抽樣：admin/roles/organizations）
+c=$(gc 'require_role\(' "$BE/routes")
+[ "$c" -ge 3 ] && ok "A01 · WSTG-ATHZ" "require_role 於 $c 處路由使用（RBAC 有落地）" \
+  || no "A01 · WSTG-ATHZ" "require_role 使用過少（$c）——RBAC 可能未落地"
+# ATHZ-05: 完整 IDOR 矩陣（學生A↔B / org 跨讀）需活站台多角色 token
+skip "A01 · WSTG-ATHZ-04" "跨學生/跨班/跨組織 IDOR 完整矩陣 → 需 BASE_URL + 多角色 token（見動態段）"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A03 注入 Injection（白箱靜態）──"
+# INPV-05: 無 f-string / .format / % 拼接進 SQL execute/text
+c=$(gc '(execute|text)\(\s*(f["\x27]|["\x27].*%|.*\.format\()' "$BE")
+[ "$c" = 0 ] && ok "A03 · WSTG-INPV-05" "無 f-string/format/% 拼接進 SQL（純 ORM/參數化）" \
+  || no "A03 · WSTG-INPV-05" "有 $c 處疑似 SQL 字串拼接"
+c=$(gc 'f["\x27](SELECT|INSERT|UPDATE|DELETE) ' "$BE")
+[ "$c" = 0 ] && ok "A03 · WSTG-INPV-05" "無 f-string SQL 語句字面" \
+  || no "A03 · WSTG-INPV-05" "有 $c 處 f-string SQL 語句"
+# INPV-01: 前端無 dangerouslySetInnerHTML / eval（React 自動 escape）
+if [ -d "$FE" ]; then
+  c=$(grep -rnaE 'dangerouslySetInnerHTML|(^|[^.])\beval\(|new Function\(' "$FE" 2>/dev/null | grep -vaE '__tests__|\.test\.|/node_modules/' | wc -l | tr -d ' ')
+  [ "$c" = 0 ] && ok "A03 · WSTG-INPV-01" "前端無 dangerouslySetInnerHTML/eval（XSS 面小）" \
+    || no "A03 · WSTG-INPV-01" "前端有 $c 處危險 HTML/eval 注入面"
+fi
+# INPV: 公開上傳端點 lesson_id 白名單擋路徑注入 + magic-bytes 反 MIME 偽造
+grep -qa '_LESSON_ID_RE.match' "$BE/routes/testset.py" && grep -qa '_audio_bytes_match_declared_mime' "$BE/routes/testset.py" \
+  && ok "A03 · WSTG-INPV / BUSL" "testset 上傳：lesson_id 白名單 + magic-bytes 校驗" \
+  || no "A03 · WSTG-INPV" "testset 上傳缺路徑白名單或 magic-bytes 校驗"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A04/A10 濫用防護 & LLM 端點 ──"
+# 全域 per-IP rate limiting（讀/寫分流）
+grep -qa 'GlobalRateLimitMiddleware' "$BE/main.py" && grep -qaE 'READ_LIMIT|WRITE_LIMIT' "$BE/main.py" \
+  && ok "A04 · WSTG-BUSL" "全域 per-IP rate limiting（讀/寫分流）已掛" \
+  || no "A04 · WSTG-BUSL" "缺全域 rate limiting"
+# OMO / 上傳有 size cap（防記憶體/成本濫用）
+c=$(gc 'MAX_AUDIO_BYTES|max.*file|MAX.*SIZE|too large' "$BE/routes/testset.py" "$BE/routes/omo/upload.py")
+[ "$c" -ge 1 ] && ok "A04 · WSTG-BUSL" "上傳端點有 size cap（防資源濫用）" \
+  || no "A04 · WSTG-BUSL" "上傳端點缺 size cap"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A05 安全設定錯誤 Security Misconfiguration ──"
+# CONF: security headers middleware（CSP/X-Frame/nosniff/HSTS/referrer）
+H="$BE/main.py"
+grep -qa 'Content-Security-Policy' "$H" && grep -qa '"X-Frame-Options"' "$H" && grep -qa 'X-Content-Type-Options' "$H" && grep -qa 'Strict-Transport-Security' "$H" \
+  && ok "A05 · WSTG-CONF-07" "安全標頭齊全（CSP/X-Frame/nosniff/HSTS）" \
+  || no "A05 · WSTG-CONF-07" "安全標頭不齊"
+# CONF: X-Frame-Options DENY + frame-ancestors none（防 clickjacking）
+grep -qaE 'X-Frame-Options"\]\s*=\s*"DENY"' "$H" && grep -qa "frame-ancestors 'none'" "$H" \
+  && ok "A05 · WSTG-CLNT-09" "clickjacking 防護（X-Frame DENY + frame-ancestors none）" \
+  || no "A05 · WSTG-CLNT-09" "clickjacking 防護不足"
+# CONF: CORS 非萬用字元
+c=$(gc 'allow_origins=\[\s*["\x27]\*' "$H")
+[ "$c" = 0 ] && grep -qa 'allow_origins=settings.origins_list' "$H" \
+  && ok "A05 · WSTG-CONF-07" "CORS 明列 origin 白名單（非 *）" \
+  || no "A05 · WSTG-CONF-07" "CORS 使用萬用字元或未白名單"
+# CONF: prod 關閉 /docs /redoc（減少資訊洩漏）
+grep -qaE 'docs_url=.*if _is_dev else None' "$H" \
+  && ok "A05 · WSTG-CONF-05" "prod 關閉 /docs /redoc" \
+  || no "A05 · WSTG-CONF-05" "prod 未關閉 API docs"
+# CONF: 500 錯誤不洩漏 stack trace 給 client（回泛用訊息）
+grep -qa '"detail": "Internal server error"' "$H" \
+  && ok "A05 · WSTG-ERRH-01" "500 回泛用訊息（不洩 stack trace）" \
+  || no "A05 · WSTG-ERRH-01" "500 可能洩漏內部細節"
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── A02/機密 敏感資料外洩 ──"
+# CONF-04: .env / .gstack 已 gitignore
+grep -qaE '^\.env' "$ROOT/.gitignore" && grep -qa 'gstack' "$ROOT/.gitignore" \
+  && ok "A02 · WSTG-CONF-04" ".env / .gstack 已 gitignore（本機機密不入 git）" \
+  || no "A02 · WSTG-CONF-04" ".env 或 .gstack 未 gitignore"
+# CONF-04: git 歷史無 commit 過的機密（gitleaks 全史掃描）
+if [ "${RUN_GITLEAKS:-1}" = 1 ] && command -v gitleaks >/dev/null 2>&1; then
+  if gitleaks git "$ROOT" --config "$ROOT/.gitleaks.toml" --redact >/dev/null 2>&1; then
+    ok "A02 · WSTG-CONF-04" "gitleaks 全 git 歷史無機密外洩"
+  else
+    no "A02 · WSTG-CONF-04" "gitleaks 在 git 歷史抓到機密" "gitleaks git . --config .gitleaks.toml 檢視"
+  fi
+else
+  skip "A02 · WSTG-CONF-04" "gitleaks 歷史掃描（未裝或 RUN_GITLEAKS=0）"
+fi
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── 白箱靜態掃碼（Semgrep OWASP，選用）──"
+if [ "${RUN_SEMGREP:-0}" = 1 ] && command -v semgrep >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  semgrep scan --config p/owasp-top-ten --config p/python --metrics off \
+    --severity ERROR --json --output "$tmp" "$BE" >/dev/null 2>&1
+  n=$(python3 -c "import json,sys;print(len(json.load(open('$tmp')).get('results',[])))" 2>/dev/null || echo "?")
+  rm -f "$tmp"
+  [ "$n" = 0 ] && ok "A03/多項 · Semgrep" "Semgrep OWASP 0 個 ERROR 級發現" \
+    || no "A03/多項 · Semgrep" "Semgrep 有 $n 個 ERROR 級發現"
+else
+  skip "Semgrep" "靜態掃碼（RUN_SEMGREP=1 開啟；需網路抓 ruleset）"
+fi
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "── 對抗複審發現（2026-07-04 appsec-pentest-reviewer；red→green 鎖，修好轉綠）──"
+# HIGH-1a: entrypoint 不得無條件信任 XFF（--forwarded-allow-ips='*' → 限流全線可繞）
+if grep -qa "forwarded-allow-ips='\*'" "$ROOT/backend/entrypoint.sh" 2>/dev/null; then
+  no "A07/A04 · WSTG-ATHN-03/BUSL-01" "HIGH-1: entrypoint --forwarded-allow-ips='*'（信任任意 XFF）" "改可信代理範圍/信任 hop 數"
+else
+  ok "A07/A04 · WSTG-ATHN-03" "entrypoint 未無條件信任 XFF"
+fi
+# HIGH-1c: per-user 限流 key 必須真的被設定（否則退化成可偽造的 per-IP）
+c=$(gc 'request\.state\.user_id\s*=' "$BE")
+[ "$c" -ge 1 ] && ok "A04 · WSTG-BUSL-01" "request.state.user_id 有被設定（per-user 限流生效）" \
+  || no "A04 · WSTG-BUSL-01" "HIGH-1: request.state.user_id 從未設定 → per-user 限流退化成 per-IP" "auth dependency 解 JWT 後寫入 request.state.user_id"
+# MED-1: 班級授權守衛不得用 is_admin 當全域 bypass（org_admin 會跨 org）
+bad=$(python3 - "$BE/auth/policies.py" <<'PY'
+import ast, sys
+src = open(sys.argv[1]).read()
+out = []
+for n in ast.walk(ast.parse(src)):
+    if isinstance(n, ast.FunctionDef) and n.name in ("require_classroom_owner", "require_classroom_member"):
+        body = ast.get_source_segment(src, n) or ""
+        if "is_admin(" in body and "is_system_admin(" not in body:
+            out.append(n.name)
+print(",".join(out))
+PY
+)
+[ -z "$bad" ] && ok "A01 · WSTG-ATHZ-02" "班級授權守衛未用 is_admin 全域 bypass（org 隔離保住）" \
+  || no "A01 · WSTG-ATHZ-02" "MED-1: $bad 用 is_admin bypass → org_admin 可跨 org 讀班級/作業/錄音" "改 is_system_admin + org scope（參 tenant._check_classroom_access）"
+# MED-2: batch-eval（30×Gemini）需 role gate，不得任何登入者可觸發
+grep -A10 'def testset_batch_eval' "$BE/routes/testset.py" 2>/dev/null | grep -qa 'require_role' \
+  && ok "A04 · WSTG-BUSL-01" "batch-eval 有 role gate" \
+  || no "A04 · WSTG-BUSL-01" "MED-2: batch-eval 無 role gate（任何學生可跑 30×Gemini 燒錢）" "加 require_role(admin/teacher)+AI 限流"
+# MED-3: Google SSO 連結帳號前需驗「id_info 的 email_verified claim」（非只設定新帳號欄位）
+grep -qaE 'id_info(\.get\(|\[)["'\'']?email_verified' "$BE/services/sso_login_service.py" \
+  && ok "A07 · WSTG-ATHN-01" "SSO 讀取並驗 id_info.email_verified claim" \
+  || no "A07 · WSTG-ATHN-01" "MED-3: SSO 未驗 id_info 的 email_verified claim（憑未驗 email 連結帳號）" "連結前 if not id_info.get('email_verified'): raise 401"
+
+# ─────────────────────────────────────────────────────────────
+# 黑箱動態（需 BASE_URL 指向本機起好的站台；⛔ 勿指向雲端正式站燒錢）
+if [ -n "${BASE_URL:-}" ]; then
+  echo; echo "── 黑箱動態（活站台 ${BASE_URL}）──"
+  code(){ curl -s -o /dev/null -w '%{http_code}' "$@"; }
+  # health 200
+  [ "$(code "$BASE_URL/api/health")" = 200 ] && ok "動態 · health" "健康檢查 200" || no "動態 · health" "健康檢查非 200"
+  # 未帶 token 讀受保護端點 → 401
+  pc=$(code "$BASE_URL/${PROTECTED_PATH:-api/auth/me}")
+  { [ "$pc" = 401 ] || [ "$pc" = 403 ]; } && ok "A01 · 動態 ATHZ" "受保護端點未授權回 $pc" || no "A01 · 動態 ATHZ" "受保護端點未授權回 $pc（應 401/403）"
+  # 偽造 JWT → 401（token 由片段 runtime 組出，source 不留 JWT 字面）
+  b64(){ printf '%s' "$1" | base64 | tr -d '=' | tr '/+' '_-'; }
+  fake_jwt="$(b64 '{"alg":"HS256","typ":"JWT"}').$(b64 '{"sub":"1"}').forged"
+  fc=$(code -H "Authorization: Bearer $fake_jwt" "$BASE_URL/${PROTECTED_PATH:-api/auth/me}")
+  { [ "$fc" = 401 ] || [ "$fc" = 403 ]; } && ok "A07 · 動態 ATHN" "偽造 JWT 被拒（$fc）" || no "A07 · 動態 ATHN" "偽造 JWT 未被拒（$fc）"
+  # 安全標頭出現在活回應
+  hdr=$(curl -sI "$BASE_URL/api/health")
+  echo "$hdr" | grep -qi 'x-frame-options: DENY' && echo "$hdr" | grep -qi 'strict-transport-security' \
+    && ok "A05 · 動態 CONF" "活站台回安全標頭（X-Frame DENY + HSTS）" || no "A05 · 動態 CONF" "活站台缺安全標頭"
+  # CORS 不反射惡意 Origin
+  acao=$(curl -s -o /dev/null -D - -H "Origin: https://evil.example" "$BASE_URL/api/health" | grep -i 'access-control-allow-origin' | grep -c 'evil.example')
+  [ "$acao" = 0 ] && ok "A05 · 動態 CORS" "不反射未白名單 Origin" || no "A05 · 動態 CORS" "反射惡意 Origin（CORS 錯設）"
+  # testset 上傳偽造 MIME → 400/415
+  sc=$(printf 'notaudio' | curl -s -o /dev/null -w '%{http_code}' -F "contributor_name=probe" -F "lesson_id=G6-L22" -F "version=correct" -F "audio=@-;type=audio/wav;filename=x.wav" "$BASE_URL/api/testset/upload")
+  { [ "$sc" = 400 ] || [ "$sc" = 415 ]; } && ok "A03 · 動態 INPV" "偽造 MIME 上傳被拒（$sc）" || no "A03 · 動態 INPV" "偽造 MIME 上傳未被拒（$sc）"
+else
+  echo; echo "  (未設 BASE_URL → 跳過黑箱動態；本機起站後：BASE_URL=http://localhost:8000 再執行)"
+fi
+
+# ─────────────────────────────────────────────────────────────
+echo; echo "════════════════════════════════════════"
+echo "結果： $PASS 通過 / $FAIL 失敗 / $DEFER 延後"
+[ "$FAIL" = 0 ] && { echo -e "\033[32m✅ 通過現階段黑白箱資安門檻\033[0m（註：我方自測，非官方稽核；完整 IDOR 需動態段）"; exit 0; } \
+                || { echo -e "\033[31m❌ 有未達門檻項，見上方 FAIL\033[0m"; exit 1; }


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

第一步（regression 鎖）for #2470。fixes 走後續 PR 把 red→green 翻綠。

## 這個 PR 幹嘛
LingoLeap 首次本機黑白箱資安驗收（2026-07-04）產出：把資安要求鎖成可重複、對映 OWASP WSTG 的 regression 測試。**只加測試/文件/CI，不動 production code。**

## 內容
- `tests/security/blackbox_acceptance.sh` — WSTG-mapped 靜態 gate（23 pass），含對抗複審 4 發現的 red→green 鎖（現 5 條紅=待修）
- `backend/tests/security/test_dynamic_security.py` — in-process TestClient 動態 gate：安全標頭 / 未授權 / 偽造+none JWT / CORS / 上傳硬化 / 跨教師+跨組織 IDOR（10 pass + 1 strict xfail=MED-1）
- `docs/security/2026-07-04-blackbox-result.md` — 完整報告 + WSTG 覆蓋表
- `pytest.yml` — 動態安全測試接進 CI

## 稽核發現（見 #2470，fix 走後續 PR）
🔴 HIGH-1 限流 XFF 繞過｜🟠 MED-1 org_admin 跨 org 班級越權｜🟠 MED-2 batch-eval 燒錢｜🟠 MED-3 SSO email_verified

## 範圍界定
我方自測 + regression lock，非官方稽核 / 非真人 pentester 簽名。

🤖 Generated with [Claude Code](https://claude.com/claude-code)