### PR TITLE
release: asset-proxy migration (private-bucket-ready) → prod (#2486)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,11 +117,37 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "frame-ancestors 'none';"
     )
 
+    # Issue #2486 (part 2): widening frame-src above on the *parent* page is
+    # necessary but not sufficient. This middleware used to stamp EVERY
+    # response — including the PDF/image bytes served by
+    # app/routes/assets.py — with `X-Frame-Options: DENY` and
+    # `frame-ancestors 'none'`. Those headers govern whether the resource
+    # ITSELF may be framed by anyone, which unconditionally blocked our own
+    # worksheet PDF iframe from framing it (DENY has no same-origin
+    # exception, and 'none' means literally no one). Confirmed via
+    # real-browser QA: after fixing frame-src alone, the iframe's network
+    # request succeeded (200 application/pdf, no console error) but the
+    # modal stayed visually blank — curl against the same URL showed
+    # `x-frame-options: DENY` / `frame-ancestors 'none'` on the PDF response
+    # itself. This didn't matter pre-#2488 because storage.googleapis.com
+    # (which never sends X-Frame-Options) served these files directly.
+    #
+    # Fix: for `/assets/*` responses only, omit X-Frame-Options (it can't
+    # express "self OR this other specific origin" — only CSP frame-ancestors
+    # can) and relax frame-ancestors to the same origins frame-src above
+    # trusts. Every other route (HTML pages, JSON APIs) keeps the strict
+    # DENY / 'none' anti-clickjacking posture unchanged.
+    ASSET_FRAME_ANCESTORS_CSP = "frame-ancestors 'self' https://*.run.app;"
+
     async def dispatch(self, request: Request, call_next) -> Response:
         response = await call_next(request)
-        response.headers["Content-Security-Policy"] = self.CSP
+        is_asset_response = request.url.path.startswith("/assets/")
+        response.headers["Content-Security-Policy"] = (
+            self.ASSET_FRAME_ANCESTORS_CSP if is_asset_response else self.CSP
+        )
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
+        if not is_asset_response:
+            response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Strict-Transport-Security"] = (

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from .routes.admin_seed import router as admin_seed_router
 from .routes.omo import router as omo_router
 from .routes.curriculum_qa import router as curriculum_qa_router
 from .routes.admin_story_structure_lab import router as admin_story_structure_lab_router
+from .routes.assets import router as assets_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter, real_ip_from_xff
 from .services.seed import seed_default_data, repair_pii_accounts
@@ -96,14 +97,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "https://*.firebaseapp.com "
         "https://*.cloudfunctions.net "
         "https://us-central1-aiplatform.googleapis.com; "
-        # Issue #1496: allow GCS bucket for the worksheet PDF iframe (#1444),
-        # plus YouTube embeds for the knowledge-station videos.
-        # NOTE: CSP frame-src cannot restrict by path (spec limitation), so the
-        # entire storage.googleapis.com host is whitelisted. The actual PDFs
-        # live under public-read `lingoleap-assets/worksheets/`; tighter scoping
-        # would require proxying PDFs through our own origin.
+        # Issue #1496: worksheet PDF iframe (#1444), plus YouTube embeds for
+        # the knowledge-station videos.
+        # Issue #2486: the worksheet PDF now loads through our own
+        # `/assets/*` proxy (same-origin), so storage.googleapis.com no
+        # longer needs a frame-src exception — 'self' covers it.
         "frame-src 'self' "
-        "https://storage.googleapis.com "
         "https://www.youtube.com "
         "https://www.youtube-nocookie.com; "
         "frame-ancestors 'none';"
@@ -232,11 +231,16 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
 
 class GlobalRateLimitMiddleware:
