### PR TITLE
feat(reading): 逐段對照左欄改顯示學生逐字實唸內容 (#2500)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -705,6 +705,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               utteranceRef={utteranceRef}
               ttsRafRef={ttsRafRef}
               streamingUserInput={evalState.streamingUserInput}
+              spokenTranscript={savedLineResult?.transcript ?? ''}
               lastDiffTokens={displayLastDiffTokens}
               isAwaitingGemini={evalState.isAwaitingGemini}
               retryCount={evalState.retryCount}

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -39,6 +39,8 @@ interface ParagraphCardProps {
   ttsRafRef: React.MutableRefObject<number | null>;
   // Evaluation state
   streamingUserInput: string;
+  /** Issue #2500 — student's verbatim STT transcript for this paragraph (對照左欄顯示). */
+  spokenTranscript?: string;
   lastDiffTokens: import('../../../types').DiffToken[] | null;
   isAwaitingGemini: boolean;
   retryCount: number;
@@ -80,6 +82,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   speakingProgress,
   utteranceRef,
   ttsRafRef,
+  spokenTranscript,
   lastDiffTokens,
   isAwaitingGemini,
   retryCount,
@@ -262,11 +265,13 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           </div>
           {/* 左右並陳 (md+) / 上下排 (sm) */}
           <div className="flex flex-col md:flex-row divide-y md:divide-y-0 md:divide-x divide-on-surface/8">
-            {/* 左欄：課文原文 */}
+            {/* 左欄：學生實際唸的內容（Issue #2500 — 逐字 STT transcript，取代課文原文）*/}
             <div className="flex-1 p-4">
-              <p className="text-xs font-bold text-on-surface-variant mb-2">課文原文</p>
+              <p className="text-xs font-bold text-on-surface-variant mb-2">你唸的內容</p>
               <p className="text-base leading-relaxed text-on-surface/90">
-                {line}
+                {spokenTranscript && spokenTranscript.trim()
+                  ? spokenTranscript
+                  : <span className="text-on-surface-variant/50">（未擷取到逐字內容）</span>}
               </p>
             </div>
             {/* 右欄：朗讀轉譯（色碼）*/}


### PR DESCRIPTION
## 實作 #2500 — 逐段對照左欄改顯示學生實唸內容

### 需求
逐段朗讀「朗讀對照」左欄原顯示**課文原文**（與上方課文重複），改成顯示**學生一字不漏的實唸內容**，右欄判斷結果不變，方便對照哪裡唸錯。

### 修改
- **ParagraphCard**：新增 `spokenTranscript` prop；對照左欄由 `line` 改為顯示學生逐字 transcript，標題「課文原文」→「你唸的內容」；無資料時顯示「（未擷取到逐字內容）」。右欄朗讀結果維持不變。
- **LiveTutor**：傳入 `savedLineResult?.transcript`。該 transcript 是 `cleaned`，於評估時與 `diffTokens` 一併寫入 `lineResults`（`useParagraphEvaluation.ts:277,296,425`），與右欄 diff 同源、必然對齊。

### 驗證
- `npm run lint`：**0 errors**（既有 warning）
- `npx vitest run`（smoke + live-tutor）：**33 passed**
- ⚠️ 需真實朗讀資料，preview 部署後請確認左欄顯示逐字實唸內容

@claude 請幫我 review 這個 PR
