### PR TITLE
fix: serve public assets via same-origin backend proxy (Related to #2486)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from .routes.admin_seed import router as admin_seed_router
 from .routes.omo import router as omo_router
 from .routes.curriculum_qa import router as curriculum_qa_router
 from .routes.admin_story_structure_lab import router as admin_story_structure_lab_router
+from .routes.assets import router as assets_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter, real_ip_from_xff
 from .services.seed import seed_default_data, repair_pii_accounts
@@ -96,14 +97,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "https://*.firebaseapp.com "
         "https://*.cloudfunctions.net "
         "https://us-central1-aiplatform.googleapis.com; "
-        # Issue #1496: allow GCS bucket for the worksheet PDF iframe (#1444),
-        # plus YouTube embeds for the knowledge-station videos.
-        # NOTE: CSP frame-src cannot restrict by path (spec limitation), so the
-        # entire storage.googleapis.com host is whitelisted. The actual PDFs
-        # live under public-read `lingoleap-assets/worksheets/`; tighter scoping
-        # would require proxying PDFs through our own origin.
+        # Issue #1496: worksheet PDF iframe (#1444), plus YouTube embeds for
+        # the knowledge-station videos.
+        # Issue #2486: the worksheet PDF now loads through our own
+        # `/assets/*` proxy (same-origin), so storage.googleapis.com no
+        # longer needs a frame-src exception — 'self' covers it.
         "frame-src 'self' "
-        "https://storage.googleapis.com "
         "https://www.youtube.com "
         "https://www.youtube-nocookie.com; "
         "frame-ancestors 'none';"
@@ -232,11 +231,16 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
 
 class GlobalRateLimitMiddleware:
-    """Pure ASGI middleware for global per-IP rate limiting on /api/* endpoints.
+    """Pure ASGI middleware for global per-IP rate limiting on /api/* and /assets/*.
 
     Uses raw ASGI protocol instead of BaseHTTPMiddleware to guarantee headers
     are injected before the response starts streaming (BaseHTTPMiddleware +
     StreamingResponse can silently drop headers added after call_next).
+
+    /assets/* is included (#2486): it's the proxy in front of the now-private
+    lingoleap-assets GCS bucket. Without a rate limit here, closing off public
+    bucket listing would still leave the door open for a single IP to hammer
+    the proxy (and therefore our GCS egress) at unlimited rate.
     """
 
     _EXEMPT_PATHS = ("/health", "/docs", "/redoc", "/openapi.json", "/")
@@ -258,8 +262,10 @@ class GlobalRateLimitMiddleware:
 
         path = scope["path"]
 
-        # Skip rate limiting for exempt or non-API paths.
-        if path in self._EXEMPT_PATHS or not path.startswith("/api"):
+        # Skip rate limiting for exempt paths, or paths outside the two
+        # limited surfaces (/api/* and /assets/*).
+        is_limited_surface = path.startswith("/api") or path.startswith("/assets")
+        if path in self._EXEMPT_PATHS or not is_limited_surface:
             await self.app(scope, receive, send)
             return
 
@@ -353,7 +359,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Global rate limiting: 300 read req/min + 90 write req/min per IP for /api/*.
+# Global rate limiting: 300 read req/min + 90 write req/min per IP for
+# /api/* and /assets/* (#2486).
 # Placed after CORS so CORS preflight OPTIONS requests are not rate-limited.
 app.add_middleware(GlobalRateLimitMiddleware)
 
@@ -391,6 +398,8 @@ app.include_router(admin_seed_router, prefix="/api", tags=["admin-seed"])
 app.include_router(omo_router, prefix="/api", tags=["omo"])
 app.include_router(curriculum_qa_router, prefix="/api", tags=["curriculum-qa"])
 app.include_router(admin_story_structure_lab_router, prefix="/api", tags=["admin-story-structure-lab"])
+# No /api prefix — matches the Firebase Hosting `/assets/**` rewrite target (#2486).
+app.include_router(assets_router)
 
 
 @app.get("/")

--- a/backend/app/routes/assets.py
+++ b/backend/app/routes/assets.py
@@ -1,0 +1,125 @@
+"""Public asset proxy — serves images/worksheets from the (private) lingoleap-assets bucket.
+
+Issue #2486: `lingoleap-assets` was public-read (allUsers objectViewer), which let
+anyone anonymously *enumerate* (list all 3900+ objects) and bulk-download the
+entire course image/worksheet library — an egress-cost risk with no cap, plus a
+content-enumeration / IP-exposure concern. This route lets the backend's own
+service-account credentials read the bucket while the bucket itself is private —
+the browser only ever talks to our own origin (Firebase Hosting `/assets/**`
+rewrite in prod/staging, or the backend's own Cloud Run URL directly in
+preview/local dev), never to storage.googleapis.com.
+
+Security posture:
+- Only 3 allow-listed top-level prefixes are servable (lessons-images/, stories/,
+  worksheets/) — these are exactly the prefixes referenced by frontend consts and
+  backend-generated URLs. Legacy prefixes not consumed by the app (pr-screenshots/,
+  qa/) are NOT proxied — no general-purpose GCS object reader.
+- Strict allow-list regex on the full decoded path before it ever reaches GCS,
+  plus an explicit ".." reject, guards against path-traversal-style requests.
+- No auth required — this is public *content* (same visibility as before); the
+  fix closes the *enumeration + uncapped egress* surface, not the content itself.
+- Covered by the app-wide GlobalRateLimitMiddleware (see main.py) so a single IP
+  can no longer hammer the bucket at unlimited rate.
+"""
+import logging
+import re
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+from starlette.responses import Response
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/assets", tags=["assets"])
+
+# Keep in sync with frontend `ASSET_BASE` consumers (assetBase.ts) and the
+# backend URL builders in lesson_layer_loaders.py — this list IS the public
+# content surface of the bucket.
+_ALLOWED_PREFIXES = ("lessons-images/", "stories/", "worksheets/")
+
+# Allow-list charset for the decoded object path. FastAPI's `{path:path}`
+# converter URL-decodes the raw request path once before this ever runs, so a
+# literal ".." here is a real traversal attempt, not a percent-encoding
+# artifact. Anything outside this charset (backslashes, NUL, unicode
+# lookalikes, control chars, ...) is rejected outright.
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_\-./]+$")
+
+_CONTENT_TYPES = {
+    ".webp": "image/webp",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".pdf": "application/pdf",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+# Cache the asset immutably at the edge (Firebase Hosting CDN) and in the
+# browser — object keys are effectively content-addressed by lesson code /
+# filename in practice, and this is exactly the lever that reduces origin
+# egress for repeat views.
+_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _is_safe_object_path(object_path: str) -> bool:
+    if not object_path or ".." in object_path:
+        return False
+    if object_path.startswith("/"):
+        return False
+    if not _SAFE_PATH_RE.match(object_path):
+        return False
+    # Must have an actual filename component after the prefix — a bare
+    # "lessons-images/" request is never a real object, reject it here
+    # instead of letting it fall through to a GCS lookup.
+    return any(
+        object_path.startswith(prefix) and len(object_path) > len(prefix)
+        for prefix in _ALLOWED_PREFIXES
+    )
+
+
+@lru_cache(maxsize=1)
+def _get_bucket():
+    """Lazily construct (and cache) the GCS bucket handle.
+
+    Import is deferred (matches the pattern in omo_storage.py) so local dev /
+    unit tests that never exercise this route don't need google-cloud-storage
+    importable at module load time.
+    """
+    from google.cloud import storage  # type: ignore[import]
+    client = storage.Client()
+    return client.bucket(settings.gcs_bucket)
+
+
+def _content_type_for(object_path: str) -> str:
+    if "." not in object_path:
+        return _DEFAULT_CONTENT_TYPE
+    ext = "." + object_path.rsplit(".", 1)[-1].lower()
+    return _CONTENT_TYPES.get(ext, _DEFAULT_CONTENT_TYPE)
+
+
+@router.get("/{object_path:path}")
+def get_asset(object_path: str) -> Response:
+    if not _is_safe_object_path(object_path):
+        raise HTTPException(status_code=404, detail="Not found")
+
+    try:
+        bucket = _get_bucket()
+        blob = bucket.blob(object_path)
+        data = blob.download_as_bytes()
+    except ImportError:
+        logger.error("google-cloud-storage not installed — asset proxy unavailable")
+        raise HTTPException(status_code=503, detail="Asset service unavailable")
+    except Exception as exc:
+        # Covers google.cloud.exceptions.NotFound and any other GCS failure.
+        # Deliberately generic — never echo the exception text or bucket name
+        # back to the client.
+        logger.warning("Asset proxy miss for %r: %s", object_path, exc)
+        raise HTTPException(status_code=404, detail="Not found")
+
+    return Response(
+        content=data,
+        media_type=_content_type_for(object_path),
+        headers={"Cache-Control": _CACHE_CONTROL},
+    )

--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -62,14 +62,37 @@ def _load_docx_codes() -> frozenset[str]:
 
 _DOCX_CODES: frozenset[str] = _load_docx_codes()
 
-_GCS_DOCX_BASE = "https://storage.googleapis.com/lingoleap-assets/worksheets"
+# Issue #2486: lingoleap-assets went private (was public-read, letting anyone
+# enumerate + bulk-download the whole course library). All URLs we derive now
+# point at our own same-origin proxy (backend `/assets/*` route, fronted by
+# the Firebase Hosting `/assets/**` rewrite) instead of the GCS host directly.
+_ASSET_PROXY_BASE = "/assets"
+_GCS_ABSOLUTE_PREFIX = "https://storage.googleapis.com/lingoleap-assets/"
+_GCS_DOCX_BASE = f"{_ASSET_PROXY_BASE}/worksheets"
+
+
+def _to_asset_proxy_url(url: str | None) -> str | None:
+    """Rewrite a legacy absolute GCS URL to our same-origin ``/assets/`` proxy path.
+
+    320+ YAML source files under ``backend/data/curriculum/lessons/`` still carry
+    literal ``https://storage.googleapis.com/lingoleap-assets/...`` strings for
+    ``worksheet_pdf_url`` (hand-editing every file was out of scope for #2486) —
+    this is the single point where those get rewritten before reaching an API
+    response. Idempotent: a value that's already relative (or unrelated to this
+    bucket) passes through unchanged. ``None``/empty pass through unchanged.
+    """
+    if not url:
+        return url
+    if url.startswith(_GCS_ABSOLUTE_PREFIX):
+        return _ASSET_PROXY_BASE + "/" + url[len(_GCS_ABSOLUTE_PREFIX):]
+    return url
 
 
 def _derive_docx_url(grade_code: str | None) -> str | None:
-    """Return the GCS docx URL if grade_code is in the checked-in manifest, else None.
+    """Return the proxied docx URL if grade_code is in the checked-in manifest, else None.
 
     YAML-explicit worksheet_docx_url always takes priority over this derived value
-    (callers use ``data.get("worksheet_docx_url") or _derive_docx_url(grade_code)``).
+    (callers use ``_to_asset_proxy_url(data.get("worksheet_docx_url")) or _derive_docx_url(grade_code)``).
     """
     if not grade_code or grade_code not in _DOCX_CODES:
         return None
@@ -243,7 +266,7 @@ def load_layer1_lessons() -> list[dict]:
             "full_text": data.get("story_text"),
             "char_count": data.get("char_count", 0),
             "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"{_ASSET_PROXY_BASE}/stories/"
                 f"thumbnails/lesson-{data['lesson_number']}.webp"
             ),
             "vocabulary": data.get("vocabulary") or [],
@@ -278,12 +301,14 @@ def load_layer1_lessons() -> list[dict]:
             "worksheet_intro": data.get("worksheet_intro"),
             # Lesson intro (#1443): docx 說明/導讀 or excel fallback
             "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Public PDF URL of the original 紙本學習單 (#1444). YAML source
+            # still has the absolute GCS URL (#2486) — rewritten to our
+            # same-origin proxy here, the single point of truth.
+            "worksheet_pdf_url": _to_asset_proxy_url(data.get("worksheet_pdf_url")),
             # Direct docx URL — YAML field takes priority; derive from GCS manifest
             # for all other lessons that have a .docx in worksheets/ (#2073, #2207)
             "worksheet_docx_url": (
-                data.get("worksheet_docx_url")
+                _to_asset_proxy_url(data.get("worksheet_docx_url"))
                 or _derive_docx_url(data.get("grade_code", ""))
             ),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
@@ -404,7 +429,7 @@ def load_layer2_lessons(
             "full_text": data.get("story_text"),
             "char_count": data.get("char_count", 0),
             "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"{_ASSET_PROXY_BASE}/stories/"
                 f"thumbnails/{norm_code}.webp"
             ),
             "vocabulary": vocabulary,
@@ -443,12 +468,14 @@ def load_layer2_lessons(
             "worksheet_intro": data.get("worksheet_intro"),
             # Lesson intro (#1443): docx 說明/導讀 or excel fallback
             "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Public PDF URL of the original 紙本學習單 (#1444). YAML source
+            # still has the absolute GCS URL (#2486) — rewritten to our
+            # same-origin proxy here, the single point of truth.
+            "worksheet_pdf_url": _to_asset_proxy_url(data.get("worksheet_pdf_url")),
             # Direct docx URL — YAML field takes priority; derive from GCS manifest
             # for all other lessons that have a .docx in worksheets/ (#2073, #2207)
             "worksheet_docx_url": (
-                data.get("worksheet_docx_url")
+                _to_asset_proxy_url(data.get("worksheet_docx_url"))
                 or _derive_docx_url(norm_code)
             ),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables

--- a/backend/tests/test_asset_url_rewrite.py
+++ b/backend/tests/test_asset_url_rewrite.py
@@ -1,0 +1,110 @@
+"""
+Tests for URL rewriting in lesson_layer_loaders.py — issue #2486.
+
+lingoleap-assets is going private. Every URL the backend hands to the frontend
+for content in that bucket (thumbnails, worksheet PDFs/DOCX) must point at our
+own `/assets/...` proxy instead of the absolute
+`https://storage.googleapis.com/lingoleap-assets/...` GCS URL — otherwise those
+URLs 403 the moment the bucket ACL flips.
+
+320+ YAML source files still contain literal absolute GCS URLs for
+`worksheet_pdf_url` (out of scope to hand-edit every one) — `_to_asset_proxy_url`
+is the single point where those get rewritten before reaching an API response.
+
+TDD: written before the lesson_layer_loaders.py rewrite. Red -> Green -> Refactor.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.lesson_layer_loaders import (
+    _to_asset_proxy_url,
+    _derive_docx_url,
+    load_layer1_lessons,
+)
+
+
+class TestToAssetProxyUrl:
+    def test_rewrites_absolute_gcs_url_to_relative_proxy_path(self):
+        absolute = "https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L23.pdf"
+        assert _to_asset_proxy_url(absolute) == "/assets/worksheets/G5-L23.pdf"
+
+    def test_rewrites_lessons_images_url(self):
+        absolute = "https://storage.googleapis.com/lingoleap-assets/lessons-images/G4-L1/G4-L1-01.jpg"
+        assert _to_asset_proxy_url(absolute) == "/assets/lessons-images/G4-L1/G4-L1-01.jpg"
+
+    def test_passes_through_none(self):
+        assert _to_asset_proxy_url(None) is None
+
+    def test_passes_through_empty_string(self):
+        assert _to_asset_proxy_url("") == ""
+
+    def test_passes_through_already_relative_url_unchanged(self):
+        """Idempotent — a URL already rewritten (or authored relative) is untouched."""
+        assert _to_asset_proxy_url("/assets/worksheets/G5-L23.pdf") == "/assets/worksheets/G5-L23.pdf"
+
+    def test_does_not_touch_unrelated_absolute_url(self):
+        """A URL pointing somewhere else entirely (not our bucket) must not be mangled."""
+        other = "https://example.com/some/other/file.pdf"
+        assert _to_asset_proxy_url(other) == other
+
+
+class TestDeriveDocxUrlIsRelative:
+    def test_derived_docx_url_uses_asset_proxy_base(self):
+        # Any grade_code from the checked-in manifest works; use a known one
+        # if present, else just check the shape via a monkeypatched code set.
+        import app.services.lesson_layer_loaders as loaders
+        original_codes = loaders._DOCX_CODES
+        try:
+            loaders._DOCX_CODES = frozenset({"G4-L01"})
+            url = _derive_docx_url("G4-L01")
+            assert url == "/assets/worksheets/G4-L01.docx"
+            assert not url.startswith("https://")
+        finally:
+            loaders._DOCX_CODES = original_codes
+
+    def test_derive_docx_url_returns_none_for_unknown_code(self):
+        assert _derive_docx_url("NOT-A-REAL-CODE") is None
+
+    def test_derive_docx_url_returns_none_for_empty_code(self):
+        assert _derive_docx_url("") is None
+        assert _derive_docx_url(None) is None
+
+
+class TestLayer1LessonsUseAssetProxyUrls:
+    """Integration: the actual lesson dicts served to the frontend must never
+    carry an absolute storage.googleapis.com URL after the #2486 fix."""
+
+    def test_no_lesson_has_absolute_gcs_thumbnail_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("thumbnail_url", "")
+            assert not url.startswith("https://storage.googleapis.com/"), (
+                f"Lesson {lesson.get('lesson_number')} thumbnail_url is still absolute: {url}"
+            )
+
+    def test_thumbnail_url_uses_asset_proxy_prefix(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            assert lesson["thumbnail_url"].startswith("/assets/stories/thumbnails/")
+
+    def test_no_lesson_has_absolute_gcs_worksheet_pdf_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("worksheet_pdf_url")
+            if url:
+                assert not url.startswith("https://storage.googleapis.com/"), (
+                    f"Lesson {lesson.get('lesson_number')} worksheet_pdf_url is still absolute: {url}"
+                )
+                assert url.startswith("/assets/worksheets/")
+
+    def test_no_lesson_has_absolute_gcs_worksheet_docx_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("worksheet_docx_url")
+            if url:
+                assert not url.startswith("https://storage.googleapis.com/"), (
+                    f"Lesson {lesson.get('lesson_number')} worksheet_docx_url is still absolute: {url}"
+                )
+                assert url.startswith("/assets/worksheets/")

--- a/backend/tests/test_assets_proxy.py
+++ b/backend/tests/test_assets_proxy.py
@@ -1,0 +1,168 @@
+"""
+Tests for GET /assets/{path} — the private-bucket asset proxy.
+
+Issue #2486: `lingoleap-assets` GCS bucket was public-read (allUsers
+objectViewer), letting anyone anonymously enumerate + bulk-download the
+entire course image/worksheet library (egress cost risk + content
+enumeration). This route lets the backend's own service-account credentials
+read the (now-private) bucket while the browser only ever talks to our own
+origin.
+
+TDD: written before app/routes/assets.py implementation. Red -> Green -> Refactor.
+"""
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _mock_bucket_with_blob(content: bytes):
+    """Build a fake GCS bucket whose .blob().download_as_bytes() returns content."""
+    blob = MagicMock()
+    blob.download_as_bytes.return_value = content
+    bucket = MagicMock()
+    bucket.blob.return_value = blob
+    return bucket, blob
+
+
+class TestAssetProxyAllowedPrefixes:
+    """Requests under an allow-listed prefix should reach GCS and stream back."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_lessons_images_returns_200_with_content_type(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"\xff\xd8\xfffakejpegbytes")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        assert resp.content == b"\xff\xd8\xfffakejpegbytes"
+        bucket.blob.assert_called_once_with("lessons-images/G4-L1/G4-L1-01.jpg")
+
+    @patch("app.routes.assets._get_bucket")
+    def test_stories_thumbnail_returns_200(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"webpbytes")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/stories/thumbnails/lesson-1.webp")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/webp"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_worksheet_pdf_returns_200(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"%PDF-1.4 fake")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/worksheets/G5-L23.pdf")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/pdf"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_worksheet_docx_returns_correct_content_type(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"PKfakedocx")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/worksheets/G5-L23.docx")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+
+    @patch("app.routes.assets._get_bucket")
+    def test_response_has_long_lived_cache_control(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"data")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_no_auth_required(self, mock_get_bucket):
+        """Public content — no Authorization header needed (matches pre-fix behavior)."""
+        bucket, _blob = _mock_bucket_with_blob(b"data")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.status_code == 200
+
+
+class TestAssetProxyAllowlistRejection:
+    """Anything outside the 3 allow-listed prefixes must 404 — no general GCS proxy."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_unknown_prefix_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/pr-screenshots/some-screenshot.png")
+        assert resp.status_code == 404
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_qa_prefix_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/qa/whatever.png")
+        assert resp.status_code == 404
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_bare_prefix_with_no_object_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/")
+        assert resp.status_code == 404
+
+
+class TestAssetProxyPathTraversal:
+    """Path traversal attempts must never reach GCS with a decoded '..' segment."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_dotdot_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/../../etc/passwd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_encoded_dotdot_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/%2e%2e/%2e%2e/etc/passwd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_absolute_path_style_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/..%2f..%2fetc%2fpasswd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_unsafe_characters_rejected(self, mock_get_bucket):
+        """Backslashes / control chars outside the allow-listed charset are rejected."""
+        resp = client.get("/assets/lessons-images/G4-L1/file%00.jpg")
+        assert resp.status_code in (400, 404)
+
+
+class TestAssetProxyMissingObject:
+    """A GCS miss (object doesn't exist) must surface as a clean 404, no internals leaked."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_gcs_not_found_returns_404_not_500(self, mock_get_bucket):
+        blob = MagicMock()
+        blob.download_as_bytes.side_effect = Exception("404 GET ... No such object")
+        bucket = MagicMock()
+        bucket.blob.return_value = blob
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/does-not-exist/x.jpg")
+
+        assert resp.status_code == 404
+        # Must not leak internal exception text / GCS bucket internals to the client.
+        assert "Exception" not in resp.text
+        assert "lingoleap-assets" not in resp.text

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -673,6 +673,32 @@ class TestGlobalRateLimitMiddleware:
         resp = client.get("/")
         assert resp.status_code != 429
 
+    def test_assets_endpoint_is_rate_limited(self, client):
+        """#2486: /assets/* (private-bucket proxy) shares the same global limit
+        as /api/* — otherwise the proxy itself becomes an uncapped abuse vector
+        for the very egress-cost concern this issue set out to close."""
+        from app.main import GlobalRateLimitMiddleware
+        from unittest.mock import patch, MagicMock
+        general_rate_limiter.reset()
+
+        ip = "testclient"
+        for _ in range(GlobalRateLimitMiddleware.READ_LIMIT):
+            general_rate_limiter.check_with_info(
+                f"global:ip:{ip}:read",
+                GlobalRateLimitMiddleware.READ_LIMIT,
+                GlobalRateLimitMiddleware.WINDOW,
+            )
+
+        with patch("app.routes.assets._get_bucket") as mock_get_bucket:
+            blob = MagicMock()
+            blob.download_as_bytes.return_value = b"data"
+            bucket = MagicMock()
+            bucket.blob.return_value = blob
+            mock_get_bucket.return_value = bucket
+            resp = client.get("/assets/lessons-images/G4-L1/x.jpg")
+
+        assert resp.status_code == 429
+
     def test_global_limit_constants(self):
         """Verify the configured limits match spec.
 

--- a/backend/tests/test_stories_api.py
+++ b/backend/tests/test_stories_api.py
@@ -148,12 +148,15 @@ class TestLessonRequiredFields:
             assert "background" in intro, f"Lesson {lesson['lesson_number']} intro missing 'background'"
 
     def test_thumbnail_url_pattern(self):
+        """#2486: thumbnail_url is served via our same-origin /assets proxy —
+        lingoleap-assets is now a private bucket, no more absolute GCS URLs."""
         lessons = get_all_lessons()
         for lesson in lessons:
             url = lesson["thumbnail_url"]
-            assert url.startswith("https://storage.googleapis.com/lingoleap-assets/"), (
+            assert url.startswith("/assets/stories/thumbnails/"), (
                 f"Lesson {lesson['lesson_number']} has unexpected thumbnail_url: {url}"
             )
+            assert not url.startswith("https://storage.googleapis.com/")
             assert f"lesson-{lesson['lesson_number']}.webp" in url
 
     def test_char_count_is_non_negative_int(self):
@@ -384,10 +387,11 @@ class TestStoryListItemSchema:
         assert "paragraphs" not in story
 
     def test_thumbnail_url_is_string(self, client):
+        """#2486: relative same-origin /assets path, not an absolute GCS URL."""
         resp = client.get("/api/stories?page_size=5")
         for story in resp.json()["stories"]:
             assert isinstance(story["thumbnail_url"], str)
-            assert story["thumbnail_url"].startswith("https://")
+            assert story["thumbnail_url"].startswith("/assets/")
 
 
 class TestGetStoryDetailEndpoint:

--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,13 @@
           }
         },
         {
+          "source": "/assets/**",
+          "run": {
+            "serviceId": "lingoleap-backend",
+            "region": "asia-east1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }
@@ -31,6 +38,13 @@
           }
         },
         {
+          "source": "/assets/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }
@@ -43,6 +57,13 @@
       "rewrites": [
         {
           "source": "/api/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
+          "source": "/assets/**",
           "run": {
             "serviceId": "lingoleap-backend-staging",
             "region": "asia-east1"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,9 @@
     <!-- Content-Security-Policy: browser-level fallback.
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://storage.googleapis.com https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <!-- #2486: frame-src no longer needs storage.googleapis.com — the worksheet
+         PDF iframe now loads through our own same-origin /assets/* proxy. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com;" />
     <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
          Per CSP spec, frame-ancestors is a navigation directive and is ignored
          when delivered via <meta> elements (causes browser console warnings).

--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -22,6 +22,7 @@
  * overflow-y; this component fills 100% of that space.
  */
 import React, { useEffect, useRef, useState } from 'react';
+import { ASSET_BASE } from '../../config/assetBase';
 
 interface GraphicTextImageStripProps {
   images: { filename: string; caption?: string; figure_label?: string }[];
@@ -35,7 +36,8 @@ interface GraphicTextImageStripProps {
   lessonCode?: string;
 }
 
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 /** Chinese numeral labels (1-based) for figure badges */
 const CHINESE_NUMERALS = ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十'];

--- a/frontend/src/components/reading-steps/InlineImageCard.tsx
+++ b/frontend/src/components/reading-steps/InlineImageCard.tsx
@@ -10,8 +10,10 @@
  */
 import React from 'react';
 import ZoomableImage from '../ui/ZoomableImage';
+import { ASSET_BASE } from '../../config/assetBase';
 
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 interface InlineImageCardProps {
   image: { filename: string; caption?: string };

--- a/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
@@ -11,9 +11,10 @@
  */
 import React from 'react';
 import { Story } from '../../../types';
+import { ASSET_BASE } from '../../../config/assetBase';
 
-/** GCS image base URL pattern (Day 2 will verify actual serving) */
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 interface GraphicTextLayoutProps {
   story: Story;

--- a/frontend/src/components/student/home/TodayLessonCard.tsx
+++ b/frontend/src/components/student/home/TodayLessonCard.tsx
@@ -13,6 +13,7 @@
 import React, { useEffect, useState } from 'react';
 import type { StudentAssignmentResponse } from '../../../services/assignmentApi';
 import type { StudentEnrolledClassroom } from '../../../services/learningApi';
+import { ASSET_BASE } from '../../../config/assetBase';
 
 // ---------------------------------------------------------------------------
 // NoClassroomWaitingScreen — shown to students not yet added to any classroom
@@ -61,7 +62,8 @@ interface BookJacketCoverProps {
   title: string;
 }
 
-const THUMBNAIL_BASE = 'https://storage.googleapis.com/lingoleap-assets/stories/thumbnails';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const THUMBNAIL_BASE = `${ASSET_BASE}/stories/thumbnails`;
 
 export const BookJacketCover: React.FC<BookJacketCoverProps> = ({ storyId, title }) => {
   const [imgOk, setImgOk] = useState(true);

--- a/frontend/src/config/assetBase.test.ts
+++ b/frontend/src/config/assetBase.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Issue #2486: ASSET_BASE mirrors API_BASE's own resolution logic exactly —
+ * same-origin relative path when the app is served through the Firebase
+ * Hosting `/assets/**` rewrite (VITE_API_URL=""), or an absolute backend URL
+ * when the frontend is served directly by its own Cloud Run service / local
+ * dev (VITE_API_URL set to an absolute backend origin).
+ *
+ * TDD: written before frontend/src/config/assetBase.ts exists. Red -> Green -> Refactor.
+ */
+
+describe('ASSET_BASE', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves to a relative /assets path when API_BASE is empty (Firebase Hosting rewrite)', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('/assets');
+  });
+
+  it('resolves to {backend}/assets when API_BASE is an absolute backend URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://lingoleap-backend-staging-xxx.run.app');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('https://lingoleap-backend-staging-xxx.run.app/assets');
+  });
+
+  it('falls back to the same localhost default as API_BASE when unset', async () => {
+    vi.stubEnv('VITE_API_URL', undefined);
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('http://localhost:8000/assets');
+  });
+
+  it('respects an explicit VITE_ASSET_BASE override', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    vi.stubEnv('VITE_ASSET_BASE', 'https://cdn.example.com/course-assets');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('https://cdn.example.com/course-assets');
+  });
+});