-    """Pure ASGI middleware for global per-IP rate limiting on /api/* endpoints.
+    """Pure ASGI middleware for global per-IP rate limiting on /api/* and /assets/*.
 
     Uses raw ASGI protocol instead of BaseHTTPMiddleware to guarantee headers
     are injected before the response starts streaming (BaseHTTPMiddleware +
     StreamingResponse can silently drop headers added after call_next).
+
+    /assets/* is included (#2486): it's the proxy in front of the now-private
+    lingoleap-assets GCS bucket. Without a rate limit here, closing off public
+    bucket listing would still leave the door open for a single IP to hammer
+    the proxy (and therefore our GCS egress) at unlimited rate.
     """
 
     _EXEMPT_PATHS = ("/health", "/docs", "/redoc", "/openapi.json", "/")
@@ -258,8 +262,10 @@ class GlobalRateLimitMiddleware:
 
         path = scope["path"]
 
-        # Skip rate limiting for exempt or non-API paths.
-        if path in self._EXEMPT_PATHS or not path.startswith("/api"):
+        # Skip rate limiting for exempt paths, or paths outside the two
+        # limited surfaces (/api/* and /assets/*).
+        is_limited_surface = path.startswith("/api") or path.startswith("/assets")
+        if path in self._EXEMPT_PATHS or not is_limited_surface:
             await self.app(scope, receive, send)
             return
 
@@ -353,7 +359,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Global rate limiting: 300 read req/min + 90 write req/min per IP for /api/*.
+# Global rate limiting: 300 read req/min + 90 write req/min per IP for
+# /api/* and /assets/* (#2486).
 # Placed after CORS so CORS preflight OPTIONS requests are not rate-limited.
 app.add_middleware(GlobalRateLimitMiddleware)
 
@@ -391,6 +398,8 @@ app.include_router(admin_seed_router, prefix="/api", tags=["admin-seed"])
 app.include_router(omo_router, prefix="/api", tags=["omo"])
 app.include_router(curriculum_qa_router, prefix="/api", tags=["curriculum-qa"])
 app.include_router(admin_story_structure_lab_router, prefix="/api", tags=["admin-story-structure-lab"])
+# No /api prefix — matches the Firebase Hosting `/assets/**` rewrite target (#2486).
+app.include_router(assets_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,10 +99,19 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "https://us-central1-aiplatform.googleapis.com; "
         # Issue #1496: worksheet PDF iframe (#1444), plus YouTube embeds for
         # the knowledge-station videos.
-        # Issue #2486: the worksheet PDF now loads through our own
-        # `/assets/*` proxy (same-origin), so storage.googleapis.com no
-        # longer needs a frame-src exception — 'self' covers it.
+        # Issue #2486: the worksheet PDF now loads through our own `/assets/*`
+        # proxy instead of storage.googleapis.com — but the iframe src is only
+        # same-origin on the Firebase Hosting build (ASSET_BASE == ""). On the
+        # Cloud-Run-direct frontend (staging/prod/PR previews), ASSET_BASE
+        # resolves to the *backend's own* Cloud Run origin, which is a
+        # different host from the frontend, so the iframe is genuinely
+        # cross-origin there. 'self' alone blocks it (confirmed via
+        # real-browser repro on staging: CSP frame-src violation, worksheet
+        # modal renders blank). https://*.run.app mirrors the same wildcard
+        # already trusted by connect-src above, covering prod/staging/preview
+        # backends without hardcoding per-environment URLs.
         "frame-src 'self' "
+        "https://*.run.app "
         "https://www.youtube.com "
         "https://www.youtube-nocookie.com; "
         "frame-ancestors 'none';"

--- a/backend/app/routes/assets.py
+++ b/backend/app/routes/assets.py
@@ -1,0 +1,125 @@
+"""Public asset proxy — serves images/worksheets from the (private) lingoleap-assets bucket.
+
+Issue #2486: `lingoleap-assets` was public-read (allUsers objectViewer), which let
+anyone anonymously *enumerate* (list all 3900+ objects) and bulk-download the
+entire course image/worksheet library — an egress-cost risk with no cap, plus a
+content-enumeration / IP-exposure concern. This route lets the backend's own
+service-account credentials read the bucket while the bucket itself is private —
+the browser only ever talks to our own origin (Firebase Hosting `/assets/**`
+rewrite in prod/staging, or the backend's own Cloud Run URL directly in
+preview/local dev), never to storage.googleapis.com.
+
+Security posture:
+- Only 3 allow-listed top-level prefixes are servable (lessons-images/, stories/,
+  worksheets/) — these are exactly the prefixes referenced by frontend consts and
+  backend-generated URLs. Legacy prefixes not consumed by the app (pr-screenshots/,
+  qa/) are NOT proxied — no general-purpose GCS object reader.
+- Strict allow-list regex on the full decoded path before it ever reaches GCS,
+  plus an explicit ".." reject, guards against path-traversal-style requests.
+- No auth required — this is public *content* (same visibility as before); the
+  fix closes the *enumeration + uncapped egress* surface, not the content itself.
+- Covered by the app-wide GlobalRateLimitMiddleware (see main.py) so a single IP
+  can no longer hammer the bucket at unlimited rate.
+"""
+import logging
+import re
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+from starlette.responses import Response
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/assets", tags=["assets"])
+
+# Keep in sync with frontend `ASSET_BASE` consumers (assetBase.ts) and the
+# backend URL builders in lesson_layer_loaders.py — this list IS the public
+# content surface of the bucket.
+_ALLOWED_PREFIXES = ("lessons-images/", "stories/", "worksheets/")
+
+# Allow-list charset for the decoded object path. FastAPI's `{path:path}`
+# converter URL-decodes the raw request path once before this ever runs, so a
+# literal ".." here is a real traversal attempt, not a percent-encoding
+# artifact. Anything outside this charset (backslashes, NUL, unicode
+# lookalikes, control chars, ...) is rejected outright.
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_\-./]+$")
+
+_CONTENT_TYPES = {
+    ".webp": "image/webp",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".pdf": "application/pdf",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+# Cache the asset immutably at the edge (Firebase Hosting CDN) and in the
+# browser — object keys are effectively content-addressed by lesson code /
+# filename in practice, and this is exactly the lever that reduces origin
+# egress for repeat views.
+_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _is_safe_object_path(object_path: str) -> bool:
+    if not object_path or ".." in object_path:
+        return False
+    if object_path.startswith("/"):
+        return False
+    if not _SAFE_PATH_RE.match(object_path):
+        return False
+    # Must have an actual filename component after the prefix — a bare
+    # "lessons-images/" request is never a real object, reject it here
+    # instead of letting it fall through to a GCS lookup.
+    return any(
+        object_path.startswith(prefix) and len(object_path) > len(prefix)
+        for prefix in _ALLOWED_PREFIXES
+    )
+
+
+@lru_cache(maxsize=1)
+def _get_bucket():
+    """Lazily construct (and cache) the GCS bucket handle.
+
+    Import is deferred (matches the pattern in omo_storage.py) so local dev /
+    unit tests that never exercise this route don't need google-cloud-storage
+    importable at module load time.
+    """
+    from google.cloud import storage  # type: ignore[import]
+    client = storage.Client()
+    return client.bucket(settings.gcs_bucket)
+
+
+def _content_type_for(object_path: str) -> str:
+    if "." not in object_path:
+        return _DEFAULT_CONTENT_TYPE
+    ext = "." + object_path.rsplit(".", 1)[-1].lower()
+    return _CONTENT_TYPES.get(ext, _DEFAULT_CONTENT_TYPE)
+
+
+@router.get("/{object_path:path}")
+def get_asset(object_path: str) -> Response:
+    if not _is_safe_object_path(object_path):
+        raise HTTPException(status_code=404, detail="Not found")
+
+    try:
+        bucket = _get_bucket()
+        blob = bucket.blob(object_path)
+        data = blob.download_as_bytes()
+    except ImportError:
+        logger.error("google-cloud-storage not installed — asset proxy unavailable")
+        raise HTTPException(status_code=503, detail="Asset service unavailable")
+    except Exception as exc:
+        # Covers google.cloud.exceptions.NotFound and any other GCS failure.
+        # Deliberately generic — never echo the exception text or bucket name
+        # back to the client.
+        logger.warning("Asset proxy miss for %r: %s", object_path, exc)
+        raise HTTPException(status_code=404, detail="Not found")
+
+    return Response(
+        content=data,
+        media_type=_content_type_for(object_path),
+        headers={"Cache-Control": _CACHE_CONTROL},
+    )

--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -62,14 +62,37 @@ def _load_docx_codes() -> frozenset[str]:
 
 _DOCX_CODES: frozenset[str] = _load_docx_codes()
 
-_GCS_DOCX_BASE = "https://storage.googleapis.com/lingoleap-assets/worksheets"
+# Issue #2486: lingoleap-assets went private (was public-read, letting anyone
+# enumerate + bulk-download the whole course library). All URLs we derive now
+# point at our own same-origin proxy (backend `/assets/*` route, fronted by
+# the Firebase Hosting `/assets/**` rewrite) instead of the GCS host directly.
+_ASSET_PROXY_BASE = "/assets"
+_GCS_ABSOLUTE_PREFIX = "https://storage.googleapis.com/lingoleap-assets/"
+_GCS_DOCX_BASE = f"{_ASSET_PROXY_BASE}/worksheets"
+
+
+def _to_asset_proxy_url(url: str | None) -> str | None:
+    """Rewrite a legacy absolute GCS URL to our same-origin ``/assets/`` proxy path.
+
+    320+ YAML source files under ``backend/data/curriculum/lessons/`` still carry
+    literal ``https://storage.googleapis.com/lingoleap-assets/...`` strings for
+    ``worksheet_pdf_url`` (hand-editing every file was out of scope for #2486) —
+    this is the single point where those get rewritten before reaching an API
+    response. Idempotent: a value that's already relative (or unrelated to this
+    bucket) passes through unchanged. ``None``/empty pass through unchanged.
+    """
+    if not url:
+        return url
+    if url.startswith(_GCS_ABSOLUTE_PREFIX):
+        return _ASSET_PROXY_BASE + "/" + url[len(_GCS_ABSOLUTE_PREFIX):]
+    return url
 
 
 def _derive_docx_url(grade_code: str | None) -> str | None:
-    """Return the GCS docx URL if grade_code is in the checked-in manifest, else None.
+    """Return the proxied docx URL if grade_code is in the checked-in manifest, else None.
 
     YAML-explicit worksheet_docx_url always takes priority over this derived value
-    (callers use ``data.get("worksheet_docx_url") or _derive_docx_url(grade_code)``).
+    (callers use ``_to_asset_proxy_url(data.get("worksheet_docx_url")) or _derive_docx_url(grade_code)``).
     """
     if not grade_code or grade_code not in _DOCX_CODES:
         return None
@@ -243,7 +266,7 @@ def load_layer1_lessons() -> list[dict]:
             "full_text": data.get("story_text"),
             "char_count": data.get("char_count", 0),
             "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"{_ASSET_PROXY_BASE}/stories/"
                 f"thumbnails/lesson-{data['lesson_number']}.webp"
             ),
             "vocabulary": data.get("vocabulary") or [],
@@ -278,12 +301,14 @@ def load_layer1_lessons() -> list[dict]:
             "worksheet_intro": data.get("worksheet_intro"),
             # Lesson intro (#1443): docx 說明/導讀 or excel fallback
             "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Public PDF URL of the original 紙本學習單 (#1444). YAML source
+            # still has the absolute GCS URL (#2486) — rewritten to our
+            # same-origin proxy here, the single point of truth.
+            "worksheet_pdf_url": _to_asset_proxy_url(data.get("worksheet_pdf_url")),
             # Direct docx URL — YAML field takes priority; derive from GCS manifest
             # for all other lessons that have a .docx in worksheets/ (#2073, #2207)
             "worksheet_docx_url": (
-                data.get("worksheet_docx_url")
+                _to_asset_proxy_url(data.get("worksheet_docx_url"))
                 or _derive_docx_url(data.get("grade_code", ""))
             ),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
@@ -404,7 +429,7 @@ def load_layer2_lessons(
             "full_text": data.get("story_text"),
             "char_count": data.get("char_count", 0),
             "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"{_ASSET_PROXY_BASE}/stories/"
                 f"thumbnails/{norm_code}.webp"
             ),
             "vocabulary": vocabulary,
@@ -443,12 +468,14 @@ def load_layer2_lessons(
             "worksheet_intro": data.get("worksheet_intro"),
             # Lesson intro (#1443): docx 說明/導讀 or excel fallback
             "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Public PDF URL of the original 紙本學習單 (#1444). YAML source
+            # still has the absolute GCS URL (#2486) — rewritten to our
+            # same-origin proxy here, the single point of truth.
+            "worksheet_pdf_url": _to_asset_proxy_url(data.get("worksheet_pdf_url")),
             # Direct docx URL — YAML field takes priority; derive from GCS manifest
             # for all other lessons that have a .docx in worksheets/ (#2073, #2207)
             "worksheet_docx_url": (
-                data.get("worksheet_docx_url")
+                _to_asset_proxy_url(data.get("worksheet_docx_url"))
                 or _derive_docx_url(norm_code)
             ),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables

--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -509,6 +509,24 @@ def build_layer2_enrichment_index() -> dict[str, dict]:
             continue
         title = data.get("title", "")
         if title:
+            # Issue #2486 (part 3): ENRICHMENT_FIELDS (below) copies this dict's
+            # worksheet_pdf_url / worksheet_docx_url verbatim onto matching
+            # Layer-1 lessons (lesson_indexes.py). load_layer2_lessons() above
+            # already rewrites those fields via _to_asset_proxy_url before they
+            # reach an API response — but this index is a *separate* raw read
+            # of the same YAML files, so without the same rewrite here, a
+            # Layer-1 lesson enriched from this index would silently regain the
+            # literal storage.googleapis.com URL. Confirmed via real-browser QA:
+            # GET /api/stories/3 returned a same-origin /assets/... thumbnail_url
+            # (thumbnail_url isn't in ENRICHMENT_FIELDS, so Layer-1's own already
+            # -correct value was untouched) alongside an absolute-GCS
+            # worksheet_pdf_url — CSP frame-src widening alone can't fix a URL
+            # that was never routed through the proxy in the first place.
+            # _to_asset_proxy_url is idempotent (already-relative or falsy
+            # values pass through unchanged), so this only rewrites the literal
+            # legacy-absolute case — no other enrichment behavior changes.
+            data["worksheet_pdf_url"] = _to_asset_proxy_url(data.get("worksheet_pdf_url"))
+            data["worksheet_docx_url"] = _to_asset_proxy_url(data.get("worksheet_docx_url"))
             layer2_by_title[title] = data
 
     return layer2_by_title

--- a/backend/tests/test_asset_url_rewrite.py
+++ b/backend/tests/test_asset_url_rewrite.py
@@ -1,0 +1,110 @@
+"""
+Tests for URL rewriting in lesson_layer_loaders.py — issue #2486.
+
+lingoleap-assets is going private. Every URL the backend hands to the frontend
+for content in that bucket (thumbnails, worksheet PDFs/DOCX) must point at our
+own `/assets/...` proxy instead of the absolute
+`https://storage.googleapis.com/lingoleap-assets/...` GCS URL — otherwise those
+URLs 403 the moment the bucket ACL flips.
+
+320+ YAML source files still contain literal absolute GCS URLs for
+`worksheet_pdf_url` (out of scope to hand-edit every one) — `_to_asset_proxy_url`
+is the single point where those get rewritten before reaching an API response.
+
+TDD: written before the lesson_layer_loaders.py rewrite. Red -> Green -> Refactor.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.lesson_layer_loaders import (
+    _to_asset_proxy_url,
+    _derive_docx_url,
+    load_layer1_lessons,
+)
+
+
+class TestToAssetProxyUrl:
+    def test_rewrites_absolute_gcs_url_to_relative_proxy_path(self):
+        absolute = "https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L23.pdf"
+        assert _to_asset_proxy_url(absolute) == "/assets/worksheets/G5-L23.pdf"
+
+    def test_rewrites_lessons_images_url(self):
+        absolute = "https://storage.googleapis.com/lingoleap-assets/lessons-images/G4-L1/G4-L1-01.jpg"
+        assert _to_asset_proxy_url(absolute) == "/assets/lessons-images/G4-L1/G4-L1-01.jpg"
+
+    def test_passes_through_none(self):
+        assert _to_asset_proxy_url(None) is None
+
+    def test_passes_through_empty_string(self):
+        assert _to_asset_proxy_url("") == ""
+
+    def test_passes_through_already_relative_url_unchanged(self):
+        """Idempotent — a URL already rewritten (or authored relative) is untouched."""
+        assert _to_asset_proxy_url("/assets/worksheets/G5-L23.pdf") == "/assets/worksheets/G5-L23.pdf"
+
+    def test_does_not_touch_unrelated_absolute_url(self):
+        """A URL pointing somewhere else entirely (not our bucket) must not be mangled."""
+        other = "https://example.com/some/other/file.pdf"
+        assert _to_asset_proxy_url(other) == other
+
+
+class TestDeriveDocxUrlIsRelative:
+    def test_derived_docx_url_uses_asset_proxy_base(self):
+        # Any grade_code from the checked-in manifest works; use a known one
+        # if present, else just check the shape via a monkeypatched code set.
+        import app.services.lesson_layer_loaders as loaders
+        original_codes = loaders._DOCX_CODES
+        try:
+            loaders._DOCX_CODES = frozenset({"G4-L01"})
+            url = _derive_docx_url("G4-L01")
+            assert url == "/assets/worksheets/G4-L01.docx"
+            assert not url.startswith("https://")
+        finally:
+            loaders._DOCX_CODES = original_codes
+
+    def test_derive_docx_url_returns_none_for_unknown_code(self):
+        assert _derive_docx_url("NOT-A-REAL-CODE") is None
+
+    def test_derive_docx_url_returns_none_for_empty_code(self):
+        assert _derive_docx_url("") is None
+        assert _derive_docx_url(None) is None
+
+
+class TestLayer1LessonsUseAssetProxyUrls:
+    """Integration: the actual lesson dicts served to the frontend must never
+    carry an absolute storage.googleapis.com URL after the #2486 fix."""
+
+    def test_no_lesson_has_absolute_gcs_thumbnail_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("thumbnail_url", "")
+            assert not url.startswith("https://storage.googleapis.com/"), (
+                f"Lesson {lesson.get('lesson_number')} thumbnail_url is still absolute: {url}"
+            )
+
+    def test_thumbnail_url_uses_asset_proxy_prefix(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            assert lesson["thumbnail_url"].startswith("/assets/stories/thumbnails/")
+
+    def test_no_lesson_has_absolute_gcs_worksheet_pdf_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("worksheet_pdf_url")
+            if url:
+                assert not url.startswith("https://storage.googleapis.com/"), (
+                    f"Lesson {lesson.get('lesson_number')} worksheet_pdf_url is still absolute: {url}"
+                )
+                assert url.startswith("/assets/worksheets/")
+
+    def test_no_lesson_has_absolute_gcs_worksheet_docx_url(self):
+        lessons = load_layer1_lessons()
+        for lesson in lessons:
+            url = lesson.get("worksheet_docx_url")
+            if url:
+                assert not url.startswith("https://storage.googleapis.com/"), (
+                    f"Lesson {lesson.get('lesson_number')} worksheet_docx_url is still absolute: {url}"
+                )
+                assert url.startswith("/assets/worksheets/")

--- a/backend/tests/test_assets_proxy.py
+++ b/backend/tests/test_assets_proxy.py
@@ -1,0 +1,168 @@
+"""
+Tests for GET /assets/{path} — the private-bucket asset proxy.
+
+Issue #2486: `lingoleap-assets` GCS bucket was public-read (allUsers
+objectViewer), letting anyone anonymously enumerate + bulk-download the
+entire course image/worksheet library (egress cost risk + content
+enumeration). This route lets the backend's own service-account credentials
+read the (now-private) bucket while the browser only ever talks to our own
+origin.
+
+TDD: written before app/routes/assets.py implementation. Red -> Green -> Refactor.
+"""
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _mock_bucket_with_blob(content: bytes):
+    """Build a fake GCS bucket whose .blob().download_as_bytes() returns content."""
+    blob = MagicMock()
+    blob.download_as_bytes.return_value = content
+    bucket = MagicMock()
+    bucket.blob.return_value = blob
+    return bucket, blob
+
+
+class TestAssetProxyAllowedPrefixes:
+    """Requests under an allow-listed prefix should reach GCS and stream back."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_lessons_images_returns_200_with_content_type(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"\xff\xd8\xfffakejpegbytes")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        assert resp.content == b"\xff\xd8\xfffakejpegbytes"
+        bucket.blob.assert_called_once_with("lessons-images/G4-L1/G4-L1-01.jpg")
+
+    @patch("app.routes.assets._get_bucket")
+    def test_stories_thumbnail_returns_200(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"webpbytes")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/stories/thumbnails/lesson-1.webp")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/webp"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_worksheet_pdf_returns_200(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"%PDF-1.4 fake")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/worksheets/G5-L23.pdf")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/pdf"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_worksheet_docx_returns_correct_content_type(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"PKfakedocx")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/worksheets/G5-L23.docx")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+
+    @patch("app.routes.assets._get_bucket")
+    def test_response_has_long_lived_cache_control(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"data")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+    @patch("app.routes.assets._get_bucket")
+    def test_no_auth_required(self, mock_get_bucket):
+        """Public content — no Authorization header needed (matches pre-fix behavior)."""
+        bucket, _blob = _mock_bucket_with_blob(b"data")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/G4-L1/G4-L1-01.jpg")
+
+        assert resp.status_code == 200
+
+
+class TestAssetProxyAllowlistRejection:
+    """Anything outside the 3 allow-listed prefixes must 404 — no general GCS proxy."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_unknown_prefix_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/pr-screenshots/some-screenshot.png")
+        assert resp.status_code == 404
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_qa_prefix_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/qa/whatever.png")
+        assert resp.status_code == 404
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_bare_prefix_with_no_object_is_404(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/")
+        assert resp.status_code == 404
+
+
+class TestAssetProxyPathTraversal:
+    """Path traversal attempts must never reach GCS with a decoded '..' segment."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_dotdot_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/../../etc/passwd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_encoded_dotdot_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/%2e%2e/%2e%2e/etc/passwd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_absolute_path_style_traversal_is_rejected(self, mock_get_bucket):
+        resp = client.get("/assets/lessons-images/..%2f..%2fetc%2fpasswd")
+        assert resp.status_code in (404, 400)
+        mock_get_bucket.assert_not_called()
+
+    @patch("app.routes.assets._get_bucket")
+    def test_unsafe_characters_rejected(self, mock_get_bucket):
+        """Backslashes / control chars outside the allow-listed charset are rejected."""
+        resp = client.get("/assets/lessons-images/G4-L1/file%00.jpg")
+        assert resp.status_code in (400, 404)
+
+
+class TestAssetProxyMissingObject:
+    """A GCS miss (object doesn't exist) must surface as a clean 404, no internals leaked."""
+
+    @patch("app.routes.assets._get_bucket")
+    def test_gcs_not_found_returns_404_not_500(self, mock_get_bucket):
+        blob = MagicMock()
+        blob.download_as_bytes.side_effect = Exception("404 GET ... No such object")
+        bucket = MagicMock()
+        bucket.blob.return_value = blob
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/does-not-exist/x.jpg")
+
+        assert resp.status_code == 404
+        # Must not leak internal exception text / GCS bucket internals to the client.
+        assert "Exception" not in resp.text
+        assert "lingoleap-assets" not in resp.text

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -673,6 +673,32 @@ class TestGlobalRateLimitMiddleware:
         resp = client.get("/")
         assert resp.status_code != 429
 
+    def test_assets_endpoint_is_rate_limited(self, client):
+        """#2486: /assets/* (private-bucket proxy) shares the same global limit
+        as /api/* — otherwise the proxy itself becomes an uncapped abuse vector
+        for the very egress-cost concern this issue set out to close."""
+        from app.main import GlobalRateLimitMiddleware
+        from unittest.mock import patch, MagicMock
+        general_rate_limiter.reset()
+
+        ip = "testclient"
+        for _ in range(GlobalRateLimitMiddleware.READ_LIMIT):
+            general_rate_limiter.check_with_info(
+                f"global:ip:{ip}:read",
+                GlobalRateLimitMiddleware.READ_LIMIT,
+                GlobalRateLimitMiddleware.WINDOW,
+            )
+
+        with patch("app.routes.assets._get_bucket") as mock_get_bucket:
+            blob = MagicMock()
+            blob.download_as_bytes.return_value = b"data"
+            bucket = MagicMock()
+            bucket.blob.return_value = blob
+            mock_get_bucket.return_value = bucket
+            resp = client.get("/assets/lessons-images/G4-L1/x.jpg")
+
+        assert resp.status_code == 429
+
     def test_global_limit_constants(self):
         """Verify the configured limits match spec.
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -4,6 +4,8 @@ Tests for OWASP security headers added by SecurityHeadersMiddleware.
 Verifies that every response (success, error, CORS preflight) carries
 the required headers defined in backend/app/main.py.
 """
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -199,3 +201,86 @@ class TestCspDirectives:
             "backend on different *.run.app origins). "
             f"Got: {frame_src_directive!r}"
         )
+
+
+class TestAssetProxyFramingHeaders:
+    """Regression test for #2486 — SecurityHeadersMiddleware blanket-denied
+    framing of its OWN `/assets/*` responses, defeating the frame-src fix above.
+
+    Widening the *parent* page's `frame-src` (TestCspDirectives above) is
+    necessary but not sufficient: the middleware unconditionally stamps
+    every response — including the PDF/image bytes served by
+    app/routes/assets.py — with `X-Frame-Options: DENY` and
+    `frame-ancestors 'none'`. Both of those govern whether the *resource
+    itself* may be framed by anyone, including our own frontend. DENY /
+    'none' block that unconditionally, regardless of frame-src.
+
+    Confirmed via real-browser QA against a live PR preview: after fixing
+    frame-src alone, the iframe network request succeeded (200
+    application/pdf, no CSP console error) but the worksheet modal stayed
+    visually blank — because the framed PDF response itself refused to be
+    framed. curl against the same URL confirmed `x-frame-options: DENY` and
+    `frame-ancestors 'none'` on the PDF response.
+
+    This didn't matter pre-#2488 because storage.googleapis.com (which
+    doesn't set X-Frame-Options) served these files directly; it only
+    surfaced once they started flowing through our own
+    SecurityHeadersMiddleware-wrapped backend.
+    """
+
+    @staticmethod
+    def _mock_bucket_with_blob(content: bytes):
+        blob = MagicMock()
+        blob.download_as_bytes.return_value = content
+        bucket = MagicMock()
+        bucket.blob.return_value = blob
+        return bucket
+
+    @patch("app.routes.assets._get_bucket")
+    def test_asset_pdf_response_does_not_send_x_frame_options_deny(self, mock_get_bucket):
+        mock_get_bucket.return_value = self._mock_bucket_with_blob(b"%PDF-1.4 fake")
+
+        resp = client.get("/assets/worksheets/G5-L23.pdf")
+
+        assert resp.status_code == 200
+        assert resp.headers.get("x-frame-options") != "DENY", (
+            "X-Frame-Options: DENY on /assets/* blocks our own worksheet PDF "
+            "iframe from framing it, in every browser (DENY has no same-origin "
+            "exception, unlike SAMEORIGIN)."
+        )
+
+    @patch("app.routes.assets._get_bucket")
+    def test_asset_pdf_response_frame_ancestors_allows_own_origins(self, mock_get_bucket):
+        mock_get_bucket.return_value = self._mock_bucket_with_blob(b"%PDF-1.4 fake")
+
+        resp = client.get("/assets/worksheets/G5-L23.pdf")
+
+        csp = resp.headers.get("content-security-policy", "")
+        frame_ancestors_directive = ""
+        for part in csp.split(";"):
+            stripped = part.strip()
+            if stripped.startswith("frame-ancestors"):
+                frame_ancestors_directive = stripped
+                break
+        assert frame_ancestors_directive, "Asset response is missing frame-ancestors entirely"
+        assert "'none'" not in frame_ancestors_directive, (
+            f"frame-ancestors 'none' blocks our own worksheet PDF iframe "
+            f"unconditionally. Got: {frame_ancestors_directive!r}"
+        )
+        assert "'self'" in frame_ancestors_directive, (
+            f"frame-ancestors must allow 'self' (Firebase Hosting same-origin "
+            f"rewrite). Got: {frame_ancestors_directive!r}"
+        )
+        assert "https://*.run.app" in frame_ancestors_directive, (
+            f"frame-ancestors must allow https://*.run.app (Cloud-Run-direct "
+            f"frontend framing the backend's own cross-origin asset URL). "
+            f"Got: {frame_ancestors_directive!r}"
+        )
+
+    def test_html_routes_are_unaffected_by_the_asset_carveout(self):
+        """Anti-clickjacking on regular pages/API responses must stay intact —
+        the relaxed framing policy is scoped to /assets/* only."""
+        resp = client.get("/")
+        assert resp.headers.get("x-frame-options") == "DENY"
+        csp = resp.headers.get("content-security-policy", "")
+        assert "frame-ancestors 'none'" in csp

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -164,3 +164,38 @@ class TestCspDirectives:
             f"CSP img-src must include 'blob:' for OMO cropped image previews (#1917). "
             f"Got: {img_src_directive!r}"
         )
+
+    def test_csp_frame_src_allows_cross_origin_run_app_backend(self):
+        """Regression test for #2486 (critic-found regression on the asset-proxy PR).
+
+        The worksheet PDF iframe (Intro.tsx) now points at whatever ASSET_BASE
+        resolves to. On the Firebase Hosting build that's a same-origin relative
+        "/assets/..." path — 'self' covers it. But on the Cloud-Run-direct
+        frontend (staging, prod, PR previews), ASSET_BASE resolves to the
+        *backend's own* Cloud Run origin (a different host from the frontend),
+        so the iframe src is genuinely cross-origin.
+
+        `frame-src 'self'` blocks that cross-origin iframe outright — confirmed
+        via real-browser reproduction on staging: iframe navigation is blocked
+        with "Framing '<backend-url>' violates ... frame-src 'self'", and the
+        worksheet modal renders permanently blank.
+
+        Fix: extend frame-src with the same `https://*.run.app` wildcard already
+        used by connect-src, covering prod/staging/PR-preview backends without
+        hardcoding per-environment URLs.
+        """
+        response = client.get("/")
+        csp = response.headers.get("content-security-policy", "")
+        frame_src_directive = ""
+        for part in csp.split(";"):
+            stripped = part.strip()
+            if stripped.startswith("frame-src"):
+                frame_src_directive = stripped
+                break
+        assert frame_src_directive, "CSP is missing frame-src directive entirely"
+        assert "https://*.run.app" in frame_src_directive, (
+            "CSP frame-src must allow https://*.run.app so the worksheet PDF "
+            "iframe isn't blocked on Cloud-Run-direct deploys (frontend and "
+            "backend on different *.run.app origins). "
+            f"Got: {frame_src_directive!r}"
+        )

--- a/backend/tests/test_stories_api.py
+++ b/backend/tests/test_stories_api.py
@@ -508,6 +508,67 @@ class TestGetStoryDetailEndpoint:
             )
 
 
+class TestWorksheetPdfUrlIsProxied:
+    """Regression test for #2486 (part 3) — worksheet_pdf_url leaked the raw
+    absolute GCS URL through GET /api/stories/{id} for Layer-1 lessons whose
+    worksheet_pdf_url came from the Layer-2 *enrichment* merge (#1666), even
+    though load_layer2_lessons() itself already rewrote the field correctly
+    for lessons served directly out of Layer-2.
+
+    Found via real-browser QA against a live PR preview (not caught by the
+    existing #2486 tests in test_asset_url_rewrite.py, which only exercise
+    load_layer1_lessons() *before* enrichment and load_layer2_lessons()
+    directly — neither one touches build_layer2_enrichment_index(), which is
+    where the raw copy actually happened).
+
+    Story id 3 (G4-L3, "長高的祕密") is the exact case reported: thumbnail_url
+    was already correctly /assets/-prefixed (it isn't a Layer-2 enrichment
+    field — see lesson_layer_loaders.py, it's synthesized fresh), but
+    worksheet_pdf_url came back as the literal
+    https://storage.googleapis.com/lingoleap-assets/... URL — which both (a)
+    defeats the CSP frame-src widening (the iframe was never pointed at a
+    *.run.app origin to begin with) and (b) would 403 the moment the bucket
+    ACL goes private.
+    """
+
+    def test_lesson_3_worksheet_pdf_url_is_proxied_not_absolute_gcs(self, client):
+        resp = client.get("/api/stories/3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["worksheet_pdf_url"], "Expected lesson 3 to have a worksheet_pdf_url"
+        assert data["worksheet_pdf_url"].startswith("/assets/worksheets/"), (
+            f"worksheet_pdf_url must be proxied, got: {data['worksheet_pdf_url']!r}"
+        )
+        assert "storage.googleapis.com" not in data["worksheet_pdf_url"]
+
+    def test_no_story_leaks_absolute_gcs_worksheet_pdf_url(self, client):
+        """Sweep every served lesson — the bug was specific to lessons enriched
+        from Layer-2 parsed data, not universal, so a single lesson isn't
+        enough to prove the fix covers every affected id."""
+        from app.services.lesson_loader import get_all_lessons
+
+        offenders = []
+        for lesson in get_all_lessons():
+            resp = client.get(f"/api/stories/{lesson['id']}")
+            assert resp.status_code == 200
+            url = resp.json().get("worksheet_pdf_url")
+            if url and "storage.googleapis.com" in url:
+                offenders.append((lesson["id"], url))
+        assert not offenders, f"Lessons with un-proxied worksheet_pdf_url: {offenders}"
+
+    def test_no_story_leaks_absolute_gcs_worksheet_docx_url(self, client):
+        from app.services.lesson_loader import get_all_lessons
+
+        offenders = []
+        for lesson in get_all_lessons():
+            resp = client.get(f"/api/stories/{lesson['id']}")
+            assert resp.status_code == 200
+            url = resp.json().get("worksheet_docx_url")
+            if url and "storage.googleapis.com" in url:
+                offenders.append((lesson["id"], url))
+        assert not offenders, f"Lessons with un-proxied worksheet_docx_url: {offenders}"
+
+
 class TestStoryDetailSchema:
     """Validate StoryDetail response schema completeness."""
 

--- a/backend/tests/test_stories_api.py
+++ b/backend/tests/test_stories_api.py
@@ -148,12 +148,15 @@ class TestLessonRequiredFields:
             assert "background" in intro, f"Lesson {lesson['lesson_number']} intro missing 'background'"
 
     def test_thumbnail_url_pattern(self):
+        """#2486: thumbnail_url is served via our same-origin /assets proxy —
+        lingoleap-assets is now a private bucket, no more absolute GCS URLs."""
         lessons = get_all_lessons()
         for lesson in lessons:
             url = lesson["thumbnail_url"]
-            assert url.startswith("https://storage.googleapis.com/lingoleap-assets/"), (
+            assert url.startswith("/assets/stories/thumbnails/"), (
                 f"Lesson {lesson['lesson_number']} has unexpected thumbnail_url: {url}"
             )
+            assert not url.startswith("https://storage.googleapis.com/")
             assert f"lesson-{lesson['lesson_number']}.webp" in url
 
     def test_char_count_is_non_negative_int(self):
@@ -384,10 +387,11 @@ class TestStoryListItemSchema:
         assert "paragraphs" not in story
 
     def test_thumbnail_url_is_string(self, client):
+        """#2486: relative same-origin /assets path, not an absolute GCS URL."""
         resp = client.get("/api/stories?page_size=5")
         for story in resp.json()["stories"]:
             assert isinstance(story["thumbnail_url"], str)
-            assert story["thumbnail_url"].startswith("https://")
+            assert story["thumbnail_url"].startswith("/assets/")
 
 
 class TestGetStoryDetailEndpoint:

--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,13 @@
           }
         },
         {
+          "source": "/assets/**",
+          "run": {
+            "serviceId": "lingoleap-backend",
+            "region": "asia-east1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }
@@ -31,6 +38,13 @@
           }
         },
         {
+          "source": "/assets/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }
@@ -43,6 +57,13 @@
       "rewrites": [
         {
           "source": "/api/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
+          "source": "/assets/**",
           "run": {
             "serviceId": "lingoleap-backend-staging",
             "region": "asia-east1"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,8 +7,13 @@
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
     <!-- #2486: frame-src no longer needs storage.googleapis.com — the worksheet
-         PDF iframe now loads through our own same-origin /assets/* proxy. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com;" />
+         PDF iframe now loads through our own /assets/* proxy. That proxy is
+         same-origin on the Firebase Hosting build, but on the Cloud-Run-direct
+         frontend (staging/prod/PR previews) ASSET_BASE resolves to the
+         backend's own Cloud Run origin — a different host — so the iframe is
+         genuinely cross-origin there. https://*.run.app (same wildcard as
+         connect-src) covers that without hardcoding per-environment URLs. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://*.run.app https://www.youtube.com https://www.youtube-nocookie.com;" />
     <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
          Per CSP spec, frame-ancestors is a navigation directive and is ignored
          when delivered via <meta> elements (causes browser console warnings).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,9 @@
     <!-- Content-Security-Policy: browser-level fallback.
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://storage.googleapis.com https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <!-- #2486: frame-src no longer needs storage.googleapis.com — the worksheet
+         PDF iframe now loads through our own same-origin /assets/* proxy. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' http://localhost:* ws://localhost:* https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com;" />
     <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
          Per CSP spec, frame-ancestors is a navigation directive and is ignored
          when delivered via <meta> elements (causes browser console warnings).

--- a/frontend/src/__tests__/csp-meta-tag.test.ts
+++ b/frontend/src/__tests__/csp-meta-tag.test.ts
@@ -67,3 +67,37 @@ describe('CSP meta tag — frame-ancestors directive', () => {
     expect(indexHtml).toContain("default-src 'self'")
   })
 })
+
+/**
+ * Regression test for #2486 (critic-found regression on the asset-proxy PR).
+ *
+ * ASSET_BASE (frontend/src/config/assetBase.ts) resolves to the backend's own
+ * Cloud Run origin on Cloud-Run-direct deploys (staging, prod, PR previews) —
+ * a different host from the frontend. The worksheet PDF iframe (Intro.tsx)
+ * src is therefore genuinely cross-origin in that deploy shape, and
+ * `frame-src 'self'` blocks it outright.
+ *
+ * Confirmed via real-browser reproduction on staging: navigating the iframe
+ * throws "Framing '<backend-url>' violates ... frame-src 'self'" and the
+ * worksheet modal renders permanently blank.
+ */
+describe('CSP meta tag — frame-src allows cross-origin *.run.app backend (#2486)', () => {
+  const indexHtml = readFileSync(
+    resolve(__dirname, '../../index.html'),
+    'utf-8'
+  )
+
+  it('should include https://*.run.app in the frame-src directive', () => {
+    const cspMetaMatch = indexHtml.match(
+      /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"/
+    )
+    expect(cspMetaMatch).not.toBeNull()
+
+    const cspContent = cspMetaMatch![1]
+    const frameSrcMatch = cspContent.match(/frame-src\s+([^;]+)/)
+    expect(frameSrcMatch).not.toBeNull()
+
+    const frameSrcValue = frameSrcMatch![1]
+    expect(frameSrcValue).toContain('https://*.run.app')
+  })
+})

