### PR TITLE
fix(security): XFF 限流取可信 hop 位置 #2470 HIGH-1a

### DIFF
--- a/backend/app/auth/rate_limiter.py
+++ b/backend/app/auth/rate_limiter.py
@@ -98,19 +98,42 @@ general_rate_limiter = InMemoryRateLimiter()
 # Helpers
 # ---------------------------------------------------------------------------
 
+def real_ip_from_xff(xff: str, peer: str | None = None) -> str:
+    """Return the real client IP behind the Cloud Run / GCP load balancer.
+
+    (#2470 HIGH-1a) GCP appends [real-client-ip, load-balancer-ip] to any
+    client-supplied X-Forwarded-For, so the trustworthy client IP is the
+    SECOND-from-right. Entries to the left are attacker-controlled (a client can
+    prepend anything) and MUST NOT be used for rate-limiting / security — taking
+    the leftmost let an attacker rotate a fake IP to bypass per-IP limits.
+    """
+    parts = [p.strip() for p in (xff or "").split(",") if p.strip()]
+    if len(parts) >= 2:
+        return parts[-2]
+    if parts:
+        return parts[-1]
+    return peer or "unknown"
+
+
+def real_client_ip(request: Request) -> str:
+    """Real client IP for a FastAPI Request (see real_ip_from_xff)."""
+    return real_ip_from_xff(
+        request.headers.get("x-forwarded-for", ""),
+        request.client.host if request.client else None,
+    )
+
+
 def get_client_key(request: Request) -> str:
     """Return a stable key for the current request client.
 
     Uses the authenticated user ID when available (from a previously decoded
-    JWT stored by the auth dependency), falling back to the client IP address.
+    JWT stored by the auth dependency), falling back to the real client IP.
     """
     # The auth dependency stores the user id in request.state.user_id.
     user_id = getattr(request.state, "user_id", None)
     if user_id is not None:
         return f"user:{user_id}"
-    client = request.client
-    ip = client.host if client else "unknown"
-    return f"ip:{ip}"
+    return f"ip:{real_client_ip(request)}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ from .routes.omo import router as omo_router
 from .routes.curriculum_qa import router as curriculum_qa_router
 from .routes.admin_story_structure_lab import router as admin_story_structure_lab_router
 from .utils.logging_config import setup_logging
-from .auth.rate_limiter import general_rate_limiter
+from .auth.rate_limiter import general_rate_limiter, real_ip_from_xff
 from .services.seed import seed_default_data, repair_pii_accounts
 
 # Initialise structured logging before anything else
@@ -263,14 +263,12 @@ class GlobalRateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Extract real client IP from headers.
+        # Extract the real client IP (#2470 HIGH-1a): take the GCP-appended
+        # second-from-right XFF entry, not the client-controlled leftmost one.
         headers_raw = dict(scope.get("headers", []))
         forwarded_for = headers_raw.get(b"x-forwarded-for", b"").decode()
-        if forwarded_for:
-            ip = forwarded_for.split(",")[0].strip()
-        else:
-            client = scope.get("client")
-            ip = client[0] if client else "unknown"
+        client = scope.get("client")
+        ip = real_ip_from_xff(forwarded_for, client[0] if client else None)
         method = scope.get("method", "GET").upper()
         is_read = method in ("GET", "HEAD", "OPTIONS")
         limit = self.READ_LIMIT if is_read else self.WRITE_LIMIT

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -26,7 +26,7 @@ from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user
 from ..auth.jwt import create_access_token
 from ..auth.password import hash_password, verify_password
-from ..auth.rate_limiter import InMemoryRateLimiter
+from ..auth.rate_limiter import InMemoryRateLimiter, real_client_ip
 from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
@@ -123,7 +123,7 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
     - Dev/staging mode: token is returned in the response body for easy testing.
     - Production: token should be emailed; remove 'verification_token' from response.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"register:{client_ip}", max_requests=5, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
@@ -173,7 +173,7 @@ def login(req: LoginRequest, request: Request, db: Session = Depends(get_db)):
     Accepts either an email address or a username in the `email` field.
     If the value contains '@', it is treated as an email; otherwise as a username.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"login:{client_ip}", max_requests=10, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
