### PR TITLE
feat(reading): 全文朗讀「你說的」可展開看全文 (#2501)

### DIFF
--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -10,7 +10,7 @@
  * to keep this component focused on the summary score + playback.
  */
 
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { DiffToken } from '../../../types';
 
 const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
@@ -52,13 +52,29 @@ const FullReadingScoreCard: React.FC<FullReadingScoreCardProps> = ({
   const transcriptRef = useRef<HTMLParagraphElement>(null);
   const [showFullTranscript, setShowFullTranscript] = useState(false);
   const [isTranscriptClampable, setIsTranscriptClampable] = useState(false);
-  useLayoutEffect(() => {
+
+  const measureClampable = useCallback(() => {
     // Skip while expanded — clamp is removed so scrollHeight === clientHeight would
     // wrongly read as "not clampable" and hide the button mid-expand.
     if (showFullTranscript) return;
     const el = transcriptRef.current;
     if (el) setIsTranscriptClampable(el.scrollHeight > el.clientHeight + 1);
-  }, [streamingTranscript, showFullTranscript]);
+  }, [showFullTranscript]);
+
+  useLayoutEffect(() => {
+    measureClampable();
+  }, [streamingTranscript, measureClampable]);
+
+  // Issue #2511 (review): re-measure on resize — a short transcript can start
+  // overflowing (or stop) when the container narrows/widens (e.g. tablet rotate),
+  // so the 看全文 button must appear/disappear accordingly.
+  useEffect(() => {
+    const el = transcriptRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => measureClampable());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [measureClampable]);
 
   return (
     <>

--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -10,7 +10,7 @@
  * to keep this component focused on the summary score + playback.
  */
 
-import React from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import { DiffToken } from '../../../types';
 
 const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
@@ -47,6 +47,19 @@ const FullReadingScoreCard: React.FC<FullReadingScoreCardProps> = ({
 }) => {
   const enc = getFullReadingEncouragement(result.matchRate);
 
+  // Issue #2501 — 你說的 transcript is collapsible (default 收合，避免佔版面).
+  // Show the 看全文/收合 toggle only when the text actually overflows the clamp.
+  const transcriptRef = useRef<HTMLParagraphElement>(null);
+  const [showFullTranscript, setShowFullTranscript] = useState(false);
+  const [isTranscriptClampable, setIsTranscriptClampable] = useState(false);
+  useLayoutEffect(() => {
+    // Skip while expanded — clamp is removed so scrollHeight === clientHeight would
+    // wrongly read as "not clampable" and hide the button mid-expand.
+    if (showFullTranscript) return;
+    const el = transcriptRef.current;
+    if (el) setIsTranscriptClampable(el.scrollHeight > el.clientHeight + 1);
+  }, [streamingTranscript, showFullTranscript]);
+
   return (
     <>
       {/* Encouragement stars (Issues #1094, #1097 — no raw numbers shown to students) */}
@@ -69,11 +82,29 @@ const FullReadingScoreCard: React.FC<FullReadingScoreCardProps> = ({
         </p>
       </div>
 
-      {/* 你說的 transcript */}
+      {/* 你說的 transcript — Issue #2501: 完整內容可展開，預設收合 */}
       {streamingTranscript && (
         <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
           <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">你說的</p>
-          <p className="text-base text-on-surface leading-relaxed line-clamp-6">{streamingTranscript}</p>
+          <p
+            ref={transcriptRef}
+            className={`text-base text-on-surface leading-relaxed ${showFullTranscript ? '' : 'line-clamp-6'}`}
+          >
+            {streamingTranscript}
+          </p>
+          {(isTranscriptClampable || showFullTranscript) && (
+            <button
+              type="button"
+              onClick={() => setShowFullTranscript(v => !v)}
+              className="mt-2 inline-flex items-center gap-0.5 text-sm font-bold text-primary hover:underline"
+              aria-expanded={showFullTranscript}
+            >
+              {showFullTranscript ? '收合' : '看全文'}
+              <span className="material-symbols-outlined text-base">
+                {showFullTranscript ? 'expand_less' : 'expand_more'}
+              </span>
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## 實作 #2501 — 全文朗讀「你說的」完整顯示 + 看全文折疊

### 問題
全文朗讀結果的「你說的」transcript 用 `line-clamp-6` 硬截斷，學生看不到完整念的內容。

### 修改
- **FullReadingScoreCard**：
  - 新增 `showFullTranscript` state：收合時 `line-clamp-6`、展開時完整顯示。
  - 「看全文 ▾ / 收合 ▴」toggle 按鈕。
  - 用 ref 量測 `scrollHeight > clientHeight` 判斷內容是否真的溢出——**只有溢出才顯示按鈕**，短內容不會出現多餘的「看全文」。展開中不重新量測，避免 clamp 移除後誤判為不可折疊。

### 驗證
- `npm run lint`：**0 errors**
- `npx vitest run`（smoke + full-reading）：**34 passed**
- ⚠️ 需真實朗讀資料，preview 部署後請確認長 transcript 可展開/收合、短 transcript 不顯示按鈕

@claude 請幫我 review 這個 PR
