### PR TITLE
fix(reading): 全文朗讀「你說的」與「重聽錄音」完成後仍持續保留 (#2503)

### DIFF
--- a/backend/app/routes/learning/learning_save_audio.py
+++ b/backend/app/routes/learning/learning_save_audio.py
@@ -59,6 +59,10 @@ class SaveAudioResponse(BaseModel):
     ok: bool
     audio_gcs_path: str | None = None
     reason: str | None = None
+    # Issue #2503: the attempt row the audio was bound to, so the frontend can
+    # persist it and later request a replay signed URL after the in-memory blob
+    # is gone (e.g. student navigates away and back).
+    attempt_id: int | None = None
 
 
 @router.post(
@@ -199,7 +203,7 @@ async def save_reading_audio(
             current_user.id,
             stored_path,
         )
-        return SaveAudioResponse(ok=True, audio_gcs_path=stored_path)
+        return SaveAudioResponse(ok=True, audio_gcs_path=stored_path, attempt_id=attempt.id)
     except Exception as exc:
         db.rollback()
         logger.warning(

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -7,6 +7,7 @@ import { useKaraoke } from '../../context/KaraokeContext';
 import { useFullReadingSession, type SavedResult } from '../../hooks/useFullReadingSession';
 import { useFullReadingTtsQueue } from '../../hooks/useFullReadingTtsQueue';
 import { useFullReadingResultPersistence } from '../../hooks/useFullReadingResultPersistence';
+import { getReadingAudioSignedUrl } from '../../services/learning/session';
 import ReadingMetricsCard from './full-reading/ReadingMetricsCard';
 import { EvalProgress } from './EvalProgress';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
@@ -68,6 +69,7 @@ const FullReading: React.FC<FullReadingProps> = ({
     userId: user?.id,
     storageKey,
     initialResult,
+    initialTranscript: initialProgress?.transcript,
   });
 
   /* ---- Self-assessment for current attempt (Issue #1386) ---- */
@@ -130,6 +132,12 @@ const FullReading: React.FC<FullReadingProps> = ({
     isTtsPlaying,
   } = useFullReadingTtsQueue({ storyContent: story.content });
 
+  /* ---- Issue #2503: persist the accepted take's attempt id so the recording can be
+   *      replayed from GCS after the in-memory blob is gone (remount). ---- */
+  const [audioAttemptId, setAudioAttemptId] = useState<number | undefined>(
+    () => initialProgress?.audio_attempt_id
+  );
+
   /* ---- STT / recording hook ---- */
   const {
     isSessionActive,
@@ -154,6 +162,7 @@ const FullReading: React.FC<FullReadingProps> = ({
       setStreamingTranscript(transcript);
       setHistoryRefreshKey(k => k + 1);
     }, [setResult, setStreamingTranscript, setHistoryRefreshKey]),
+    onAudioSaved: useCallback((attemptId: number) => setAudioAttemptId(attemptId), []),
   });
 
   /* ---- Issue #2266: In-memory audio replay (same-session).
@@ -228,10 +237,26 @@ const FullReading: React.FC<FullReadingProps> = ({
         },
         self_rating: selfRating,
         transcript: streamingTranscript,
+        audio_attempt_id: audioAttemptId,
       },
       false,
     );
-  }, [result, selfRating, streamingTranscript, onProgressChange]);
+  }, [result, selfRating, streamingTranscript, audioAttemptId, onProgressChange]);
+
+  /* ---- Issue #2503: replay recording from GCS when the in-memory blob is gone.
+   *      After handleFinish + remount, audioRecorder has no blob but the audio was
+   *      uploaded to GCS; fetch a short-lived signed URL via the persisted attempt id
+   *      so 重聽錄音 stays available. ---- */
+  const [persistedAudioUrl, setPersistedAudioUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (audioRecorder.audioUrl) return;           // in-memory blob still available
+    if (!result || !token || dbSessionId == null || audioAttemptId == null) return;
+    let cancelled = false;
+    getReadingAudioSignedUrl(dbSessionId, audioAttemptId, token)
+      .then((url) => { if (!cancelled && url) setPersistedAudioUrl(url); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [audioRecorder.audioUrl, result, token, dbSessionId, audioAttemptId]);
 
   const zhuyinLines = useMemo(
     () => processLinesSelective(story.content, vocabWords),
@@ -422,7 +447,7 @@ const FullReading: React.FC<FullReadingProps> = ({
               <FullReadingScoreCard
                 result={result}
                 streamingTranscript={streamingTranscript}
-                audioUrl={audioRecorder.audioUrl ?? null}
+                audioUrl={audioRecorder.audioUrl ?? persistedAudioUrl}
               />
 
               {/* 朗讀結果 (Issue #1960 — same style as LiveTutor ParagraphCard) */}

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -306,6 +306,11 @@ const FullReading: React.FC<FullReadingProps> = ({
     setResult(null);
     setStreamingTranscript('');
     audioRecorder.clearRecording();
+    // Issue #2503 (review): clear the persisted audio pointer on retry so the next
+    // take's 重聽錄音 can't fetch the PREVIOUS attempt's recording if this take's
+    // upload callback hasn't landed yet (張冠李戴 race).
+    setAudioAttemptId(undefined);
+    setPersistedAudioUrl(null);
     setSelfRating(undefined);
     setShowComparison(false);
     clearFallbackReason();

--- a/frontend/src/hooks/useFullReadingResultPersistence.ts
+++ b/frontend/src/hooks/useFullReadingResultPersistence.ts
@@ -33,6 +33,9 @@ interface UseFullReadingResultPersistenceProps {
   storageKey: string;
   /** Session-level result rehydrated from DB (Bug #1320 — fallback when localStorage is cleared). */
   initialResult?: FullReadingResult | null;
+  /** Issue #2503: transcript rehydrated from DB step_data — fallback when localStorage
+   *  is cleared (handleFinish removes it) so 你說的 doesn't vanish on remount. */
+  initialTranscript?: string;
 }
 
 interface UseFullReadingResultPersistenceReturn {
@@ -52,6 +55,7 @@ export function useFullReadingResultPersistence({
   userId,
   storageKey,
   initialResult,
+  initialTranscript,
 }: UseFullReadingResultPersistenceProps): UseFullReadingResultPersistenceReturn {
   /* ---- Bug #1320 Bug 3: Derive initial result priority:
    *   1. localStorage (same-browser persistence, most complete — has diffTokens)
@@ -83,7 +87,9 @@ export function useFullReadingResultPersistence({
 
   const [result, setResult] = useState<SavedResult | null>(getInitialResult);
   const [streamingTranscript, setStreamingTranscript] = useState(
-    () => savedProgress.current?.transcript ?? ''
+    // Issue #2503: localStorage wins (most recent), else DB step_data transcript,
+    // so 你說的 survives handleFinish's localStorage clear + remount.
+    () => savedProgress.current?.transcript ?? initialTranscript ?? ''
   );
   const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
 

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -84,6 +84,9 @@ interface UseFullReadingSessionProps {
   dbSessionId?: number | null;
   stopTtsAll: () => void;
   onResultReady: (result: SavedResult, transcript: string) => void;
+  /** Issue #2503: fired when the accepted take's audio is persisted to GCS, so the
+   *  caller can remember the attempt id and replay the recording after remount. */
+  onAudioSaved?: (attemptId: number) => void;
 }
 
 interface UseFullReadingSessionReturn {
@@ -115,6 +118,7 @@ export function useFullReadingSession({
   dbSessionId,
   stopTtsAll,
   onResultReady,
+  onAudioSaved,
 }: UseFullReadingSessionProps): UseFullReadingSessionReturn {
   const [isPreparing, setIsPreparing] = useState(false);
   const [isSessionActive, setIsSessionActive] = useState(false);
@@ -226,6 +230,11 @@ export function useFullReadingSession({
       // Fail-safe: .catch() ensures upload failure never affects score display.
       if (token && dbSessionId != null) {
         saveReadingAudio(capturedAudioBlob, dbSessionId, undefined, token)
+          .then((res) => {
+            // Issue #2503: remember the attempt id so the recording can be replayed
+            // from GCS after the in-memory blob is gone (student navigates away/back).
+            if (res.ok && res.attempt_id != null) onAudioSaved?.(res.attempt_id);
+          })
           .catch((err) => console.warn('[FullReading] saveReadingAudio error:', err));
       }
 
@@ -277,7 +286,7 @@ export function useFullReadingSession({
       // No token — cannot reach Gemini.
       setMicError('未偵測到語音，請重試。');
     }
-  }, [fullText, stopSession, token, storyId, dbSessionId, onResultReady, audioRecorder.stopAndGetBlob, audioRecorder.getPeakVolume]);
+  }, [fullText, stopSession, token, storyId, dbSessionId, onResultReady, onAudioSaved, audioRecorder.stopAndGetBlob, audioRecorder.getPeakVolume]);
 
   return {
     isSessionActive,

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -132,6 +132,11 @@ export function useFullReadingSession({
 
   const isSessionActiveRef = useRef(false);
   const startTimeRef       = useRef<number>(0);
+  // Issue #2503 (review): monotonic recording generation — bumped on each startSession.
+  // submitReading captures the current gen; the deferred saveReadingAudio callback only
+  // reports its attempt_id if the gen still matches, so a slow upload from a previous
+  // take can't overwrite a newer take's attempt id (張冠李戴 race).
+  const recordingGenRef = useRef(0);
 
   const audioRecorder = useAudioRecorder(120);
 
@@ -153,6 +158,7 @@ export function useFullReadingSession({
     setMicError('');
 
     // Immediately activate — no Web Speech handshake needed.
+    recordingGenRef.current += 1; // Issue #2503: new take → invalidate prior upload callbacks
     startTimeRef.current = Date.now();
     isSessionActiveRef.current = true;
     setIsSessionActive(true);
@@ -178,6 +184,7 @@ export function useFullReadingSession({
     /* #1632 double-click guard: isSessionActiveRef is flipped synchronously. */
     if (!isSessionActiveRef.current) return;
     const durationMs = Date.now() - startTimeRef.current;
+    const submitGen = recordingGenRef.current; // Issue #2503: tie this take's async upload to its generation
     stopSession();
 
     /* P1#2: stop recorder FIRST (before any early-return) so the mic is always
@@ -233,7 +240,11 @@ export function useFullReadingSession({
           .then((res) => {
             // Issue #2503: remember the attempt id so the recording can be replayed
             // from GCS after the in-memory blob is gone (student navigates away/back).
-            if (res.ok && res.attempt_id != null) onAudioSaved?.(res.attempt_id);
+            // Ignore a stale callback from a superseded take (review): if the student
+            // re-recorded before this upload resolved, recordingGenRef has advanced.
+            if (res.ok && res.attempt_id != null && recordingGenRef.current === submitGen) {
+              onAudioSaved?.(res.attempt_id);
+            }
           })
           .catch((err) => console.warn('[FullReading] saveReadingAudio error:', err));
       }

--- a/frontend/src/services/learning/session.ts
+++ b/frontend/src/services/learning/session.ts
@@ -147,7 +147,7 @@ export async function saveReadingAudio(
   sessionId: number,
   attemptId?: number,
   token?: string,
-): Promise<{ ok: boolean; audio_gcs_path?: string }> {
+): Promise<{ ok: boolean; audio_gcs_path?: string; attempt_id?: number }> {
   if (!token) {
     console.warn('[saveReadingAudio] no token — skipping upload');
     return { ok: false };
@@ -172,6 +172,7 @@ export async function saveReadingAudio(
     return {
       ok: data?.ok === true,
       audio_gcs_path: typeof data?.audio_gcs_path === 'string' ? data.audio_gcs_path : undefined,
+      attempt_id: typeof data?.attempt_id === 'number' ? data.attempt_id : undefined,
     };
   } catch (err) {
     console.warn('[saveReadingAudio] error:', err);

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -105,6 +105,9 @@ export interface FullReadingStepData {
   self_rating?: number;
   /** Raw streaming transcript captured during evaluation. */
   transcript?: string;
+  /** Issue #2503: ReadingAttemptHistory id the GCS audio was bound to — lets the
+   *  student replay their recording after the in-memory blob is gone (remount). */
+  audio_attempt_id?: number;
 }
 
 /** Step 7 — AssessmentReport. */


### PR DESCRIPTION
## 修復 #2503 — 全文朗讀「你說的」與「重聽錄音」完成後消失

### 根因
`handleFinish` 會 `localStorage.removeItem(storageKey)`，而：
- `streamingTranscript`（你說的）只從 localStorage 還原
- 「重聽錄音」用的是記憶體 blob URL（`audioRecorder.audioUrl`）

→ 完成朗讀後再進入全文朗讀（remount），`result` 仍能從 DB 還原（所以分數/朗讀結果還在），但**你說的變空、重聽錄音消失**，正好符合「這兩個欄位消失、其餘還在」。

### 修改
- **transcript 持久化**：`useFullReadingResultPersistence` 新增 `initialTranscript`，localStorage 被清後改從 DB `step_data.transcript` 還原（FullReading 傳入 `initialProgress?.transcript`）。
- **錄音持久化**：錄音其實已上傳 GCS。
  - backend `SaveAudioResponse` 新增 `attempt_id`（optional，向後相容）。
  - frontend `saveReadingAudio` 回傳 `attempt_id`；`useFullReadingSession` 新增 `onAudioSaved` callback 把它送出。
  - FullReading 記住 `audioAttemptId` 並存進 `step_data.audio_attempt_id`；remount 且無記憶體 blob 時，用 `getReadingAudioSignedUrl(sessionId, attemptId)` 取回 GCS 簽名網址回放。
  - `FullReadingStepData` 型別新增 `audio_attempt_id`。

### 驗證
- `npm run lint`：**0 errors**（既有 warning）
- `npx tsc`：本 PR 改動檔無新型別錯誤
- `npx vitest run`（smoke + full-reading + hooks）：**82 passed**
- ⚠️ 本地無 pytest（backend deps 未安裝），後端改動僅為附加 optional response 欄位，向後相容；請於 CI/preview 確認
- ⚠️ 需真實朗讀 + 導頁往返驗證，preview 部署後請確認完成後再進全文朗讀，你說的＋重聽錄音都還在

@claude 請幫我 review 這個 PR