--- a/frontend/src/config/assetBase.ts
+++ b/frontend/src/config/assetBase.ts
@@ -1,0 +1,24 @@
+/**
+ * ASSET_BASE — base path for public course assets (thumbnails, lesson images),
+ * served via the same-origin `/assets/*` proxy in front of the (now-private)
+ * `lingoleap-assets` GCS bucket.
+ *
+ * Issue #2486: components used to hardcode
+ * `https://storage.googleapis.com/lingoleap-assets/...` directly, which let
+ * anyone anonymously enumerate + bulk-download the entire course library
+ * (egress cost risk + content enumeration). The bucket is now private; the
+ * backend's `/assets/{path}` route (app/routes/assets.py) reads it with its
+ * own service-account credentials instead.
+ *
+ * Mirrors apiConfig.ts's own `API_BASE` resolution exactly, because the two
+ * proxy paths are deployed identically:
+ * - Firebase Hosting build (VITE_API_URL="") → relative "/assets", handled by
+ *   the `/assets/**` rewrite in firebase.json (same trick as `/api/**`).
+ * - Cloud Run direct-serve frontend / PR preview (VITE_API_URL=absolute
+ *   backend URL) → `{backend}/assets`, a direct cross-origin call to the
+ *   backend's own Cloud Run service.
+ * - Local dev (VITE_API_URL unset) → same localhost:8000 default as API_BASE.
+ */
+import { API_BASE } from '../services/apiConfig';
+
+export const ASSET_BASE = import.meta.env.VITE_ASSET_BASE ?? `${API_BASE}/assets`;

