### PR TITLE
fix(security): 限流 per-user + batch-eval role gate + SSO email_verified (#2470 HIGH-1核心/MED-2/MED-3)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -163,6 +163,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             except Exception:
                 pass  # Not critical — we just won't have user_id
 
+        # Expose the (signature-verified) user id for per-user rate limiting.
+        # (#2470 HIGH-1: get_client_key relies on request.state.user_id; without
+        # it, per-user AI limits silently fell back to a spoofable per-IP key.)
+        request.state.user_id = user_id
+
         try:
             response = await call_next(request)
             duration_ms = (time.perf_counter() - start) * 1000

--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 
 from ..auth.dependencies import get_current_user, require_role
+from ..auth.rate_limiter import make_ai_rate_limit_dependency
 from ..models.user import User
 from ..services.audio_upload_service import (
     _get_gcs_bucket,
@@ -300,15 +301,19 @@ def testset_recordings():
     return {"ok": True, "count": len(out), "recordings": out}
 
 
-@router.post("/testset/batch-eval")
+@router.post(
+    "/testset/batch-eval",
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=5, window_seconds=60))],
+)
 async def testset_batch_eval(
-    current_user: User = Depends(get_current_user),
+    current_user: User = require_role("system_admin", "org_admin", "teacher"),
     name: str | None = Query(default=None, description="過濾貢獻者名字（slug 比對）"),
     lesson: str | None = Query(default=None, description="過濾課文 lesson_id（字串精確比對）"),
 ) -> dict:
     """批次跑 STT + 評分 pipeline，驗測試集準度（Issue #2340）。
 
-    Auth: 登入使用者才可呼叫（get_current_user），不需 teacher/admin role。
+    Auth: 需 teacher/org_admin/system_admin role（#2470 MED-2：原本任何登入者即可，
+    含學生，且單次跑 ≤30 次 Gemini → 成本濫用）。另加 per-user AI rate-limit。
 
     Query params:
         name   — 過濾 contributor slug（局部比對，例如 '王小明' → slug '王小明'）

--- a/backend/app/services/sso_login_service.py
+++ b/backend/app/services/sso_login_service.py
@@ -88,6 +88,15 @@ def resolve_google_user(db: Session, id_info: dict) -> tuple[User, bool]:
             detail="Google account does not expose an email address.",
         )
 
+    # (#2470 MED-3): only trust the email for account lookup/linking if Google has
+    # verified it. Otherwise an attacker could add a victim's email (unverified) to
+    # their Google account and link/hijack the existing password account.
+    if not id_info.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Google email is not verified.",
+        )
+
     is_new_user = False
 
     # 1. Returning user (matched by google_id)

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -307,6 +307,40 @@ def test_idor_org_admin_cannot_read_cross_org_user(client):
     assert client.get(f"/api/users/{cross_org_user}", headers=_auth(tok_sys)).status_code == 200
 
 
+# ── A04 · WSTG-BUSL-01 MED-2：batch-eval 需 role gate（學生不可燒錢）──────────
+def test_med2_student_cannot_run_batch_eval(client):
+    u = uuid.uuid4().hex[:8]
+    student = _create_user(f"stud_{u}@example.com")
+    _grant_role(student, "student", "school", "1")
+    tok = create_access_token(student)
+    # 學生（無 teacher/admin role）呼叫 batch-eval → 403（role gate 擋在進 Gemini 前）
+    r = client.post("/api/testset/batch-eval", headers=_auth(tok))
+    assert r.status_code == 403, r.text
+
+
+# ── A07 · WSTG-ATHN-01 MED-3：SSO 未驗 email_verified 不得連結帳號 ──────────
+def test_med3_sso_rejects_unverified_email():
+    from fastapi import HTTPException
+    from app.services.sso_login_service import resolve_google_user
+
+    db = TestingSessionLocal()
+    try:
+        id_info = {
+            "sub": "attacker-google-sub",
+            "email": f"victim_{uuid.uuid4().hex[:8]}@custom-school.edu.tw",
+            "email_verified": False,  # Google 未驗證此 email
+            "name": "Attacker",
+        }
+        raised = None
+        try:
+            resolve_google_user(db, id_info)
+        except HTTPException as e:
+            raised = e
+        assert raised is not None and raised.status_code == 401, "未驗證 email 應被拒 401"
+    finally:
+        db.close()
+
+
 def test_idor_org_admin_cannot_read_cross_org_classroom(client):
     # 教師在自己的 school 建一個班級
     teacher = _register_teacher(client)

--- a/backend/tests/test_testset_batch_eval.py
+++ b/backend/tests/test_testset_batch_eval.py
@@ -29,7 +29,7 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
-from app.models.user import Role, User
+from app.models.user import Role, User, UserRole
 from app.auth.dependencies import get_current_user
 from app.auth.rate_limiter import ai_rate_limiter, general_rate_limiter
 
@@ -134,6 +134,18 @@ def setup_db():
     db.commit()
     student_role = db.query(Role).filter(Role.name == "student").first()
     _fake_user.role_id = student_role.id if student_role else None
+    # batch-eval now requires teacher/org_admin/system_admin (#2470 MED-2); persist the
+    # fake evaluator + grant a teacher role so require_role passes (it queries UserRole,
+    # and the UserRole FK needs a real users row).
+    if not db.query(User).filter(User.id == _fake_user.id).first():
+        db.add(User(id=_fake_user.id, username="test_evaluator", name="Test Evaluator",
+                    email="eval@example.com", password_hash="fake"))
+        db.commit()
+    teacher_role = db.query(Role).filter(Role.name == "teacher").first()
+    if teacher_role and not db.query(UserRole).filter(UserRole.user_id == _fake_user.id).first():
+        db.add(UserRole(user_id=_fake_user.id, role_id=teacher_role.id,
+                        scope_type="school", scope_id="1", is_active=True))
+        db.commit()
     db.close()
     yield
     Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

修 #2470 的限流/LLM/SSO 三項（stacked 在 authz PR #2472 上，已 rebase）。

## 內容
- **HIGH-1 核心**：`RequestLoggingMiddleware` 把已驗簽的 JWT user_id 寫入 `request.state.user_id` → per-user AI 限流不再退化成可偽造的 per-IP
- **MED-2**：`/testset/batch-eval` 加 `require_role(teacher/org_admin/system_admin)` + per-user AI 限流（原本任何登入者含學生可跑 ≤30 次 Gemini）
- **MED-3**：Google SSO 連結帳號前驗 `id_info.email_verified`（防未驗 email 帳號劫持）

## 驗證
dynamic security **14 passed**（含 `test_med2_student_cannot_run_batch_eval` 403、`test_med3_sso_rejects_unverified_email` 401）

## 未含（deferred，見 #2470）
- HIGH-1a entrypoint `--forwarded-allow-ips` / 匿名 IP 限流 XFF hop — 需 Cloud Run proxy 語義查證

🤖 Generated with [Claude Code](https://claude.com/claude-code)