### PR TITLE
fix(assets): allow CJK object names in /assets proxy (#2486 QA regression)

### DIFF
--- a/backend/app/routes/assets.py
+++ b/backend/app/routes/assets.py
@@ -42,9 +42,17 @@ _ALLOWED_PREFIXES = ("lessons-images/", "stories/", "worksheets/")
 # Allow-list charset for the decoded object path. FastAPI's `{path:path}`
 # converter URL-decodes the raw request path once before this ever runs, so a
 # literal ".." here is a real traversal attempt, not a percent-encoding
-# artifact. Anything outside this charset (backslashes, NUL, unicode
-# lookalikes, control chars, ...) is rejected outright.
-_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_\-./]+$")
+# artifact.
+#
+# `\w` (Unicode by default for str patterns) matches ASCII word chars PLUS
+# non-ASCII letters/digits, so CJK object names are allowed — this is a
+# 國語文 (Chinese-literacy) platform and real thumbnails are named e.g.
+# `文-L1.webp` (#2486 regression: the old ASCII-only class 404'd every
+# classical-Chinese lesson thumbnail even though the object existed). Still
+# rejected outright: backslashes, NUL, control chars, whitespace, `%`, quotes
+# — none are in `[\w\-./]`. Path traversal is caught by the explicit ".."
+# check + the allow-listed-prefix check in `_is_safe_object_path`.
+_SAFE_PATH_RE = re.compile(r"[\w\-./]+")
 
 _CONTENT_TYPES = {
     ".webp": "image/webp",
@@ -68,7 +76,7 @@ def _is_safe_object_path(object_path: str) -> bool:
         return False
     if object_path.startswith("/"):
         return False
-    if not _SAFE_PATH_RE.match(object_path):
+    if not _SAFE_PATH_RE.fullmatch(object_path):
         return False
     # Must have an actual filename component after the prefix — a bare
     # "lessons-images/" request is never a real object, reject it here

--- a/backend/tests/test_assets_proxy.py
+++ b/backend/tests/test_assets_proxy.py
@@ -100,6 +100,51 @@ class TestAssetProxyAllowedPrefixes:
         assert resp.status_code == 200
 
 
+class TestAssetProxyUnicodeFilenames:
+    """Regression: #2486 — CJK-named objects must be servable.
+
+    Found by /qa on 2026-07-05: the classical-Chinese (文言文) lesson
+    thumbnails are stored under CJK object names (e.g. `文-L1.webp`, verified
+    16266 bytes in the bucket). The original ASCII-only allow-list charset
+    404'd every one of them even though the object existed — a real regression
+    on a 國語文 platform. `\\w` is Unicode-aware, so these now pass while
+    traversal / control chars stay rejected.
+    """
+
+    @patch("app.routes.assets._get_bucket")
+    def test_cjk_thumbnail_returns_200_and_reaches_gcs(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"webpbytes")
+        mock_get_bucket.return_value = bucket
+
+        # Browser URL-encodes 文 as %E6%96%87; FastAPI decodes before our guard.
+        resp = client.get("/assets/stories/thumbnails/文-L1.webp")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/webp"
+        bucket.blob.assert_called_once_with("stories/thumbnails/文-L1.webp")
+
+    @patch("app.routes.assets._get_bucket")
+    def test_cjk_lesson_image_returns_200(self, mock_get_bucket):
+        bucket, _blob = _mock_bucket_with_blob(b"\x89PNGfake")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/lessons-images/文-L1/文-L1-01.png")
+
+        assert resp.status_code == 200
+        bucket.blob.assert_called_once_with("lessons-images/文-L1/文-L1-01.png")
+
+    @patch("app.routes.assets._get_bucket")
+    def test_cjk_does_not_weaken_traversal_guard(self, mock_get_bucket):
+        """Allowing Unicode letters must not re-open `..` traversal."""
+        bucket, _blob = _mock_bucket_with_blob(b"x")
+        mock_get_bucket.return_value = bucket
+
+        resp = client.get("/assets/stories/thumbnails/../../文-secret.webp")
+
+        assert resp.status_code == 404
+        bucket.blob.assert_not_called()
+
+
 class TestAssetProxyAllowlistRejection:
     """Anything outside the 3 allow-listed prefixes must 404 — no general GCS proxy."""
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

`/qa` on staging caught a real regression: 6 文言文 lesson thumbnails (文-L1/L2/L5/L6/L7/L10.webp — verified to exist, e.g. 文-L1.webp=16266 bytes) returned 404 from the `/assets` proxy because `_SAFE_PATH_RE` was ASCII-only.

**Fix**: widen to `[\w\-./]` (Unicode-aware) + `.fullmatch()`. CJK passes; traversal/control/bidi/homoglyph/fullwidth still rejected; `..`+prefix defenses unchanged.

**Security**: independently reviewed by appsec-pentest-reviewer (assume-guilty, empirical char-class probing) → **SAFE_TO_MERGE**.

**Tests**: TestAssetProxyUnicodeFilenames (3 new); assets_proxy 17 / +rewrite +headers = 49 passed.

Separate: 5 ASCII-named broken thumbs (G7-L31, G8-L{3,6,9,12}b) = pre-existing content gap (objects don't exist), not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)