--- a/frontend/src/services/api.assetUrl.test.ts
+++ b/frontend/src/services/api.assetUrl.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #2486 regression: fetchStory/fetchStories must resolve the backend's
+ * same-origin-relative "/assets/..." URLs (thumbnail_url, worksheet_pdf_url,
+ * worksheet_docx_url) onto ASSET_BASE before handing them to components.
+ *
+ * Root cause this locks: a real-browser QA pass on the PR preview (frontend
+ * and backend on different Cloud Run origins) showed the lesson cover image
+ * on Intro.tsx as a broken <img>. The backend correctly returns a relative
+ * "/assets/stories/thumbnails/lesson-1.webp" path, but Intro.tsx renders it
+ * as <img src={story.thumbnail}> directly — the browser resolved that
+ * relative path against the FRONTEND's own origin (which has no such route,
+ * and falls back to serving index.html), not the backend's. The fix belongs
+ * in api.ts's response-mapping layer (the single choke point every consumer
+ * — Intro.tsx, StoryCard.tsx — goes through), not in each component.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+vi.mock('../config/assetBase', () => ({
+  ASSET_BASE: 'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets',
+}));
+
+import { fetchStory, fetchStories } from './api';
+
+function mockJsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+const BASE_DETAIL_FIELDS = {
+  lesson_number: 1,
+  title: '贏得喝采的輸家',
+  grade: 4,
+  grade_code: 'G4-01',
+  genre: '記敘文',
+  category: 'Fable',
+  char_count: 100,
+  reading_strategy: null,
+  intro: { author: 'x', background: 'y' },
+  paragraphs: ['p1'],
+  source_file: 'L1.yml',
+};
+
+describe('fetchStory / fetchStories — asset URL resolution (#2486)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('resolves a relative thumbnail_url onto ASSET_BASE (fetchStory)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.thumbnail).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/stories/thumbnails/lesson-1.webp',
+    );
+  });
+
+  it('resolves relative worksheet_pdf_url and worksheet_docx_url onto ASSET_BASE', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+      worksheet_pdf_url: '/assets/worksheets/G4-L01.pdf',
+      worksheet_docx_url: '/assets/worksheets/G4-L01.docx',
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.worksheetPdfUrl).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/worksheets/G4-L01.pdf',
+    );
+    expect(story.worksheetDocxUrl).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/worksheets/G4-L01.docx',
+    );
+  });
+
+  it('leaves worksheet URLs undefined when absent (no false-positive resolution)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+      worksheet_pdf_url: null,
+      worksheet_docx_url: null,
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.worksheetPdfUrl).toBeUndefined();
+    expect(story.worksheetDocxUrl).toBeUndefined();
+  });
+
+  it('resolves thumbnail_url for list items (fetchStories)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      stories: [{
+        lesson_number: 1,
+        title: '贏得喝采的輸家',
+        grade: 4,
+        category: 'Fable',
+        char_count: 100,
+        intro: { author: 'x', background: 'y' },
+        thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+        genre: '記敘文',
+      }],
+      total: 1,
+      grades: [4],
+    }));
+
+    const { stories } = await fetchStories();
+
+    expect(stories[0].thumbnail).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/stories/thumbnails/lesson-1.webp',
+    );
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,9 +13,35 @@
 
 import type { Story } from '../types';
 import { API_BASE } from './apiConfig';