@@ -267,7 +267,7 @@ def forgot_password(req: ForgotPasswordRequest, request: Request, db: Session = 
     Always returns HTTP 200 to prevent user enumeration.
     Dev mode: token returned in body. Production: send via email only.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"forgot-password:{client_ip}", max_requests=5, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
@@ -328,7 +328,7 @@ def resend_verification(req: ResendVerificationRequest, request: Request, db: Se
 
     Issue #460. Rate-limited. Dev/staging mode: returns token directly.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"resend-verification:{client_ip}", max_requests=5, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
@@ -351,7 +351,7 @@ def google_login(req: GoogleLoginRequest, request: Request, db: Session = Depend
     3. Else if a user with matching email exists -> link the Google account.
     4. Else -> create a new user account (email_verified=True, no password).
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"google-login:{client_ip}", max_requests=20, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
@@ -426,7 +426,7 @@ def junyi_login(req: JunyiLoginRequest, request: Request, db: Session = Depends(
 
     The code is single-use with a 600s TTL (enforced by Junyi's backend).
     """
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = real_client_ip(request)
     if not rate_limiter.check(f"junyi-login:{client_ip}", max_requests=20, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -48,4 +48,9 @@ PYEOF
     echo "Migrations complete."
 fi
 
-exec uvicorn app.main:app --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips='*'
+# (#2470 HIGH-1a) Do NOT trust X-Forwarded-For from arbitrary clients: removed the
+# forwarded-allow-ips wildcard (which let any caller spoof request.client.host).
+# Security-relevant client IP is derived in-app from the GCP-appended XFF entry
+# (see app.auth.rate_limiter.real_ip_from_xff). --proxy-headers stays with uvicorn's
+# safe default (trust only 127.0.0.1) so request.client.host is not client-spoofable.
+exec uvicorn app.main:app --host 0.0.0.0 --port 8080 --proxy-headers

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -683,3 +683,30 @@ class TestGlobalRateLimitMiddleware:
         assert GlobalRateLimitMiddleware.READ_LIMIT == 300
         assert GlobalRateLimitMiddleware.WRITE_LIMIT == 90
         assert GlobalRateLimitMiddleware.WINDOW == 60
+
+
+class TestRealClientIpXFF:
+    """#2470 HIGH-1a: real client IP must come from the GCP-appended second-from-right
+    X-Forwarded-For entry, never the client-controlled leftmost one — else an attacker
+    rotates a fake leftmost IP to bypass per-IP rate limits."""
+
+    def test_takes_second_from_right(self):
+        from app.auth.rate_limiter import real_ip_from_xff
+        # GCP appends [real-client, load-balancer]; client prepended a spoof
+        assert real_ip_from_xff("1.1.1.1, 5.5.5.5, 9.9.9.9") == "5.5.5.5"
+
+    def test_rotating_leftmost_does_not_change_result(self):
+        from app.auth.rate_limiter import real_ip_from_xff
+        a = real_ip_from_xff("11.11.11.11, 5.5.5.5, 9.9.9.9")
+        b = real_ip_from_xff("22.22.22.22, 5.5.5.5, 9.9.9.9")
+        assert a == b == "5.5.5.5"  # bypass attempt (rotate spoof) has no effect
+
+    def test_no_spoof_prefix(self):
+        from app.auth.rate_limiter import real_ip_from_xff
+        # No client-supplied prefix: GCP set [real-client, lb]
+        assert real_ip_from_xff("5.5.5.5, 9.9.9.9") == "5.5.5.5"
+
+    def test_empty_falls_back_to_peer(self):
+        from app.auth.rate_limiter import real_ip_from_xff
+        assert real_ip_from_xff("", "10.0.0.1") == "10.0.0.1"
+        assert real_ip_from_xff("") == "unknown"

--- a/tests/security/blackbox_acceptance.sh
+++ b/tests/security/blackbox_acceptance.sh
@@ -170,7 +170,7 @@ fi
 # ─────────────────────────────────────────────────────────────
 echo; echo "── 對抗複審發現（2026-07-04 appsec-pentest-reviewer；red→green 鎖，修好轉綠）──"
 # HIGH-1a: entrypoint 不得無條件信任 XFF（--forwarded-allow-ips='*' → 限流全線可繞）
-if grep -qa "forwarded-allow-ips='\*'" "$ROOT/backend/entrypoint.sh" 2>/dev/null; then
+if grep -qaE "^[^#]*forwarded-allow-ips='\*'" "$ROOT/backend/entrypoint.sh" 2>/dev/null; then
   no "A07/A04 · WSTG-ATHN-03/BUSL-01" "HIGH-1: entrypoint --forwarded-allow-ips='*'（信任任意 XFF）" "改可信代理範圍/信任 hop 數"
 else
   ok "A07/A04 · WSTG-ATHN-03" "entrypoint 未無條件信任 XFF"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

修 #2470 HIGH-1a：限流原本用 client 可控的 XFF 最左值 → 攻擊者輪換假 IP 繞過 per-IP 限流。GCP/Cloud Run 會附加 [真實client, LB] 到 client 送的 XFF 後，故改取右邊數第 2 個（GCP 設的真實 client）。

- `real_ip_from_xff`/`real_client_ip` helper（取 [-2]）
- global middleware + auth.py 5 端點（login/register/forgot/resend/google）改用
- entrypoint 移除 forwarded-allow-ips 萬用字元
- +4 regression test（輪換最左假 IP 無效）

驗證：受影響檔個別跑全綠（batch 失敗是既有污染）、acceptance HIGH-1a 翻綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)