### PR TITLE
fix(auth): list_my_classrooms 租戶 scoping #2470 MED-1d（最後一項）

### DIFF
--- a/backend/app/routes/classrooms/classroom_crud.py
+++ b/backend/app/routes/classrooms/classroom_crud.py
@@ -7,9 +7,9 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
-from ...auth.policies import is_system_admin, _is_org_admin_of_school
+from ...auth.policies import is_system_admin, _is_org_admin_of_school, _org_admin_org_ids
 from ...database import get_db
-from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
+from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher, School
 from ...models.user import User
 from ...schemas.classroom import (
     ClassroomCreateRequest,
@@ -27,7 +27,6 @@ from .helpers import (
     classroom_to_response,
     generate_join_code,
     get_classroom_or_404,
-    is_admin,
     require_member_or_admin,
     require_owner_or_admin,
 )
@@ -123,16 +122,26 @@ def list_my_classrooms(
 ):
     """List classrooms.
 
-    - system_admin / org_admin: returns ALL platform classrooms (platform-wide view).
-    - Regular teacher: returns only classrooms they own or co-teach.
+    - system_admin: ALL platform classrooms (platform-wide view).
+    - org_admin/org_owner: classrooms in schools of their org(s) only (#2470 MED-1d:
+      was is_admin → any org_admin saw the whole platform's classroom metadata).
+    - Regular teacher: only classrooms they own or co-teach.
 
     #1999: regular teachers also get dev/test classrooms (PM dogfood / Bulk驗證)
     filtered out — same regex as /api/teacher/classrooms (#1985). Admins still
-    see every classroom, including dev ones, for full platform visibility.
+    see dev ones for full visibility within their scope.
     """
-    caller_is_admin = is_admin(current_user.id, db)
-    if caller_is_admin:
+    caller_is_sysadmin = is_system_admin(current_user.id, db)
+    caller_org_ids = _org_admin_org_ids(current_user.id, db)
+    caller_is_admin = caller_is_sysadmin or bool(caller_org_ids)  # controls dev-classroom filter below
+    if caller_is_sysadmin:
         query = db.query(Classroom)
+    elif caller_org_ids:
+        query = (
+            db.query(Classroom)
+            .join(School, Classroom.school_id == School.id)
+            .filter(School.organization_id.in_(caller_org_ids))
+        )
     else:
         co_teacher_classroom_ids = (
             db.query(ClassroomTeacher.classroom_id)

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -414,3 +414,41 @@ def test_idor_any_user_cannot_enumerate_school_members(client):
     # 正確行為：無關使用者不該讀到全校成員名冊（PII）→ 應 403
     # 目前無授權檢查會回 200 + email（漏洞）→ 本測 xfail，修好後轉綠
     assert client.get(f"/api/schools/{sid}/members", headers=_auth(tok)).status_code == 403
+
+
+def _create_classroom_direct(school_id: int, teacher_id: int, name: str) -> int:
+    from app.models.school import Classroom
+    import secrets as _s
+    db = TestingSessionLocal()
+    try:
+        c = Classroom(school_id=school_id, teacher_id=teacher_id, name=name,
+                      grade=6, join_code=_s.token_hex(3).upper())
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+        return c.id
+    finally:
+        db.close()
+
+
+def test_med1d_org_admin_lists_only_own_org_classrooms(client):
+    # #2470 MED-1d: GET /api/classrooms must scope org_admin to their own org's
+    # classrooms, not the whole platform (was is_admin → any org_admin saw all).
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"L1dA_{u}")
+    org_b = _create_org(f"L1dB_{u}")
+    school_a = _create_school(org_a)
+    school_b = _create_school(org_b)
+    t_a = _create_user(f"l1d_ta_{u}@example.com")
+    t_b = _create_user(f"l1d_tb_{u}@example.com")
+    cls_a = _create_classroom_direct(school_a, t_a, f"ClsA_{u}")
+    cls_b = _create_classroom_direct(school_b, t_b, f"ClsB_{u}")
+
+    admin_a = _create_user(f"l1d_oa_{u}@example.com")
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+
+    r = client.get("/api/classrooms?limit=100", headers=_auth(create_access_token(admin_a)))
+    assert r.status_code == 200, r.text
+    ids = [c["id"] for c in r.json()["items"]]
+    assert cls_a in ids, "org_admin should see own org's classroom"
+    assert cls_b not in ids, "org_admin must NOT see another org's classroom (MED-1d)"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

修 #2470 最後一項 MED-1d：GET /api/classrooms 原用 is_admin → 任何 org_admin 看全平台班級 metadata。改成 system_admin 看全部、org_admin 只看自己 org（school→org join）、teacher 看 own/co-taught。is_admin 從 classroom_crud 移除。+regression test。**至此 #2470 十一項全修完。**

驗證：dynamic security 16 pass、test_classrooms_api 43 pass（TestAdminListAllClassrooms 用 system_admin 仍看全部=正確）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)