### PR TITLE
fix(reading): 補「藍色=通融(同音)」圖例並統一朗讀對照配色 (#2498)

### DIFF
--- a/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
@@ -8,6 +8,7 @@
 import React, { useMemo } from 'react';
 import { DiffToken } from '../../../types';
 import { interleavePunctuation } from '../../../utils/textDiff';
+import { ReadingDiffLegend, renderDiffTokenSpans } from '../readingDiffStyle';
 
 export interface FullReadingFeedbackPanelProps {
   /** Token array from reading evaluation. undefined or empty → renders nothing. */
@@ -16,23 +17,6 @@ export interface FullReadingFeedbackPanelProps {
   targetText: string;
   /** Lesson paragraphs — when provided and join to targetText, split 朗讀結果 by paragraph. */
   paragraphs?: string[];
-}
-
-function diffTokenClassName(type: DiffToken['type']): string {
-  return type === 'punctuation' ? 'text-on-surface' :
-    type === 'correct' ? 'text-emerald-600 font-medium' :
-    type === 'forgiven' ? 'text-blue-500' :
-    type === 'wrong' ? 'text-tertiary line-through' :
-    type === 'missing' || type === 'unread' ? 'text-on-surface-variant/30' :
-    'text-on-surface';
-}
-
-function renderDiffTokenSpans(tokens: DiffToken[], keyPrefix: string) {
-  return tokens.map((t, i) => (
-    <span key={`${keyPrefix}-${i}`} className={diffTokenClassName(t.type)}>
-      {t.char}
-    </span>
-  ));
 }
 
 const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({
@@ -69,6 +53,10 @@ const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({
       <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">
         朗讀結果
       </p>
+      {/* Issue #2498：補上色碼圖例（含藍色「通融」），與逐段朗讀一致 */}
+      <div className="mb-4 pb-3 border-b border-on-surface/5">
+        <ReadingDiffLegend title={null} />
+      </div>
       <div className="space-y-4">
         {paragraphTokenGroups.map(({ idx, tokens }) => (
           <p key={idx} className="text-lg leading-relaxed indent-[2em]">

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -10,6 +10,7 @@ import { groupIdxForProgress } from '../../../utils/ttsHighlight';
 import { useKaraoke } from '../../../context/KaraokeContext';
 import { interleavePunctuation } from '../../../utils/textDiff';
 import { getEncouragement } from '../../../utils/readingEncouragement';
+import { ReadingDiffLegend, renderDiffTokenSpans } from '../readingDiffStyle';
 
 /** Per-sentence retry (record + eval). Off until short-sentence practice ships. */
 const SENTENCE_RETRY_UI_ENABLED = false;
@@ -247,18 +248,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
       {/* ── Painpoint 4: 原文 vs 朗讀結果 — 左右並陳（桌機），上下排（手機） ── */}
       {readingResultTokens && !isSessionActive && (
         <div className="mt-6 rounded-2xl bg-surface-container-low overflow-hidden">
-          {/* 圖例說明 */}
-          <div className="px-4 pt-3 pb-2 flex flex-wrap gap-x-4 gap-y-1 border-b border-on-surface/5">
-            <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">朗讀對照</span>
-            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
-              <span className="text-emerald-600 font-bold">●</span> 正確
-            </span>
-            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
-              <span className="text-tertiary font-bold">●</span> 唸錯
-            </span>
-            <span className="flex items-center gap-1 text-xs text-on-surface-variant">
-              <span className="text-on-surface-variant/40 font-bold">●</span> 漏念
-            </span>
+          {/* 圖例說明（Issue #2498：共用 ReadingDiffLegend，含藍色「通融」） */}
+          <div className="px-4 pt-3 pb-2 border-b border-on-surface/5">
+            <ReadingDiffLegend />
           </div>
           {/* 左右並陳 (md+) / 上下排 (sm) */}
           <div className="flex flex-col md:flex-row divide-y md:divide-y-0 md:divide-x divide-on-surface/8">
@@ -273,21 +265,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
             <div className="flex-1 p-4">
               <p className="text-xs font-bold text-on-surface-variant mb-2">朗讀結果</p>
               <p className="text-base leading-relaxed">
-                {readingResultTokens.map((t, i) => (
-                  <span
-                    key={i}
-                    className={
-                      t.type === 'punctuation' ? 'text-on-surface' :
-                      t.type === 'correct' ? 'text-emerald-600 font-medium' :
-                      t.type === 'forgiven' ? 'text-blue-500' :
-                      t.type === 'wrong' ? 'text-tertiary line-through' :
-                      t.type === 'missing' || t.type === 'unread' ? 'text-on-surface-variant/30' :
-                      'text-on-surface'
-                    }
-                  >
-                    {t.char}
-                  </span>
-                ))}
+                {renderDiffTokenSpans(readingResultTokens, 'para')}
               </p>
             </div>
           </div>

--- a/frontend/src/components/reading-steps/readingDiffStyle.tsx
+++ b/frontend/src/components/reading-steps/readingDiffStyle.tsx
@@ -1,0 +1,58 @@
+/**
+ * readingDiffStyle — single source of truth for student-facing 朗讀結果 diff colors
+ * and the accompanying legend (Issue #2498).
+ *
+ * Before this file, ParagraphCard (逐段) and FullReadingFeedbackPanel (全文) each
+ * hard-coded the same color mapping, and the blue `forgiven` (同音通融) color had no
+ * legend entry at all — students saw blue characters with no explanation.
+ *
+ * The teacher-facing DiffDisplay.tsx keeps its own (different) palette on purpose;
+ * this module only governs the two student inline panels so they stay in sync.
+ */
+
+import React from 'react';
+import { DiffToken } from '../../types';
+
+/** Tailwind classes for each diff token type in the student inline panels. */
+export function diffTokenClassName(type: DiffToken['type']): string {
+  return type === 'punctuation' ? 'text-on-surface' :
+    type === 'correct' ? 'text-emerald-600 font-medium' :
+    type === 'forgiven' ? 'text-blue-500 font-medium' :
+    type === 'wrong' ? 'text-tertiary line-through' :
+    type === 'missing' || type === 'unread' ? 'text-on-surface-variant/30' :
+    'text-on-surface';
+}
+
+/** Render diff tokens as colored <span>s. */
+export function renderDiffTokenSpans(tokens: DiffToken[], keyPrefix: string) {
+  return tokens.map((t, i) => (
+    <span key={`${keyPrefix}-${i}`} className={diffTokenClassName(t.type)}>
+      {t.char}
+    </span>
+  ));
+}
+
+/** Legend rows — keep in sync with diffTokenClassName above. */
+const LEGEND_ITEMS: { dotClass: string; label: string }[] = [
+  { dotClass: 'text-emerald-600', label: '正確' },
+  { dotClass: 'text-blue-500', label: '通融（同音／讀音相近）' },
+  { dotClass: 'text-tertiary', label: '唸錯' },
+  { dotClass: 'text-on-surface-variant/40', label: '漏念' },
+];
+
+/**
+ * 朗讀對照色碼圖例 — shared by 逐段 (ParagraphCard) and 全文 (FullReadingFeedbackPanel).
+ * `title` defaults to 朗讀對照; pass a custom label or null to omit.
+ */
+export const ReadingDiffLegend: React.FC<{ title?: string | null }> = ({ title = '朗讀對照' }) => (
+  <div className="flex flex-wrap gap-x-4 gap-y-1 items-center">
+    {title && (
+      <span className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">{title}</span>
+    )}
+    {LEGEND_ITEMS.map(({ dotClass, label }) => (
+      <span key={label} className="flex items-center gap-1 text-xs text-on-surface-variant">
+        <span className={`${dotClass} font-bold`}>●</span> {label}
+      </span>
+    ))}
+  </div>
+);

--- a/frontend/src/components/ui/DiffDisplay.tsx
+++ b/frontend/src/components/ui/DiffDisplay.tsx
@@ -78,9 +78,22 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({
                 </span>
               );
             case 'correct':
-            case 'forgiven':
               return (
                 <span key={idx} className="text-gray-900 inline-flex flex-col items-center">
+                  <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
+                </span>
+              );
+            case 'forgiven':
+              // Issue #2498: render 通融 with the sky style its legend already advertises
+              // (previously it looked identical to 正確, so the legend entry was invisible).
+              return (
+                <span
+                  key={idx}
+                  className="bg-sky-100 text-sky-700 border-b-2 border-dashed border-sky-500 rounded-sm px-0.5 mx-px cursor-help inline-flex flex-col items-center"
+                  title={token.expected && token.expected !== token.char ? `課文是「${token.expected}」，讀音相近予以通融` : '讀音相近，予以通融'}
+                  aria-label={`通融：讀成「${token.char}」，讀音相近予以算對`}
+                  role="mark"
+                >
                   <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
                 </span>
               );


### PR DESCRIPTION
## 修復 #2498 — 藍色字沒圖例 + 三元件配色不一致

### 問題
朗讀結果出現藍色字（= `forgiven`，學生唸的字與課文不同但**同音／讀音相近，予以通融算對**），但：
- 逐段（ParagraphCard）圖例只有 3 色，缺藍色
- 全文（FullReadingFeedbackPanel）**完全沒有圖例**
- 教師端（DiffDisplay）把 forgiven 畫成跟正確一樣的灰色，legend 卻宣稱藍色「通融」→ 自身矛盾

### 修改
- **新增 `readingDiffStyle.tsx`**：學生端 diff 配色（`diffTokenClassName` / `renderDiffTokenSpans`）+ `ReadingDiffLegend` 單一來源，逐段與全文共用，避免各寫各的。
- **ParagraphCard**：改用共用 legend/render，圖例補上第 4 項 🔵 通融（同音／讀音相近）。
- **FullReadingFeedbackPanel**：補上完整圖例（原本沒有），與逐段一致。
- **DiffDisplay（教師端）**：forgiven 改用其 legend 早已宣告的 sky-100 樣式（含 hover 說明「讀音相近予以通融」），不再與正確同色。

### 驗證
- `npm run lint`：**0 errors**（1 個既有 warning）
- `npx vitest run`（DiffDisplay / full-reading / live-tutor / smoke）：**53 passed**
- ⚠️ 帶顏色的朗讀結果需真實朗讀資料，preview 部署後請確認逐段/全文圖例都出現藍色「通融」且與字色一致

@claude 請幫我 review 這個 PR