--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -22,6 +22,7 @@
  * overflow-y; this component fills 100% of that space.
  */
 import React, { useEffect, useRef, useState } from 'react';
+import { ASSET_BASE } from '../../config/assetBase';
 
 interface GraphicTextImageStripProps {
   images: { filename: string; caption?: string; figure_label?: string }[];
@@ -35,7 +36,8 @@ interface GraphicTextImageStripProps {
   lessonCode?: string;
 }
 
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 /** Chinese numeral labels (1-based) for figure badges */
 const CHINESE_NUMERALS = ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十'];

--- a/frontend/src/components/reading-steps/InlineImageCard.tsx
+++ b/frontend/src/components/reading-steps/InlineImageCard.tsx
@@ -10,8 +10,10 @@
  */
 import React from 'react';
 import ZoomableImage from '../ui/ZoomableImage';
+import { ASSET_BASE } from '../../config/assetBase';
 
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 interface InlineImageCardProps {
   image: { filename: string; caption?: string };

--- a/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
@@ -11,9 +11,10 @@
  */
 import React from 'react';
 import { Story } from '../../../types';
+import { ASSET_BASE } from '../../../config/assetBase';
 
-/** GCS image base URL pattern (Day 2 will verify actual serving) */
-const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const GCS_IMAGE_BASE = `${ASSET_BASE}/lessons-images`;
 
 interface GraphicTextLayoutProps {
   story: Story;

--- a/frontend/src/components/student/home/TodayLessonCard.tsx
+++ b/frontend/src/components/student/home/TodayLessonCard.tsx
@@ -13,6 +13,7 @@
 import React, { useEffect, useState } from 'react';
 import type { StudentAssignmentResponse } from '../../../services/assignmentApi';
 import type { StudentEnrolledClassroom } from '../../../services/learningApi';
+import { ASSET_BASE } from '../../../config/assetBase';
 
 // ---------------------------------------------------------------------------
 // NoClassroomWaitingScreen — shown to students not yet added to any classroom
@@ -61,7 +62,8 @@ interface BookJacketCoverProps {
   title: string;
 }
 
-const THUMBNAIL_BASE = 'https://storage.googleapis.com/lingoleap-assets/stories/thumbnails';
+// Same-origin asset proxy (#2486) — lingoleap-assets is now a private GCS bucket.
+const THUMBNAIL_BASE = `${ASSET_BASE}/stories/thumbnails`;
 
 export const BookJacketCover: React.FC<BookJacketCoverProps> = ({ storyId, title }) => {
   const [imgOk, setImgOk] = useState(true);

--- a/frontend/src/config/assetBase.test.ts
+++ b/frontend/src/config/assetBase.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Issue #2486: ASSET_BASE mirrors API_BASE's own resolution logic exactly —
+ * same-origin relative path when the app is served through the Firebase
+ * Hosting `/assets/**` rewrite (VITE_API_URL=""), or an absolute backend URL
+ * when the frontend is served directly by its own Cloud Run service / local
+ * dev (VITE_API_URL set to an absolute backend origin).
+ *
+ * TDD: written before frontend/src/config/assetBase.ts exists. Red -> Green -> Refactor.
+ */
+
+describe('ASSET_BASE', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves to a relative /assets path when API_BASE is empty (Firebase Hosting rewrite)', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('/assets');
+  });
+
+  it('resolves to {backend}/assets when API_BASE is an absolute backend URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://lingoleap-backend-staging-xxx.run.app');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('https://lingoleap-backend-staging-xxx.run.app/assets');
+  });
+
+  it('falls back to the same localhost default as API_BASE when unset', async () => {
+    vi.stubEnv('VITE_API_URL', undefined);
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('http://localhost:8000/assets');
+  });
+
+  it('respects an explicit VITE_ASSET_BASE override', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    vi.stubEnv('VITE_ASSET_BASE', 'https://cdn.example.com/course-assets');
+    const { ASSET_BASE } = await import('./assetBase');
+    expect(ASSET_BASE).toBe('https://cdn.example.com/course-assets');
+  });
+});

