### PR TITLE
fix(auth): 統一 tenant-scoped 授權 #2470（MED-1 + NEW-1/3/4/5 + roles）

### DIFF
--- a/backend/app/auth/policies.py
+++ b/backend/app/auth/policies.py
@@ -96,23 +96,67 @@ def resolve_user_org_ids(user_id: int, db: Session) -> set[str]:
     return org_ids
 
 
+def _org_admin_org_ids(user_id: int, db: Session) -> set[str]:
+    """Org ids where the user holds an active org_admin/org_owner role (org-scoped).
+
+    This is "which orgs the user *administers*", NOT mere membership. Used to scope
+    the org-level bypass so an org_admin of org A cannot reach org B's resources.
+    """
+    rows = (
+        db.query(UserRole.scope_id)
+        .join(Role, UserRole.role_id == Role.id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            UserRole.scope_type == "organization",
+            Role.name.in_(["org_admin", "org_owner"]),
+            UserRole.scope_id.isnot(None),
+        )
+        .all()
+    )
+    return {str(r[0]) for r in rows}
+
+
+def _is_org_admin_of_school(user_id: int, school_id, db: Session) -> bool:
+    """True if user is org_admin/org_owner of the org that owns ``school_id``.
+
+    Orphan schools (organization_id IS NULL) return False on purpose — an org_admin
+    cannot claim an unscoped school via org; such access must come from ownership /
+    membership, not the org bypass.
+    """
+    if school_id is None:
+        return False
+    school = db.query(School).filter(School.id == school_id).first()
+    if school is None or school.organization_id is None:
+        return False
+    return str(school.organization_id) in _org_admin_org_ids(user_id, db)
+
+
 def require_classroom_owner(classroom: Classroom, user: User, db: Session) -> None:
-    """Allow classroom primary teacher OR system/org admin. Raise 403 otherwise.
+    """Allow classroom primary teacher, system_admin, or org_admin/org_owner OF THE
+    CLASSROOM'S ORG. Raise 403 otherwise.
 
     Use for write operations (update, delete, assign).
     Co-teachers (assistants) are NOT allowed for write ops.
+
+    NOTE: global bypass is system_admin only; org admins are scoped to their own
+    org (via school→org) so a cross-org org_admin cannot write another org's class.
     """
     if classroom.teacher_id == user.id:
         return
-    if is_admin(user.id, db):
+    if is_system_admin(user.id, db):
+        return
+    if _is_org_admin_of_school(user.id, classroom.school_id, db):
         return
     raise HTTPException(status_code=403, detail="Not your classroom")
 
 
 def require_classroom_member(classroom: Classroom, user: User, db: Session) -> None:
-    """Allow classroom owner, co-teachers, or system/org admins. Raise 403 otherwise.
+    """Allow classroom owner, co-teachers, system_admin, or org_admin/org_owner OF
+    THE CLASSROOM'S ORG. Raise 403 otherwise.
 
     Use for read operations (view students, progress).
+    Org admins are scoped to their own org (via school→org), not a global bypass.
     """
     if classroom.teacher_id == user.id:
         return
@@ -126,23 +170,44 @@ def require_classroom_member(classroom: Classroom, user: User, db: Session) -> N
     )
     if ct:
         return
-    if is_admin(user.id, db):
+    if is_system_admin(user.id, db):
+        return
+    if _is_org_admin_of_school(user.id, classroom.school_id, db):
         return
     raise HTTPException(status_code=403, detail="Not your classroom")
 
 
 def require_student_visible_to_teacher(student_id: int, user: User, db: Session) -> None:
-    """Verify teacher (primary or co-teacher) has access to a student, OR user is admin.
+    """Verify the user may access a student's data.
 
-    A student is visible to a teacher if:
-    - The teacher owns a classroom containing the student (primary teacher), OR
-    - The teacher is a co-teacher of a classroom containing the student, OR
-    - The user is a system/org admin
+    Allowed:
+    - system_admin (global), OR
+    - org_admin/org_owner of the student's org (via enrolled classroom's school→org), OR
+    - the primary teacher or co-teacher of a classroom containing the student.
 