+import { ASSET_BASE } from '../config/assetBase';
 import { stepSequenceFromWorksheet } from '../config/stepConfig';
 
 const inFlightStoryById = new Map<string, Promise<Story>>();
+
+/**
+ * Resolve a same-origin-relative "/assets/..." URL (thumbnail_url,
+ * worksheet_pdf_url, worksheet_docx_url — issue #2486) onto ASSET_BASE.
+ *
+ * The backend always returns these as relative paths. That's correct when
+ * the frontend is served through the Firebase Hosting `/assets/**` rewrite
+ * (ASSET_BASE === "", stays relative) — but when the frontend and backend
+ * are on different origins (Cloud Run direct-serve, PR previews, local dev),
+ * a bare "/assets/..." resolves against the FRONTEND's own origin, which has
+ * no such route and silently falls back to the SPA shell (broken <img>,
+ * found via real-browser QA on the #2486 PR preview). ASSET_BASE already
+ * encodes the correct origin for whichever deploy shape is active, so this
+ * is the single choke point every consumer (Intro.tsx, StoryCard.tsx, ...)
+ * goes through instead of each hand-rolling origin resolution.
+ */
+function resolveAssetUrl(url: string): string;
+function resolveAssetUrl(url: string | null | undefined): string | undefined;
+function resolveAssetUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith('/assets/')) {
+    return `${ASSET_BASE}${url.slice('/assets'.length)}`;
+  }
+  return url; // already absolute (or some other shape) — leave unchanged
+}
 
 export class SessionExpiredError extends Error {
   constructor(message: string) {
@@ -121,7 +147,7 @@ function apiListItemToStory(item: ApiStoryListItem): Story {
     title: item.title,
     level: item.grade,
     content: [],
-    thumbnail: item.thumbnail_url,
+    thumbnail: resolveAssetUrl(item.thumbnail_url),
     category: item.category as Story['category'],
     filename: '',
     intro: item.intro,
@@ -138,7 +164,7 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     title: detail.title,
     level: detail.grade,
     content: detail.paragraphs,
-    thumbnail: detail.thumbnail_url,
+    thumbnail: resolveAssetUrl(detail.thumbnail_url),
     category: detail.category as Story['category'],
     filename: detail.source_file,
     intro: detail.intro,
@@ -183,8 +209,8 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     worksheetSectionOrder: detail.worksheet_section_order ?? undefined,
     worksheetIntro: detail.worksheet_intro ?? undefined,
     lessonIntro: detail.lesson_intro ?? undefined,
-    worksheetPdfUrl: detail.worksheet_pdf_url ?? undefined,
-    worksheetDocxUrl: detail.worksheet_docx_url ?? undefined,
+    worksheetPdfUrl: resolveAssetUrl(detail.worksheet_pdf_url),
+    worksheetDocxUrl: resolveAssetUrl(detail.worksheet_docx_url),
     tables: detail.tables ?? undefined,
     // Plugin-pattern dispatch fields (#1404 / #1341):
     layout_mode: (detail.layout_mode as Story['layout_mode']) ?? 'standard',

--- a/frontend/src/utils/downloadRemoteFile.test.ts
+++ b/frontend/src/utils/downloadRemoteFile.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadRemoteFile } from './downloadRemoteFile';
+
+/**
+ * Issue #2486: worksheet_pdf_url / worksheet_docx_url are now relative
+ * same-origin paths (e.g. "/assets/worksheets/G5-L23.pdf") instead of
+ * absolute GCS URLs. `filenameFromUrl`'s fallback path used
+ * `new URL(url)` with no base, which throws on a relative URL — silently
+ * swallowed by the try/catch into a generic 'download' filename. This test
+ * locks the fix: relative URLs must produce a real filename, not silently
+ * degrade.
+ */
+describe('downloadRemoteFile', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: vi.fn().mockResolvedValue(new Blob(['fake pdf bytes'])),
+    });
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-object-url');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('fetches a relative same-origin URL without throwing', async () => {
+    await expect(downloadRemoteFile('/assets/worksheets/G5-L23.pdf')).resolves.toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith('/assets/worksheets/G5-L23.pdf');
+  });
+
+  it('derives a real filename from a relative URL when no filename is given', async () => {
+    const anchor = document.createElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('/assets/worksheets/G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('still works with an absolute cross-origin URL (Cloud Run direct-serve case)', async () => {
+    const anchor = document.createElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('https://lingoleap-backend-staging-xxx.run.app/assets/worksheets/G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+  });
+
+  it('uses the explicit filename argument when provided, regardless of URL shape', async () => {
+    const anchor = document.createElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('/assets/worksheets/G5-L23.pdf', 'G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+  });
+
+  it('throws when the response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    await expect(downloadRemoteFile('/assets/worksheets/missing.pdf')).rejects.toThrow('404');
+  });
+});

--- a/frontend/src/utils/downloadRemoteFile.ts
+++ b/frontend/src/utils/downloadRemoteFile.ts
@@ -1,13 +1,17 @@
 function filenameFromUrl(url: string): string {
   try {
-    const base = new URL(url).pathname.split('/').pop();
+    // Issue #2486: worksheet URLs are now same-origin relative paths
+    // (e.g. "/assets/worksheets/G5-L23.pdf") rather than absolute GCS URLs.
+    // `new URL(url)` throws on a relative string with no base — pass
+    // window.location.origin as the base so both shapes resolve correctly.
+    const base = new URL(url, window.location.origin).pathname.split('/').pop();
     return base && base.length > 0 ? base : 'download';
   } catch {
     return 'download';
   }
 }
 
-/** Trigger a browser file download for a cross-origin URL (e.g. GCS public assets). */
+/** Trigger a browser file download for a same-origin or cross-origin URL. */
 export async function downloadRemoteFile(url: string, filename?: string): Promise<void> {
   const response = await fetch(url);
   if (!response.ok) {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Related to #2486

## Summary
- 新增 `GET /assets/{path}` backend proxy（白名單前綴 `lessons-images/` `stories/` `worksheets/`、path-traversal 防護、GCS miss 統一回乾淨 404、長效 `Cache-Control`）
- `GlobalRateLimitMiddleware` 涵蓋範圍擴大到 `/assets/*`（原本只管 `/api/*`）—— 否則收掉公開列舉後，proxy 本身會變成新的無上限打法
- `lesson_layer_loaders.py` 新增 `_to_asset_proxy_url()` 單一改寫點，把 320+ 篇 YAML 裡寫死的絕對 GCS 網址（`worksheet_pdf_url`）+ `thumbnail_url` + `worksheet_docx_url` 都改成同源 `/assets/...`
- 前端 4 個元件（`TodayLessonCard` / `InlineImageCard` / `GraphicTextImageStrip` / `GraphicTextLayout`）改用新增的共用 `frontend/src/config/assetBase.ts`（`ASSET_BASE`，鏡射既有 `API_BASE` 解析邏輯，涵蓋 Firebase Hosting relative / Cloud Run 直連 absolute / local dev）
- 順手修 `downloadRemoteFile.ts` 一個潛在 bug：`new URL()` 對相對網址會 throw（已補 base + regression test）
- `firebase.json` 三個 hosting target 都加 `/assets/**` rewrite（放在 SPA fallback 之前）
- CSP `frame-src` 拿掉 `storage.googleapis.com`（worksheet PDF iframe 現在走同源 proxy，`'self'` 就夠）

**這個 PR 落地時 bucket 仍是 public**（非破壞式過渡）——確認 staging + prod 都用新路徑正常顯示、且全 repo 無殘留絕對網址後，才會在後續步驟收 private。

## Test plan
- [x] Backend TDD：`test_assets_proxy.py`（14 條，white-list/traversal/404/content-type/cache-control）全綠
- [x] Backend TDD：`test_asset_url_rewrite.py`（13 條，`_to_asset_proxy_url` + `_derive_docx_url` + 全部 Layer-1 lesson 無殘留絕對網址）全綠
- [x] Rate-limit regression：`/assets/*` 命中同一組 per-IP 限流（先紅後綠驗證過）
- [x] 既有 `test_stories_api.py` 3 條 thumbnail_url 斷言已同步改成新相對路徑格式，全綠
- [x] `specs/run-ci.sh`（本 repo 的 local CI gate）：Gate 1-3 全過（`== Local Spec CI: PASS ==`，748 passed + 4 xfailed + 205 passed）
- [x] `specs/test_lesson_loader_spec.py`（lesson-loader spec module 契約，18 條）全綠
- [x] `test_security_headers.py`（CSP 收斂後）15 條全綠
- [x] 前端：`assetBase.test.ts`（4 條）+ `downloadRemoteFile.test.ts`（5 條）全綠、render-smoke gate 全綠、`npm run lint` 0 error
- [x] 已用 git-stash 基準比對排除「全跑 pytest/vitest 出現的既有大量失敗」與本次改動無關（皆為已知技術債：57→158 課資料集舊斷言、`lesson_loader._LESSONS_DIR` 重新命名後的舊 fixture 等）
- [ ] Staging 真瀏覽器 QA（圖片從 `/assets` 正常顯示）— 待 preview 部署後執行
- [ ] Prod 真瀏覽器 QA — 待 merge 後執行
- [ ] 確認全 repo 無殘留 `storage.googleapis.com/lingoleap-assets` 直連
- [ ] Bucket 收 private + 匿名直連 GCS 驗證 403 — 排在 staging+prod 都驗證通過後