--- a/frontend/src/config/assetBase.ts
+++ b/frontend/src/config/assetBase.ts
@@ -1,0 +1,24 @@
+/**
+ * ASSET_BASE — base path for public course assets (thumbnails, lesson images),
+ * served via the same-origin `/assets/*` proxy in front of the (now-private)
+ * `lingoleap-assets` GCS bucket.
+ *
+ * Issue #2486: components used to hardcode
+ * `https://storage.googleapis.com/lingoleap-assets/...` directly, which let
+ * anyone anonymously enumerate + bulk-download the entire course library
+ * (egress cost risk + content enumeration). The bucket is now private; the
+ * backend's `/assets/{path}` route (app/routes/assets.py) reads it with its
+ * own service-account credentials instead.
+ *
+ * Mirrors apiConfig.ts's own `API_BASE` resolution exactly, because the two
+ * proxy paths are deployed identically:
+ * - Firebase Hosting build (VITE_API_URL="") → relative "/assets", handled by
+ *   the `/assets/**` rewrite in firebase.json (same trick as `/api/**`).
+ * - Cloud Run direct-serve frontend / PR preview (VITE_API_URL=absolute
+ *   backend URL) → `{backend}/assets`, a direct cross-origin call to the
+ *   backend's own Cloud Run service.
+ * - Local dev (VITE_API_URL unset) → same localhost:8000 default as API_BASE.
+ */
+import { API_BASE } from '../services/apiConfig';
+
+export const ASSET_BASE = import.meta.env.VITE_ASSET_BASE ?? `${API_BASE}/assets`;