-    Raises 403 if none of the above.
+    Org admins are scoped to their own org (not a global bypass). Raises 403 otherwise.
     """
-    if is_admin(user.id, db):
+    if is_system_admin(user.id, db):
         return
+
+    # org_admin/org_owner scoped to the student's org (resolved via school→org).
+    caller_org_admin = _org_admin_org_ids(user.id, db)
+    if caller_org_admin:
+        student_orgs = {
+            str(org_id)
+            for (org_id,) in (
+                db.query(School.organization_id)
+                .join(Classroom, Classroom.school_id == School.id)
+                .join(ClassroomStudent, ClassroomStudent.classroom_id == Classroom.id)
+                .filter(
+                    ClassroomStudent.student_id == student_id,
+                    School.organization_id.isnot(None),
+                )
+                .all()
+            )
+        }
+        if caller_org_admin & student_orgs:
+            return
 
     # Check if student is in any classroom where user is primary teacher or co-teacher
     enrollment = (

--- a/backend/app/routes/classrooms/classroom_crud.py
+++ b/backend/app/routes/classrooms/classroom_crud.py
@@ -7,11 +7,6 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
-from ...auth.policies import (
-    is_system_admin,
-    resolve_user_org_ids,
-    _is_org_admin_of_school,
-)
 from ...database import get_db
 from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
 from ...models.user import User
@@ -57,34 +52,9 @@ def create_classroom(
     if school is None:
         raise HTTPException(status_code=404, detail="School not found")
 
-    # (#2470 NEW-2): the caller must have standing in THIS school. Allowed:
-    #   - system_admin (anywhere), OR
-    #   - a member of the school itself (any school-scoped role, e.g. the teacher
-    #     of an auto-created domain school — which may be orphan/org=None), OR
-    #   - org_admin/org_owner of the school's org.
-    # This closes "any teacher creates in any school" without breaking a teacher
-    # creating a classroom in their own (possibly orphan) school.
-    caller_is_sysadmin = is_system_admin(current_user.id, db)
-    if not caller_is_sysadmin:
-        is_school_member = any(
-            ur.is_active and ur.scope_type == "school" and ur.scope_id == str(school.id)
-            for ur in current_user.user_roles
-        )
-        is_school_org_admin = (
-            school.organization_id is not None
-            and str(school.organization_id) in resolve_user_org_ids(current_user.id, db)
-        )
-        if not (is_school_member or is_school_org_admin):
-            raise HTTPException(
-                status_code=403,
-                detail="Not authorized to create a classroom in this school",
-            )
-
     effective_teacher_id = current_user.id
     if payload.teacher_id is not None and payload.teacher_id != current_user.id:
-        # Creating on behalf of another teacher requires admin authority over the
-        # school's org (system_admin, or org_admin/org_owner of the school's org).
-        if not (caller_is_sysadmin or _is_org_admin_of_school(current_user.id, school.id, db)):
+        if not is_admin(current_user.id, db):
             raise HTTPException(
                 status_code=403,
                 detail="Only admins can create classrooms for other teachers",

--- a/backend/app/routes/classrooms/classroom_crud.py
+++ b/backend/app/routes/classrooms/classroom_crud.py
@@ -7,6 +7,11 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
+from ...auth.policies import (
+    is_system_admin,
+    resolve_user_org_ids,
+    _is_org_admin_of_school,
+)
 from ...database import get_db
 from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
 from ...models.user import User
@@ -52,9 +57,34 @@ def create_classroom(
     if school is None:
         raise HTTPException(status_code=404, detail="School not found")
 
+    # (#2470 NEW-2): the caller must have standing in THIS school. Allowed:
+    #   - system_admin (anywhere), OR
+    #   - a member of the school itself (any school-scoped role, e.g. the teacher
+    #     of an auto-created domain school — which may be orphan/org=None), OR
+    #   - org_admin/org_owner of the school's org.
+    # This closes "any teacher creates in any school" without breaking a teacher
+    # creating a classroom in their own (possibly orphan) school.
+    caller_is_sysadmin = is_system_admin(current_user.id, db)
+    if not caller_is_sysadmin:
+        is_school_member = any(
+            ur.is_active and ur.scope_type == "school" and ur.scope_id == str(school.id)
+            for ur in current_user.user_roles
+        )
+        is_school_org_admin = (
+            school.organization_id is not None
+            and str(school.organization_id) in resolve_user_org_ids(current_user.id, db)
+        )
+        if not (is_school_member or is_school_org_admin):
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to create a classroom in this school",
+            )
+
     effective_teacher_id = current_user.id
     if payload.teacher_id is not None and payload.teacher_id != current_user.id:
-        if not is_admin(current_user.id, db):
+        # Creating on behalf of another teacher requires admin authority over the
+        # school's org (system_admin, or org_admin/org_owner of the school's org).
+        if not (caller_is_sysadmin or _is_org_admin_of_school(current_user.id, school.id, db)):
             raise HTTPException(
                 status_code=403,
                 detail="Only admins can create classrooms for other teachers",

--- a/backend/app/routes/organization_dashboard.py
+++ b/backend/app/routes/organization_dashboard.py
@@ -12,7 +12,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user
-from ..auth.policies import is_admin
+from ..auth.policies import is_system_admin
 from ..database import get_db
 from ..models.school import Classroom, ClassroomStudent, School
 from ..models.session import LearningSession
@@ -33,8 +33,9 @@ def get_organization_dashboard(
     """Return aggregate statistics for an organization."""
     org = _get_org_or_404(org_id, db)
 
-    # Permission check: system_admin, org_owner, or org_admin only
-    if not is_admin(current_user.id, db):
+    # Permission check: system_admin (global), or org_owner/org_admin of THIS org.
+    # Use is_system_admin (not is_admin) so org_admin can't bypass org scoping.
+    if not is_system_admin(current_user.id, db):
         has_org_role = any(
             ur.is_active
             and ur.scope_type == "organization"

--- a/backend/app/routes/organization_points.py
+++ b/backend/app/routes/organization_points.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user
-from ..auth.policies import is_admin
+from ..auth.policies import is_system_admin
 from ..database import get_db
 from ..models.points_log import OrganizationPointsLog
 from ..models.user import Role, User, UserRole
@@ -33,15 +33,18 @@ def get_points_logs(
     """List points usage logs for an organization."""
     org = _get_org_or_404(org_id, db)
 
-    # Permission: system_admin/org_admin (sees all) or org_owner for this org specifically
-    if not is_admin(current_user.id, db):
+    # Permission: system_admin (global bypass), or org_owner/org_admin scoped to
+    # THIS org. Use is_system_admin (not is_admin) so an org_admin of another org
+    # can't bypass org scoping; the fallback below re-admits org_admin/org_owner of
+    # this specific org (regression guard — previously only org_owner was allowed).
+    if not is_system_admin(current_user.id, db):
         has_org_role = (
             db.query(UserRole)
             .join(Role, UserRole.role_id == Role.id)
             .filter(
                 UserRole.user_id == current_user.id,
                 UserRole.is_active == True,  # noqa: E712
-                Role.name == "org_owner",
+                Role.name.in_(["org_owner", "org_admin"]),
                 UserRole.scope_type == "organization",
                 UserRole.scope_id == str(org.id),
             )

--- a/backend/app/routes/roles.py
+++ b/backend/app/routes/roles.py
@@ -5,6 +5,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user, require_role
+from ..auth.policies import is_system_admin, resolve_user_org_ids
 from ..database import get_db
 from ..models.user import Role, User, UserRole
 from ..schemas.role import (
@@ -163,18 +164,13 @@ def list_user_roles(
 ):
     """List all active roles for a specific user."""
     if current_user.id != user_id:
-        admin_roles = (
-            db.query(UserRole)
-            .join(Role)
-            .filter(
-                UserRole.user_id == current_user.id,
-                UserRole.is_active == True,
-                Role.name.in_(["system_admin", "org_admin"]),
-            )
-            .first()
-        )
-        if not admin_roles:
-            raise HTTPException(status_code=403, detail="Not authorized")
+        # system_admin may read any user's roles; org_admin only for a user who
+        # shares one of their orgs (#2470: was any org_admin → any user, cross-org).
+        if not is_system_admin(current_user.id, db):
+            caller_orgs = resolve_user_org_ids(current_user.id, db)
+            target_orgs = resolve_user_org_ids(user_id, db)
+            if not (caller_orgs & target_orgs):
+                raise HTTPException(status_code=403, detail="Not authorized")
 
     # Verify target user exists
     target_user = db.query(User).filter(User.id == user_id).first()

--- a/backend/app/routes/roles.py
+++ b/backend/app/routes/roles.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user, require_role
-from ..auth.policies import is_system_admin, resolve_user_org_ids
+from ..auth.policies import is_system_admin, resolve_user_org_ids, _org_admin_org_ids
 from ..database import get_db
 from ..models.user import Role, User, UserRole
 from ..schemas.role import (
@@ -164,12 +164,15 @@ def list_user_roles(
 ):
     """List all active roles for a specific user."""
     if current_user.id != user_id:
-        # system_admin may read any user's roles; org_admin only for a user who
-        # shares one of their orgs (#2470: was any org_admin → any user, cross-org).
+        # Only system_admin, or an org_admin/org_owner of an org the target belongs
+        # to, may read another user's roles. Use _org_admin_org_ids for the CALLER
+        # (admin roles only) — NOT resolve_user_org_ids, which would also let any
+        # plain teacher/student read same-org members' roles (#2470 QA: caller
+        # authorization must stay admin-gated, was widened by an earlier fix).
         if not is_system_admin(current_user.id, db):
-            caller_orgs = resolve_user_org_ids(current_user.id, db)
+            caller_admin_orgs = _org_admin_org_ids(current_user.id, db)
             target_orgs = resolve_user_org_ids(user_id, db)
-            if not (caller_orgs & target_orgs):
+            if not (caller_admin_orgs & target_orgs):
                 raise HTTPException(status_code=403, detail="Not authorized")
 
     # Verify target user exists

--- a/backend/app/routes/schools.py
+++ b/backend/app/routes/schools.py
@@ -88,6 +88,17 @@ def create_school(
         if org is None:
             raise HTTPException(status_code=404, detail="Organization not found")
 
+    # (#2470 create_school): org_admin may only create schools inside their own org.
+    # system_admin (org_ids is None) may create anywhere, incl. an orphan school.
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is not None and (
+        payload.organization_id is None or payload.organization_id not in org_ids
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to create a school in this organization",
+        )
+
     # Sanitize admin-provided text fields
     safe_name, _ = sanitize_ai_input(payload.name, user_id=str(current_user.id))
 
@@ -181,8 +192,15 @@ def regenerate_school_code(
     current_user: User = require_role("system_admin", "org_admin"),
     db: Session = Depends(get_db),
 ):
-    """Regenerate the join code for a school. Requires admin."""
+    """Regenerate the join code for a school. Requires admin.
+
+    (#2470 NEW-5: org_admin must be scoped to the school's org, mirroring
+    update_school — previously any org_admin could reset any school's join code.)
+    """
     school = _get_school_or_404(school_id, db)
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is not None and school.organization_id not in org_ids:
+        raise HTTPException(status_code=403, detail="Not authorized for this school")
     school.join_code = _generate_school_join_code(db)
     db.commit()
     db.refresh(school)
@@ -205,8 +223,15 @@ def list_school_classrooms(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List all classrooms belonging to a school (admin view)."""
-    _get_school_or_404(school_id, db)
+    """List all classrooms belonging to a school (admin view).
+
+    Scoped like get_school: system_admin sees any; org_admin only within their org.
+    (#2470 NEW-1: previously any authenticated user could enumerate a school.)
+    """
+    school = _get_school_or_404(school_id, db)
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is not None and school.organization_id not in org_ids:
+        raise HTTPException(status_code=403, detail="Not authorized for this school")
 
     classrooms = (
         db.query(Classroom)
@@ -243,8 +268,16 @@ def list_school_members(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List all users who have a role scoped to this school."""
-    _get_school_or_404(school_id, db)
+    """List all users who have a role scoped to this school.
+
+    Scoped like get_school: system_admin sees any; org_admin only within their org.
+    (#2470 NEW-1: previously any authenticated user could read a school's member
+    roster incl. email — cross-tenant PII exposure.)
+    """
+    school = _get_school_or_404(school_id, db)
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is not None and school.organization_id not in org_ids:
+        raise HTTPException(status_code=403, detail="Not authorized for this school")
 
     rows = (
         db.query(User, Role, UserRole)

--- a/backend/app/routes/semesters.py
+++ b/backend/app/routes/semesters.py
@@ -20,8 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator, model_validator
 from sqlalchemy.orm import Session
 
-from ..auth.dependencies import get_current_user
-from ..auth.policies import is_admin
+from ..auth.dependencies import get_current_user, get_user_org_ids
 from ..database import get_db
 from ..models.school import School
 from ..models.semester import Semester
@@ -102,11 +101,39 @@ def _get_school_or_404(school_id: int, db: Session) -> School:
     return school
 
 
+def _user_is_school_member(user: User, school_id: int) -> bool:
+    return any(
+        ur.is_active and ur.scope_type == "school" and ur.scope_id == str(school_id)
+        for ur in user.user_roles
+    )
+
+
 def _require_school_write_access(school: School, current_user: User, db: Session) -> None:
-    """Allow system_admin, org_admin; block others."""
-    if is_admin(current_user.id, db):
+    """Allow system_admin (global) or org_admin/org_owner OF THIS school's org.
+
+    (#2470 NEW-4: previously any org_admin — even of another org — could write.)
+    """
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is None:  # system_admin sees/does all
+        return
+    if school.organization_id is not None and school.organization_id in org_ids:
         return
     raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+
+def _require_school_read_access(school: School, current_user: User) -> None:
+    """Allow system_admin, org_admin/org_owner of the org, OR a member of the school.
+
+    (#2470 NEW-4: reads were open to any authenticated user across schools.)
+    """
+    org_ids = get_user_org_ids(current_user)
+    if org_ids is None:  # system_admin
+        return
+    if school.organization_id is not None and school.organization_id in org_ids:
+        return
+    if _user_is_school_member(current_user, school.id):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this school")
 
 
 def _semester_to_response(s: Semester) -> SemesterResponse:
@@ -138,7 +165,8 @@ def list_school_semesters(
     db: Session = Depends(get_db),
 ):
     """Return all semesters for a school, newest first."""
-    _get_school_or_404(school_id, db)
+    school = _get_school_or_404(school_id, db)
+    _require_school_read_access(school, current_user)
     semesters = list_semesters(school_id, db)
     return [_semester_to_response(s) for s in semesters]
 
@@ -191,7 +219,8 @@ def get_school_active_semester(
     db: Session = Depends(get_db),
 ):
     """Return the currently active semester, or null if none."""
-    _get_school_or_404(school_id, db)
+    school = _get_school_or_404(school_id, db)
+    _require_school_read_access(school, current_user)
     semester = get_active_semester(school_id, db)
     if semester is None:
         return None

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -329,6 +329,44 @@ def test_idor_org_admin_cannot_read_cross_org_classroom(client):
     assert client.get(f"/api/classrooms/{cid}", headers=_auth(tok)).status_code == 403
 
 
+def _create_school(org_id: str) -> int:
+    from app.models.school import School
+
+    db = TestingSessionLocal()
+    try:
+        s = School(name=f"S_{uuid.uuid4().hex[:6]}", organization_id=org_id)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+        return s.id
+    finally:
+        db.close()
+
+
+def test_roles_list_requires_admin_not_mere_org_member(client):
+    # #2470 QA (Cursor): reading another user's roles must be admin-gated, not open
+    # to any same-org member. A school-scoped teacher belongs to the org (via
+    # school→org) but is NOT an admin → must be denied.
+    u = uuid.uuid4().hex[:6]
+    org = _create_org(f"RolesOrg_{u}")
+    school = _create_school(org)
+
+    teacher = _create_user(f"rl_teacher_{u}@example.com")
+    target = _create_user(f"rl_target_{u}@example.com")
+    _grant_role(teacher, "teacher", "school", str(school))
+    _grant_role(target, "teacher", "school", str(school))
+    org_admin = _create_user(f"rl_orgadmin_{u}@example.com")
+    _grant_role(org_admin, "org_admin", "organization", org)
+    sysadmin = _create_user(f"rl_sys_{u}@example.com")
+    _grant_role(sysadmin, "system_admin", "platform", None)
+
+    # 一般同 org teacher 讀他人 roles → 403（非 admin）
+    assert client.get(f"/api/users/{target}/roles", headers=_auth(create_access_token(teacher))).status_code == 403
+    # org_admin of the org → 200；system_admin → 200
+    assert client.get(f"/api/users/{target}/roles", headers=_auth(create_access_token(org_admin))).status_code == 200
+    assert client.get(f"/api/users/{target}/roles", headers=_auth(create_access_token(sysadmin))).status_code == 200
+
+
 def test_idor_any_user_cannot_enumerate_school_members(client):
     # 註冊教師會建立預設 school（含該教師為成員，帶 email）
     _register_teacher(client)

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -117,7 +117,27 @@ def _register_teacher(client) -> dict:
         client.get(f"/api/auth/verify-email?token={vt}")
     tok = client.post("/api/auth/login", json={"email": email, "password": pw}).json()["access_token"]
     uid = client.get("/api/users/me", headers=_auth(tok)).json()["id"]
-    return {"token": tok, "user_id": uid, "email": email}
+    return {"token": tok, "user_id": uid, "email": email, "school_id": _own_school_id(uid)}
+
+
+def _own_school_id(user_id: int):
+    """The school the user is scoped to (teachers auto-join a domain school on register)."""
+    from app.models.user import UserRole
+
+    db = TestingSessionLocal()
+    try:
+        r = (
+            db.query(UserRole)
+            .filter(
+                UserRole.user_id == user_id,
+                UserRole.scope_type == "school",
+                UserRole.is_active == True,
+            )
+            .first()
+        )
+        return int(r.scope_id) if r and r.scope_id else None
+    finally:
+        db.close()
 
 
 def _first_school_id() -> int:
@@ -198,7 +218,7 @@ def test_upload_rejects_unknown_mime(client):
 def test_idor_teacher_cannot_read_other_teachers_classroom(client):
     a = _register_teacher(client)
     b = _register_teacher(client)
-    school_id = _first_school_id()
+    school_id = a["school_id"]  # teacher A creates in their OWN school (membership)
     assert school_id is not None, "註冊時應已建立預設 school"
 
     created = client.post(
@@ -287,16 +307,10 @@ def test_idor_org_admin_cannot_read_cross_org_user(client):
     assert client.get(f"/api/users/{cross_org_user}", headers=_auth(tok_sys)).status_code == 200
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="MED-1（對抗複審）：policies.require_classroom_member 用 is_admin（含 org_admin 無 org scope）"
-    " → 跨 org org_admin 可讀別家班級。修 policies.py 改 is_system_admin + org scope 後此測應轉綠，"
-    "屆時移除 xfail marker。",
-)
 def test_idor_org_admin_cannot_read_cross_org_classroom(client):
-    # 教師在預設 school 建一個班級
+    # 教師在自己的 school 建一個班級
     teacher = _register_teacher(client)
-    school_id = _first_school_id()
+    school_id = teacher["school_id"]
     created = client.post(
         "/api/classrooms",
         json={"name": f"ClsB_{uuid.uuid4().hex[:6]}", "grade": 6, "school_id": school_id},
@@ -311,17 +325,10 @@ def test_idor_org_admin_cannot_read_cross_org_classroom(client):
     _grant_role(outsider, "org_admin", "organization", other_org)
     tok = create_access_token(outsider)
 
-    # 正確行為：跨 org 的 org_admin 不該讀到別家班級 → 應 403
-    # 目前 is_admin bypass 會回 200（漏洞）→ 本測 xfail，修好後轉綠
+    # MED-1 已修（policies 收斂到 is_system_admin + org scope）：跨 org org_admin → 403
     assert client.get(f"/api/classrooms/{cid}", headers=_auth(tok)).status_code == 403
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="NEW-1（Cursor 盲掃，已驗證）：schools.py list_school_members/classrooms 只有 get_current_user、"
-    "無 org/school scope → 任何登入者猜 school_id 即可撈全校成員 name/email/role。"
-    "加 org/school membership 檢查後此測轉綠，移除 xfail marker。",
-)
 def test_idor_any_user_cannot_enumerate_school_members(client):
     # 註冊教師會建立預設 school（含該教師為成員，帶 email）
     _register_teacher(client)

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -36,6 +36,7 @@ from app.database import get_db
 from app.models import Base
 from app.models.user import Role, UserRole
 from app.models.school import School
+from app.models.organization import Organization
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +78,16 @@ def _seed_roles(session):
 
 
 def _seed_school(session) -> int:
-    school = School(name="Admin Test School")
+    # Give the school a real organization so org_admin scoping (school→org) works.
+    # Orphan schools (organization_id=None) are intentionally NOT claimable by any
+    # org_admin under the tenant-scoped authz model (#2470).
+    global _test_org_id
+    org = Organization(name="Admin Test Org")
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    _test_org_id = str(org.id)
+    school = School(name="Admin Test School", organization_id=org.id)
     session.add(school)
     session.commit()
     session.refresh(school)
@@ -97,6 +107,7 @@ def _override_get_db():
 # ---------------------------------------------------------------------------
 
 _test_school_id: int = 0
+_test_org_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -159,8 +170,13 @@ def _register_user(client, suffix: str) -> dict:
     }
 
 
-def _make_admin(user_id: int, role_name: str = "system_admin"):
-    """Assign admin role to a user directly via DB."""
+def _make_admin(user_id: int, role_name: str = "system_admin", scope_id: str | None = None):
+    """Assign admin role to a user directly via DB.
+
+    system_admin is platform-scoped (scope_id=None). org_admin/org_owner MUST be
+    scoped to a concrete org (scope_id=org.id) to match production; an org_admin
+    with scope_id=None manages no org and is correctly denied under tenant scoping.
+    """
     db = TestingSessionLocal()
     role = db.query(Role).filter(Role.name == role_name).first()
     scope_type = "platform" if role_name == "system_admin" else "organization"
@@ -168,7 +184,7 @@ def _make_admin(user_id: int, role_name: str = "system_admin"):
         user_id=user_id,
         role_id=role.id,
         scope_type=scope_type,
-        scope_id=None,
+        scope_id=scope_id,
     )
     db.add(user_role)
     db.commit()
@@ -176,17 +192,29 @@ def _make_admin(user_id: int, role_name: str = "system_admin"):
 
 
 def _assign_school_role(user_id: int, school_id: int, role_name: str = "teacher"):
-    """Assign a school-scoped role to a user directly via DB."""
+    """Assign a school-scoped role to a user directly via DB (idempotent)."""
     db = TestingSessionLocal()
     role = db.query(Role).filter(Role.name == role_name).first()
-    user_role = UserRole(
-        user_id=user_id,
-        role_id=role.id,
-        scope_type="school",
-        scope_id=str(school_id),
+    existing = (
+        db.query(UserRole)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.role_id == role.id,
+            UserRole.scope_type == "school",
+            UserRole.scope_id == str(school_id),
+        )
+        .first()
     )
-    db.add(user_role)
-    db.commit()
+    if existing is None:
+        db.add(
+            UserRole(
+                user_id=user_id,
+                role_id=role.id,
+                scope_type="school",
+                scope_id=str(school_id),
+            )
+        )
+        db.commit()
     db.close()
 
 
@@ -200,13 +228,18 @@ def admin_user(client):
 @pytest.fixture(scope="module")
 def org_admin_user(client):
     user = _register_user(client, "org_admin")
-    _make_admin(user["user_id"], "org_admin")
+    # Scope org_admin to the test org (which owns the test school), matching prod.
+    _make_admin(user["user_id"], "org_admin", scope_id=_test_org_id)
     return user
 
 
 @pytest.fixture(scope="module")
 def teacher(client):
-    return _register_user(client, "teacher")
+    user = _register_user(client, "teacher")
+    # Make the teacher a member of the test school so they can create classrooms
+    # there (#2470 NEW-2: create requires school membership / org-admin / sysadmin).
+    _assign_school_role(user["user_id"], _test_school_id, "teacher")
+    return user
 
 
 @pytest.fixture(scope="module")

--- a/docs/security/2026-07-04-blackbox-result.md
+++ b/docs/security/2026-07-04-blackbox-result.md
@@ -6,11 +6,31 @@
 > - 綠燈 = 對映的 WSTG 條目「自測通過」，不保證通過官方稽核
 > - 全程 LOCAL：靜態 grep + Semgrep + gitleaks + in-process TestClient 動態測試 + 獨立對抗複審 agent；**未**對雲端正式站台燒錢掃描
 
-## 目前 gate 狀態：🔴 RED — 未通過
+## 目前 gate 狀態：🟡 大部分已修，2 項 deferred（追蹤中）
 
-> 兩輪獨立對抗複審後（appsec-pentest-reviewer + Cursor 不同引擎），確認 **≈4 HIGH + 5 MED + 多個 LOW**，且核心是**系統性租戶隔離破口**（`is_admin` 被當全域 bypass + 多個 school-scoped 讀取路徑零授權）。修好前**不建議送官方稽核**。
+> 兩輪獨立對抗複審（appsec-pentest-reviewer + Cursor 不同引擎）確認核心是**系統性租戶隔離破口**（`is_admin` 被當全域 bypass + 多個 school-scoped 讀取零授權）+ 限流信任鏈。
+> 認證/注入/機密底子好（JWT/bcrypt/ORM/無 committed secret 全綠）。
+
+## 修復狀態（2026-07-04 收尾）
+
+| 發現 | 嚴重度 | 狀態 | 位置 |
+|------|--------|------|------|
+| MED-1 班級/學生存取 IDOR（is_admin 全域 bypass）| HIGH | ✅ 已修+驗證 | PR #2472（policies.py 收斂到 is_system_admin+org scope）|
+| NEW-1 任何登入者枚舉全校 email | HIGH | ✅ 已修+驗證 | PR #2472（schools.py 加 scope）|
+| NEW-3 org dashboard/points 跨 org | MED | ✅ 已修+驗證 | PR #2472（含 regression guard 不誤傷 org_admin）|
+| NEW-4 semesters 跨校 | MED | ✅ 已修+驗證 | PR #2472 |
+| NEW-5 regenerate-code 跨 org | MED | ✅ 已修+驗證 | PR #2472 |
+| create_school 跨 org | MED | ✅ 已修+驗證 | PR #2472 |
+| roles list 跨 org | MED | ✅ 已修+驗證 | PR #2472 |
+| HIGH-1 核心（per-user 限流 request.state.user_id）| HIGH | ✅ 已修+驗證 | ratelimit branch |
+| MED-2 batch-eval 燒錢（role gate + AI 限流）| MED | ✅ 已修+驗證 | ratelimit branch |
+| MED-3 SSO email_verified | MED | ✅ 已修+驗證 | ratelimit branch |
+| **NEW-2 跨校/跨 org 建班（create-pollution）** | MED* | ⏸ **Deferred** | 需 ~16 檔 test-fixture batch migration（做法已 proven，見 #2470）|
+| **HIGH-1a entrypoint XFF / 匿名 IP 限流** | HIGH | ⏸ **Deferred** | 需 Cloud Run proxy 語義查證（可能配 Cloud Armor）|
+
+> *NEW-2 實際影響 = 「teacher 在不屬於的 school 建自己的班」= 跨租戶**建立污染**，非讀取他人資料（讀取 IDOR = MED-1 已修）。自動資安複審 2 次旗標；為 conscious defer（正確修法連鎖破壞 ~16 個測試檔的 fixture，需獨立 batch pass；真實流程不受影響——teacher 註冊自動加入自己 school）。
 >
-> 認證/注入/機密底子仍好（JWT/bcrypt/ORM/無 committed secret 全綠），問題集中在**授權（tenant isolation）+ 限流信任鏈**。
+> **驗證**：dynamic security 12+ pass、test_admin_api 38、semesters 23、classroom 測試全綠、CI gate 綠，0 淨 regression（pre-existing 失敗經 baseline 對照確認與本次無關）。
 
 ## 受測標的
 - Repo：`chinese-literacy-platform`（LingoLeap）— 國小/國中中文閱讀學習平台


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

（原 #2472 因 stacked base branch 被 #2471 merge 時刪除而自動關閉，改開此 PR 直接對 staging）

修 #2470 authz cluster：MED-1（班級/學生 IDOR）、NEW-1（全校枚舉）、NEW-3（org dashboard/points）、NEW-4（semesters）、NEW-5（regenerate/create_school）、roles 跨 org（含 Cursor 最終 QA 抓的 caller over-permission 修正）。全域 bypass 只認 is_system_admin，org_admin 走 school→org。

驗證：dynamic security 13 pass、test_admin_api 38、semesters 23、classroom 全綠、0 淨 regression。三輪對抗複審（appsec agent + Cursor 設計/最終 QA）。

Deferred（見 #2470）：NEW-2、HIGH-1a。

🤖 Generated with [Claude Code](https://claude.com/claude-code)