### PR TITLE
release: NEW-2 create_classroom 授權 → production (#2470 收尾)

### DIFF
--- a/backend/app/routes/classrooms/classroom_crud.py
+++ b/backend/app/routes/classrooms/classroom_crud.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
+from ...auth.policies import is_system_admin, _is_org_admin_of_school
 from ...database import get_db
 from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
 from ...models.user import User
@@ -52,9 +53,28 @@ def create_classroom(
     if school is None:
         raise HTTPException(status_code=404, detail="School not found")
 
+    # (#2470 NEW-2): caller must have standing in THIS school — system_admin (any),
+    # a member of the school (school-scoped role, incl. orphan/domain schools), or
+    # org_admin/org_owner of the school's org. Closes "any teacher creates in any
+    # school" (cross-school / cross-org create-pollution). The common attack sets
+    # teacher_id == self, so this must NOT live only in the delegation branch below.
+    caller_is_sysadmin = is_system_admin(current_user.id, db)
+    if not caller_is_sysadmin:
+        is_school_member = any(
+            ur.is_active and ur.scope_type == "school" and ur.scope_id == str(school.id)
+            for ur in current_user.user_roles
+        )
+        if not (is_school_member or _is_org_admin_of_school(current_user.id, school.id, db)):
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to create a classroom in this school",
+            )
+
     effective_teacher_id = current_user.id
     if payload.teacher_id is not None and payload.teacher_id != current_user.id:
-        if not is_admin(current_user.id, db):
+        # Creating on behalf of another teacher requires admin authority over the
+        # school's org (system_admin, or org_admin/org_owner of the school's org).
+        if not (caller_is_sysadmin or _is_org_admin_of_school(current_user.id, school.id, db)):
             raise HTTPException(
                 status_code=403,
                 detail="Only admins can create classrooms for other teachers",

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -131,6 +131,22 @@ def school_id():
     return _test_school_id
 
 
+def _grant_school_teacher_role(user_id: int) -> None:
+    """Grant a school-scoped teacher UserRole for `_test_school_id` (idempotent)."""
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
+
 def _register_user(client, suffix: str) -> dict:
     unique = uuid.uuid4().hex[:8]
     email = f"{suffix}_{unique}@example.com"
@@ -153,6 +169,7 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+    _grant_school_teacher_role(user_id)
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 
@@ -1891,6 +1908,7 @@ def _register_and_login(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+    _grant_school_teacher_role(user_id)
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_classroom_join_and_batch.py
+++ b/backend/tests/test_classroom_join_and_batch.py
@@ -147,6 +147,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_classroom_texts_api.py
+++ b/backend/tests/test_classroom_texts_api.py
@@ -142,6 +142,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_classrooms_api.py
+++ b/backend/tests/test_classrooms_api.py
@@ -32,7 +32,7 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
-from app.models.user import Role
+from app.models.user import Role, UserRole
 from app.models.school import School
 
 
@@ -156,6 +156,20 @@ def _register_user(client, suffix: str) -> dict:
     # Get user ID from /users/me
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_co_teaching_api.py
+++ b/backend/tests/test_co_teaching_api.py
@@ -31,7 +31,7 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
-from app.models.user import Role
+from app.models.user import Role, UserRole
 from app.models.school import School
 
 
@@ -64,6 +64,7 @@ SEED_ROLES = [
 
 # Module-level state shared across tests
 _state: dict = {}
+_test_school_id: int = 0
 
 
 def _seed_roles(session):
@@ -104,7 +105,25 @@ def _register(client, name, email, password="Password123!"):
     # Login to get access_token
     login_r = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_r.status_code == 200, login_r.text
-    return login_r.json()["access_token"]
+    token = login_r.json()["access_token"]
+
+    me_r = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    user_id = me_r.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
+    return token
 
 
 def _create_classroom(client, token, school_id):
@@ -122,10 +141,12 @@ def _create_classroom(client, token, school_id):
 @pytest.fixture(scope="module", autouse=True)
 def setup_module():
     """Create tables, seed data, register users, create classroom."""
+    global _test_school_id
     Base.metadata.create_all(bind=engine)
     session = TestingSessionLocal()
     _seed_roles(session)
     school_id = _seed_school(session)
+    _test_school_id = school_id
     session.close()
 
     app.dependency_overrides[get_db] = _override_get_db

--- a/backend/tests/test_copyright.py
+++ b/backend/tests/test_copyright.py
@@ -140,7 +140,24 @@ def _register_and_login(client) -> str:
     if verification_token:
         client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
-    return login_resp.json()["access_token"]
+    token = login_resp.json()["access_token"]
+
+    me_resp = client.get("/api/users/me", headers=_auth_header(token))
+    user_id = me_resp.json()["id"]
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
+    return token
 
 
 def _create_classroom(client, token: str, school_id: int) -> int:

--- a/backend/tests/test_csv_upload.py
+++ b/backend/tests/test_csv_upload.py
@@ -142,6 +142,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -145,9 +145,24 @@ def _register_user(client, suffix: str) -> dict:
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
+    user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {
         "token": token,
-        "user_id": me_resp.json()["id"],
+        "user_id": user_id,
         "email": email,
         "name": name,
     }

--- a/backend/tests/test_student_tags.py
+++ b/backend/tests/test_student_tags.py
@@ -111,6 +111,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_teacher_analytics.py
+++ b/backend/tests/test_teacher_analytics.py
@@ -143,6 +143,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=_auth(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_teacher_api.py
+++ b/backend/tests/test_teacher_api.py
@@ -147,6 +147,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_teacher_instructions.py
+++ b/backend/tests/test_teacher_instructions.py
@@ -146,6 +146,20 @@ def _register_user(client, suffix: str) -> dict:
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "name": name, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_teacher_report_completion_1911.py
+++ b/backend/tests/test_teacher_report_completion_1911.py
@@ -165,6 +165,20 @@ def _register_and_login(client, prefix: str) -> dict:
     token = login.json()["access_token"]
     me = client.get("/api/users/me", headers=auth_header(token))
     user_id = me.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_teacher_students_1882.py
+++ b/backend/tests/test_teacher_students_1882.py
@@ -164,6 +164,20 @@ def _register_and_login(client, prefix: str) -> dict:
     token = login.json()["access_token"]
     me = client.get("/api/users/me", headers=auth_header(token))
     user_id = me.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
     return {"email": email, "token": token, "user_id": user_id}
 
 

--- a/backend/tests/test_text_cleanup.py
+++ b/backend/tests/test_text_cleanup.py
@@ -157,7 +157,22 @@ def _register_user(client, suffix: str) -> dict:
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
-    return {"email": email, "token": token, "user_id": me_resp.json()["id"]}
+    user_id = me_resp.json()["id"]
+
+    _mk = TestingSessionLocal()
+    try:
+        _trole = _mk.query(Role).filter(Role.name == "teacher").first()
+        if _trole and not _mk.query(UserRole).filter(
+            UserRole.user_id == user_id, UserRole.role_id == _trole.id,
+            UserRole.scope_type == "school", UserRole.scope_id == str(_test_school_id),
+        ).first():
+            _mk.add(UserRole(user_id=user_id, role_id=_trole.id,
+                             scope_type="school", scope_id=str(_test_school_id)))
+            _mk.commit()
+    finally:
+        _mk.close()
+
+    return {"email": email, "token": token, "user_id": user_id}
 
 
 def _make_admin(user_id: int):


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Staging → main（prod 同步）：#2470 最後一項 NEW-2。

create_classroom 加 school-standing 檢查（system_admin / org_admin 該 org / 該校 member），關閉跨校/跨 org 建班污染。15 檔 test fixture 遷移配合。

Staging 驗證：/api/health 200、batch-eval no-auth 401、spec 契約 748+205 pass。至此 #2470 十個 findings 全上 production（僅 list_my_classrooms scoping MED-1d 仍追蹤）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)