--- a/frontend/src/services/api.assetUrl.test.ts
+++ b/frontend/src/services/api.assetUrl.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #2486 regression: fetchStory/fetchStories must resolve the backend's
+ * same-origin-relative "/assets/..." URLs (thumbnail_url, worksheet_pdf_url,
+ * worksheet_docx_url) onto ASSET_BASE before handing them to components.
+ *
+ * Root cause this locks: a real-browser QA pass on the PR preview (frontend
+ * and backend on different Cloud Run origins) showed the lesson cover image
+ * on Intro.tsx as a broken <img>. The backend correctly returns a relative
+ * "/assets/stories/thumbnails/lesson-1.webp" path, but Intro.tsx renders it
+ * as <img src={story.thumbnail}> directly — the browser resolved that
+ * relative path against the FRONTEND's own origin (which has no such route,
+ * and falls back to serving index.html), not the backend's. The fix belongs
+ * in api.ts's response-mapping layer (the single choke point every consumer
+ * — Intro.tsx, StoryCard.tsx — goes through), not in each component.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+vi.mock('../config/assetBase', () => ({
+  ASSET_BASE: 'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets',
+}));
+
+import { fetchStory, fetchStories } from './api';
+
+function mockJsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+const BASE_DETAIL_FIELDS = {
+  lesson_number: 1,
+  title: '贏得喝采的輸家',
+  grade: 4,
+  grade_code: 'G4-01',
+  genre: '記敘文',
+  category: 'Fable',
+  char_count: 100,
+  reading_strategy: null,
+  intro: { author: 'x', background: 'y' },
+  paragraphs: ['p1'],
+  source_file: 'L1.yml',
+};
+
+describe('fetchStory / fetchStories — asset URL resolution (#2486)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('resolves a relative thumbnail_url onto ASSET_BASE (fetchStory)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.thumbnail).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/stories/thumbnails/lesson-1.webp',
+    );
+  });
+
+  it('resolves relative worksheet_pdf_url and worksheet_docx_url onto ASSET_BASE', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+      worksheet_pdf_url: '/assets/worksheets/G4-L01.pdf',
+      worksheet_docx_url: '/assets/worksheets/G4-L01.docx',
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.worksheetPdfUrl).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/worksheets/G4-L01.pdf',
+    );
+    expect(story.worksheetDocxUrl).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/worksheets/G4-L01.docx',
+    );
+  });
+
+  it('leaves worksheet URLs undefined when absent (no false-positive resolution)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      ...BASE_DETAIL_FIELDS,
+      thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+      worksheet_pdf_url: null,
+      worksheet_docx_url: null,
+    }));
+
+    const story = await fetchStory('1');
+
+    expect(story.worksheetPdfUrl).toBeUndefined();
+    expect(story.worksheetDocxUrl).toBeUndefined();
+  });
+
+  it('resolves thumbnail_url for list items (fetchStories)', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({
+      stories: [{
+        lesson_number: 1,
+        title: '贏得喝采的輸家',
+        grade: 4,
+        category: 'Fable',
+        char_count: 100,
+        intro: { author: 'x', background: 'y' },
+        thumbnail_url: '/assets/stories/thumbnails/lesson-1.webp',
+        genre: '記敘文',
+      }],
+      total: 1,
+      grades: [4],
+    }));
+
+    const { stories } = await fetchStories();
+
+    expect(stories[0].thumbnail).toBe(
+      'https://lingoleap-backend-issue-2486-oja2sffiya-de.a.run.app/assets/stories/thumbnails/lesson-1.webp',
+    );
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,9 +13,35 @@
 
 import type { Story } from '../types';
 import { API_BASE } from './apiConfig';
