### PR TITLE
test(auth): 修 SSO 測試 mock 缺 email_verified (#2470 MED-3 followup)

### DIFF
--- a/backend/tests/test_auth_route_split_1844.py
+++ b/backend/tests/test_auth_route_split_1844.py
@@ -491,6 +491,7 @@ class TestSSOLogin:
             "email": email,
             "name": "Existing User",
             "picture": None,
+            "email_verified": True,  # #2470 MED-3: legitimate Google logins are verified
         }
 
         # After refactor: patch at the sso_login_service module level
@@ -522,6 +523,7 @@ class TestSSOLogin:
             "email": email,
             "name": "New Google User",
             "picture": None,
+            "email_verified": True,  # #2470 MED-3: legitimate Google logins are verified
         }
 
         with patch("app.services.sso_login_service.settings") as mock_settings:
@@ -565,6 +567,7 @@ class TestSSOLogin:
             "email": email,
             "name": "Returning Google User",
             "picture": None,
+            "email_verified": True,  # #2470 MED-3: legitimate Google logins are verified
         }
 
         with patch("app.services.sso_login_service.settings") as mock_settings:

--- a/backend/tests/test_google_oauth.py
+++ b/backend/tests/test_google_oauth.py
@@ -75,6 +75,7 @@ FAKE_ID_INFO = {
     "email": "newuser@gmail.com",
     "name": "New User",
     "picture": "https://lh3.googleusercontent.com/photo.jpg",
+    "email_verified": True,  # #2470 MED-3: legitimate Google logins are verified
 }
 
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

MED-3（email_verified gate）經前一個 PR 進 staging，但打到 SSO 測試（mock id_info 沒設 email_verified → 401）。正當 Google 登入本就帶 email_verified=True，補進 mock。修好我先前沒 gate 住 spec-CI 就 merge 造成的 regression。

test_google_oauth 9 pass、test_auth_route_split_1844 28 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)