### PR TITLE
fix(story-structure): 修正共用 /g regex lastIndex 殘留污染填空 cell 判定

### DIFF
--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -236,12 +236,13 @@ function cellInteractiveText(cell: StructureRow | StructureSubRow): string {
 }
 
 function countBlanks(text: string): number {
-  return [...text.matchAll(INLINE_BLANK_RE)].length;
+  // 每次呼叫都用新鮮的 /g literal，避免共用單例 INLINE_BLANK_RE 的 lastIndex 殘留跨 cell 污染
+  return text.match(/【[^】]*】/g)?.length ?? 0;
 }
 
 function classifyInteractive(value: string): InteractiveType {
-  if (INLINE_BLANK_RE.test(value)) return 'fill_blank';
-  return 'display';
+  // 用不帶 /g 的 literal，.test() 不會推進 lastIndex（共用單例會有殘留狀態）
+  return /【[^】]*】/.test(value) ? 'fill_blank' : 'display';
 }
 
 function resolveGradeIndex(

--- a/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
@@ -1,20 +1,50 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// StoryStructureTable 內部呼叫 useAuth；測試不掛 AuthProvider，
+// 依 repo 慣例（見 src/__smoke__/render-smoke.test.tsx）stub 掉 AuthContext，
+// 否則會 throw "useAuth must be used within an AuthProvider"。
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    mustChangePassword: false,
+    loginPassword: null,
+    needsTermsAcceptance: false,
+    hasClassroom: true,
+    teacherGatingEnforced: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    clearMustChangePassword: vi.fn(),
+    refreshUser: vi.fn(),
+    acceptTerms: vi.fn(),
+    loginWithGoogle: vi.fn(),
+    loginWithJunyi: vi.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 import StoryStructureTable from '../StoryStructureTable';
 
+// 現行 cards layout 需要 interactive_type='display' 才會把 value 當文字渲染；
+// 沒標的 cell 會被 renderCellContent 當成 fill_blank 畫成空 input（值不顯示）。
 const simpleRows = [
-  { label: '主角', value: '小明' },
-  { label: '主題', value: '友情的重要性' },
+  { label: '主角', value: '小明', interactive_type: 'display' },
+  { label: '主題', value: '友情的重要性', interactive_type: 'display' },
 ];
 
 const groupedRows = [
   {
     label: '事例',
     value: '',
+    interactive_type: 'display',
     sub_rows: [
-      { label: '背景', value: '小明轉學到新學校' },
-      { label: '經過', value: '遇到熱心同學阿偉' },
-      { label: '結果', value: '兩人成為好朋友' },
+      { label: '背景', value: '小明轉學到新學校', interactive_type: 'display' },
+      { label: '經過', value: '遇到熱心同學阿偉', interactive_type: 'display' },
+      { label: '結果', value: '兩人成為好朋友', interactive_type: 'display' },
     ],
   },
 ];
@@ -65,7 +95,7 @@ describe('StoryStructureTable', () => {
 
   it('renders simple rows (no sub_rows)', async () => {
     mockFetchSuccess({ rows: simpleRows });
-    render(<StoryStructureTable storyId="lesson-01" />);
+    render(<StoryStructureTable storyId="lesson-01" showCoach={false} />);
     await waitFor(() => expect(screen.getByText('主角')).toBeTruthy());
     expect(screen.getByText('小明')).toBeTruthy();
     expect(screen.getByText('主題')).toBeTruthy();
@@ -74,7 +104,7 @@ describe('StoryStructureTable', () => {
 
   it('renders grouped rows with sub_rows', async () => {
     mockFetchSuccess({ rows: groupedRows });
-    render(<StoryStructureTable storyId="lesson-01" />);
+    render(<StoryStructureTable storyId="lesson-01" showCoach={false} />);
     await waitFor(() => expect(screen.getByText('事例')).toBeTruthy());
     expect(screen.getByText('背景')).toBeTruthy();
     expect(screen.getByText('小明轉學到新學校')).toBeTruthy();
@@ -84,8 +114,73 @@ describe('StoryStructureTable', () => {
 
   it('shows 文章重點表 header title', async () => {
     mockFetchSuccess({ rows: simpleRows });
-    render(<StoryStructureTable storyId="lesson-01" />);
+    render(<StoryStructureTable storyId="lesson-01" showCoach={false} />);
     await waitFor(() => expect(screen.getByText(/文章重點表/)).toBeTruthy());
+  });
+
+  // 迴歸測試（#story-structure-inline-blank-regex）：
+  // 共用 /g regex 的 lastIndex 殘留曾讓帶情境句子的 fill_blank cell 被誤判成 0 blank，
+  // 掉到 FillBlankCell 只畫光禿空格、丟掉整句情境；多空格列還會少畫一格。
+  // 修好後每個子列的情境句子文字都要出現，且空格數量要對。
+  it('renders every fill_blank context sentence and correct input count in a section_block', async () => {
+    const worksheetStructure = {
+      layout: 'worksheet_table',
+      title: '文章重點表',
+      worksheet_rows: [
+        {
+          kind: 'section_block',
+          section: '問題',
+          items: [
+            { label: '問題1', value: '食客中有一位會模仿【　　　】的樣子' },
+            { label: '問題2', value: '他也想學會【　　　】和【　　　】的本領' },
+            { label: '問題3', value: '最後大家都覺得很【　　　】' },
+          ],
+        },
+      ],
+      rows: [
+        {
+          label: '問題',
+          value: '',
+          interactive_type: 'display',
+          sub_rows: [
+            {
+              label: '問題1',
+              value: '食客中有一位會模仿【　　　】的樣子',
+              interactive_type: 'fill_blank',
+            },
+            {
+              label: '問題2',
+              value: '他也想學會【　　　】和【　　　】的本領',
+              interactive_type: 'fill_blank',
+            },
+            {
+              label: '問題3',
+              value: '最後大家都覺得很【　　　】',
+              interactive_type: 'fill_blank',
+            },
+          ],
+        },
+      ],
+    };
+
+    mockFetchSuccess(worksheetStructure);
+    const { container } = render(
+      <StoryStructureTable storyId="lesson-g6-l22" showCoach={false} />
+    );
+
+    // 等表格載入
+    await waitFor(() => expect(screen.getByText('問題1')).toBeTruthy());
+
+    // 每個子列的「情境句子片段」都要出現在畫面上（bug 時會被 FillBlankCell 丟掉）
+    expect(screen.getByText(/食客中有一位會模仿/)).toBeTruthy();
+    expect(screen.getByText(/的樣子/)).toBeTruthy();
+    expect(screen.getByText(/他也想學會/)).toBeTruthy();
+    expect(screen.getByText(/的本領/)).toBeTruthy();
+    expect(screen.getByText(/最後大家都覺得很/)).toBeTruthy();
+
+    // 空格總數 = 1 + 2 + 1 = 4；bug 時每列只畫 1 個光禿 input（共 3 個）→ 少畫
+    const inputs = container.querySelectorAll('input');
+    expect(inputs.length).toBe(4);
   });
 
   it('re-fetches when storyId prop changes', async () => {


### PR DESCRIPTION
Closes #2506

## 問題

「文章重點表」（story-structure）填空題的**情境句子整句消失、只剩光禿 `【___】`**，多空格列還會少畫一格（見 #2506，G6-L22 截圖）。

## 根因

`StoryStructureTable.tsx` 的模組層級共用 `/g` regex `INLINE_BLANK_RE`（L94）被兩個有狀態 helper 呼叫，`lastIndex` 殘留跨 cell 污染：
- `countBlanks`（L239）`matchAll` 沿用殘留 lastIndex
- `classifyInteractive`（L243）`.test()` 推進 lastIndex

→ 帶句子的填空 cell 被誤判成 0 blank / display → 掉到 `FillBlankCell` 只畫光禿空格、丟掉 `cell.value`。

## 修法（最小，只動渲染層）

- `classifyInteractive` 改用不帶 /g 的 `/【[^】]*】/.test(value)`
- `countBlanks` 改用 `text.match(/【[^】]*】/g)?.length ?? 0`

共用 `INLINE_BLANK_RE` 常數保留（`new RegExp(...,'g')` / `.replace()` 用法本來就安全）。**不涉及資料/後端。**

## 驗證

- 新增 section_block 多空格迴歸測試：修前紅（3 input、句子消失）→ 修後綠（4 input、每句情境都在）。
- `npm run lint` 0 error；StoryStructureTable 7 passed、render-smoke 14 passed。
- 本機（此分支前端 + proxy staging 真實資料）實測 G6-L22 情境句子回來、問題2 兩空皆在。

## 備註

- 完整 suite 另有 32 個既有失敗（VocabApplication / JoinClassroomPage / ReadingTrendChart… 等 12 檔），已在乾淨 base 重跑確認**與本 PR 無關**。
- QA 截圖：本機 DB 為舊 schema 供不出此功能資料，改用 Vite dev-proxy 到 staging 後端驗（純前端修復的合理驗法）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