+import { ASSET_BASE } from '../config/assetBase';
 import { stepSequenceFromWorksheet } from '../config/stepConfig';
 
 const inFlightStoryById = new Map<string, Promise<Story>>();
+
+/**
+ * Resolve a same-origin-relative "/assets/..." URL (thumbnail_url,
+ * worksheet_pdf_url, worksheet_docx_url — issue #2486) onto ASSET_BASE.
+ *
+ * The backend always returns these as relative paths. That's correct when
+ * the frontend is served through the Firebase Hosting `/assets/**` rewrite
+ * (ASSET_BASE === "", stays relative) — but when the frontend and backend
+ * are on different origins (Cloud Run direct-serve, PR previews, local dev),
+ * a bare "/assets/..." resolves against the FRONTEND's own origin, which has
+ * no such route and silently falls back to the SPA shell (broken <img>,
+ * found via real-browser QA on the #2486 PR preview). ASSET_BASE already
+ * encodes the correct origin for whichever deploy shape is active, so this
+ * is the single choke point every consumer (Intro.tsx, StoryCard.tsx, ...)
+ * goes through instead of each hand-rolling origin resolution.
+ */
+function resolveAssetUrl(url: string): string;
+function resolveAssetUrl(url: string | null | undefined): string | undefined;
+function resolveAssetUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith('/assets/')) {
+    return `${ASSET_BASE}${url.slice('/assets'.length)}`;
+  }
+  return url; // already absolute (or some other shape) — leave unchanged
+}
 
 export class SessionExpiredError extends Error {
   constructor(message: string) {
@@ -121,7 +147,7 @@ function apiListItemToStory(item: ApiStoryListItem): Story {
     title: item.title,
     level: item.grade,
     content: [],
-    thumbnail: item.thumbnail_url,
+    thumbnail: resolveAssetUrl(item.thumbnail_url),
     category: item.category as Story['category'],
     filename: '',
     intro: item.intro,
@@ -138,7 +164,7 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     title: detail.title,
     level: detail.grade,
     content: detail.paragraphs,
-    thumbnail: detail.thumbnail_url,
+    thumbnail: resolveAssetUrl(detail.thumbnail_url),
     category: detail.category as Story['category'],
     filename: detail.source_file,
     intro: detail.intro,
@@ -183,8 +209,8 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     worksheetSectionOrder: detail.worksheet_section_order ?? undefined,
     worksheetIntro: detail.worksheet_intro ?? undefined,
     lessonIntro: detail.lesson_intro ?? undefined,
-    worksheetPdfUrl: detail.worksheet_pdf_url ?? undefined,
-    worksheetDocxUrl: detail.worksheet_docx_url ?? undefined,
+    worksheetPdfUrl: resolveAssetUrl(detail.worksheet_pdf_url),
+    worksheetDocxUrl: resolveAssetUrl(detail.worksheet_docx_url),
     tables: detail.tables ?? undefined,
     // Plugin-pattern dispatch fields (#1404 / #1341):
     layout_mode: (detail.layout_mode as Story['layout_mode']) ?? 'standard',

--- a/frontend/src/utils/downloadRemoteFile.test.ts
+++ b/frontend/src/utils/downloadRemoteFile.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadRemoteFile } from './downloadRemoteFile';
+
+/**
+ * Issue #2486: worksheet_pdf_url / worksheet_docx_url are now relative
+ * same-origin paths (e.g. "/assets/worksheets/G5-L23.pdf") instead of
+ * absolute GCS URLs. `filenameFromUrl`'s fallback path used
+ * `new URL(url)` with no base, which throws on a relative URL — silently
+ * swallowed by the try/catch into a generic 'download' filename. This test
+ * locks the fix: relative URLs must produce a real filename, not silently
+ * degrade.
+ */
+describe('downloadRemoteFile', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: vi.fn().mockResolvedValue(new Blob(['fake pdf bytes'])),
+    });
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-object-url');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('fetches a relative same-origin URL without throwing', async () => {
+    await expect(downloadRemoteFile('/assets/worksheets/G5-L23.pdf')).resolves.toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith('/assets/worksheets/G5-L23.pdf');
+  });
+
+  it('derives a real filename from a relative URL when no filename is given', async () => {
+    const anchor = document.createElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('/assets/worksheets/G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('still works with an absolute cross-origin URL (Cloud Run direct-serve case)', async () => {
+    const anchor = document.createElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('https://lingoleap-backend-staging-xxx.run.app/assets/worksheets/G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+  });
+
+  it('uses the explicit filename argument when provided, regardless of URL shape', async () => {
+    const anchor = document.createElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    await downloadRemoteFile('/assets/worksheets/G5-L23.pdf', 'G5-L23.pdf');
+
+    expect(anchor.download).toBe('G5-L23.pdf');
+  });
+
+  it('throws when the response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    await expect(downloadRemoteFile('/assets/worksheets/missing.pdf')).rejects.toThrow('404');
+  });
+});

--- a/frontend/src/utils/downloadRemoteFile.ts
+++ b/frontend/src/utils/downloadRemoteFile.ts
@@ -1,13 +1,17 @@
 function filenameFromUrl(url: string): string {
   try {
-    const base = new URL(url).pathname.split('/').pop();
+    // Issue #2486: worksheet URLs are now same-origin relative paths
+    // (e.g. "/assets/worksheets/G5-L23.pdf") rather than absolute GCS URLs.
+    // `new URL(url)` throws on a relative string with no base — pass
+    // window.location.origin as the base so both shapes resolve correctly.
+    const base = new URL(url, window.location.origin).pathname.split('/').pop();
     return base && base.length > 0 ? base : 'download';
   } catch {
     return 'download';
   }
 }
 
-/** Trigger a browser file download for a cross-origin URL (e.g. GCS public assets). */
+/** Trigger a browser file download for a same-origin or cross-origin URL. */
 export async function downloadRemoteFile(url: string, filename?: string): Promise<void> {
   const response = await fetch(url);
   if (!response.ok) {


### PR DESCRIPTION
Deploys the #2486 asset-proxy migration to production (bucket stays public during this deploy = non-breaking; private flip is a separate final step after both envs verified).

Includes (all #2486):
- #2488: same-origin `/assets/*` backend proxy + firebase rewrite + frontend ASSET_BASE + api.ts resolver at choke point
- #2489: 3-layer render fix — CSP frame-src `*.run.app`, stop stamping X-Frame-Options DENY on `/assets/*`, rewrite worksheet_pdf_url/docx in Layer-2 enrichment index (42 lessons)

Verified on staging (Cloud-Run-direct, real browser): thumbnails render (backend `/assets`, 0 broken), worksheet PDF iframe src=run.app + 200 application/pdf + 0 CSP violations; sweep 0 residual raw GCS across sampled lessons; CI 11 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)