### PR TITLE
fix(reading): 錄音播放進度條可拖拉快轉並顯示時長 (#2499)

### DIFF
--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { DiffToken } from '../../../types';
+import AudioPlayer from '../../ui/AudioPlayer';
 
 const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
   { min: 0.90, stars: 5, text: '太厲害了！',         color: 'text-emerald-600' },
@@ -81,7 +82,8 @@ const FullReadingScoreCard: React.FC<FullReadingScoreCardProps> = ({
       {audioUrl && (
         <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
           <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">重聽錄音</p>
-          <audio src={audioUrl} controls className="w-full h-10" aria-label="播放您的朗讀錄音" />
+          {/* Issue #2499: custom seekable player — native <audio> can't seek WebM (Infinity duration) */}
+          <AudioPlayer src={audioUrl} aria-label="播放您的朗讀錄音" />
         </div>
       )}
     </>

--- a/frontend/src/components/ui/AudioPlayer.tsx
+++ b/frontend/src/components/ui/AudioPlayer.tsx
@@ -1,0 +1,132 @@
+/**
+ * AudioPlayer — seekable audio player with a working progress bar (Issue #2499).
+ *
+ * The native <audio controls> is broken for MediaRecorder WebM blobs: those blobs
+ * carry no duration metadata, so `audio.duration` is Infinity → the browser's
+ * progress bar can't be dragged and no total length is shown.
+ *
+ * This component:
+ *   - forces the browser to compute the real duration (the Infinity → seek-to-end
+ *     → reset trick), so the total length and a draggable seek bar both work;
+ *   - shows 目前時間 / 總時長;
+ *   - lets the student drag the bar to scrub anywhere in the recording.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+function formatClock(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export interface AudioPlayerProps {
+  src: string;
+  className?: string;
+  'aria-label'?: string;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, className = '', 'aria-label': ariaLabel }) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  // Guards the one-shot WebM duration-fix so it doesn't loop.
+  const durationFixDoneRef = useRef(false);
+
+  // Reset when the source changes.
+  useEffect(() => {
+    durationFixDoneRef.current = false;
+    setIsPlaying(false);
+    setDuration(0);
+    setCurrentTime(0);
+  }, [src]);
+
+  const handleLoadedMetadata = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (el.duration === Infinity || Number.isNaN(el.duration)) {
+      // WebM-from-MediaRecorder: force the browser to compute the real duration by
+      // seeking past the end once; the resulting 'timeupdate' reports a finite value.
+      if (durationFixDoneRef.current) return;
+      durationFixDoneRef.current = true;
+      const onFixTimeUpdate = () => {
+        el.removeEventListener('timeupdate', onFixTimeUpdate);
+        el.currentTime = 0;
+        setDuration(Number.isFinite(el.duration) ? el.duration : 0);
+      };
+      el.addEventListener('timeupdate', onFixTimeUpdate);
+      el.currentTime = 1e101;
+    } else {
+      setDuration(el.duration);
+    }
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (el.paused) {
+      el.play().then(() => setIsPlaying(true)).catch(() => setIsPlaying(false));
+    } else {
+      el.pause();
+      setIsPlaying(false);
+    }
+  }, []);
+
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = audioRef.current;
+    if (!el) return;
+    const next = Number(e.target.value);
+    el.currentTime = next;
+    setCurrentTime(next);
+  }, []);
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <audio
+        ref={audioRef}
+        src={src}
+        preload="metadata"
+        aria-label={ariaLabel}
+        onLoadedMetadata={handleLoadedMetadata}
+        onTimeUpdate={() => {
+          const el = audioRef.current;
+          // Ignore the transient huge currentTime from the duration-fix seek.
+          if (el && Number.isFinite(el.currentTime) && el.currentTime < 1e100) {
+            setCurrentTime(el.currentTime);
+          }
+        }}
+        onEnded={() => { setIsPlaying(false); setCurrentTime(0); }}
+        onPause={() => setIsPlaying(false)}
+        onPlay={() => setIsPlaying(true)}
+      />
+      <button
+        type="button"
+        onClick={togglePlay}
+        className="shrink-0 w-10 h-10 rounded-full bg-primary text-on-primary flex items-center justify-center active:scale-[0.98] transition-all"
+        aria-label={isPlaying ? '暫停' : '播放'}
+      >
+        <span className="material-symbols-outlined" style={{ fontVariationSettings: "'FILL' 1" }}>
+          {isPlaying ? 'pause' : 'play_arrow'}
+        </span>
+      </button>
+      <input
+        type="range"
+        min={0}
+        max={duration || 0}
+        step={0.1}
+        value={Math.min(currentTime, duration || 0)}
+        onChange={handleSeek}
+        className="flex-1 accent-primary cursor-pointer"
+        aria-label="播放進度，可拖拉快轉"
+        disabled={!duration}
+      />
+      <span className="shrink-0 text-xs font-mono text-on-surface-variant tabular-nums">
+        {formatClock(currentTime)} / {duration ? formatClock(duration) : '--:--'}
+      </span>
+    </div>
+  );
+};
+
+export default AudioPlayer;

--- a/frontend/src/components/ui/AudioPlayer.tsx
+++ b/frontend/src/components/ui/AudioPlayer.tsx
@@ -34,14 +34,28 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, className = '', 'aria-la
   const [currentTime, setCurrentTime] = useState(0);
   // Guards the one-shot WebM duration-fix so it doesn't loop.
   const durationFixDoneRef = useRef(false);
+  // Holds the pending duration-fix 'timeupdate' listener so it can be removed on
+  // src change / unmount (review #2513): otherwise a stale listener left on the
+  // reused <audio> node could reset a new recording's currentTime to 0.
+  const fixListenerRef = useRef<(() => void) | null>(null);
 
-  // Reset when the source changes.
+  const removeFixListener = useCallback(() => {
+    const el = audioRef.current;
+    if (el && fixListenerRef.current) {
+      el.removeEventListener('timeupdate', fixListenerRef.current);
+    }
+    fixListenerRef.current = null;
+  }, []);
+
+  // Reset when the source changes; also drop any pending duration-fix listener
+  // (and on unmount) so it never fires against a different recording.
   useEffect(() => {
     durationFixDoneRef.current = false;
     setIsPlaying(false);
     setDuration(0);
     setCurrentTime(0);
-  }, [src]);
+    return removeFixListener;
+  }, [src, removeFixListener]);
 
   const handleLoadedMetadata = useCallback(() => {
     const el = audioRef.current;
@@ -52,16 +66,17 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, className = '', 'aria-la
       if (durationFixDoneRef.current) return;
       durationFixDoneRef.current = true;
       const onFixTimeUpdate = () => {
-        el.removeEventListener('timeupdate', onFixTimeUpdate);
+        removeFixListener();
         el.currentTime = 0;
         setDuration(Number.isFinite(el.duration) ? el.duration : 0);
       };
+      fixListenerRef.current = onFixTimeUpdate;
       el.addEventListener('timeupdate', onFixTimeUpdate);
       el.currentTime = 1e101;
     } else {
       setDuration(el.duration);
     }
-  }, []);
+  }, [removeFixListener]);
 
   const togglePlay = useCallback(() => {
     const el = audioRef.current;
@@ -83,12 +98,11 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, className = '', 'aria-la
   }, []);
 
   return (
-    <div className={`flex items-center gap-3 ${className}`}>
+    <div className={`flex items-center gap-3 ${className}`} role="group" aria-label={ariaLabel}>
       <audio
         ref={audioRef}
         src={src}
         preload="metadata"
-        aria-label={ariaLabel}
         onLoadedMetadata={handleLoadedMetadata}
         onTimeUpdate={() => {
           const el = audioRef.current;


### PR DESCRIPTION
## 修復 #2499 — 錄音播放進度條無法拖拉、看不到時長

### 根因
原生 `<audio controls>` 對 MediaRecorder 產生的 WebM blob 無效：WebM 沒有 duration metadata → `audio.duration = Infinity` → 進度條拖不動、也顯示不出錄音長度。

### 修改
- 新增共用 **`AudioPlayer`** 元件（`components/ui/AudioPlayer.tsx`）：
  - **WebM duration 修正**：偵測到 `Infinity/NaN` 時用「seek 到極大值 → 觸發瀏覽器計算 → 讀回 duration → reset 為 0」的標準 hack（一次性、有 ref guard 防迴圈）。
  - **可拖拉 seekbar**（`input[type=range]`）快轉/倒退到任意位置。
  - 顯示 **目前時間 / 總時長**。
- `FullReadingScoreCard`「重聽錄音」改用 `AudioPlayer` 取代原生 `<audio controls>`。

> 逐段朗讀評估前的「▶ 播放錄音」是暫時試聽按鈕（非持久進度條），且該檔對 stopPlaybackSync 有 TDZ 敏感度（#2279），本 PR 不動它，聚焦修全文那個壞掉的進度條。

### 驗證
- `npm run lint`：**0 errors**
- `npx tsc`：改動檔無型別錯誤
- `npx vitest run`（smoke + full-reading + ui）：**52 passed**
- ⚠️ 需真實錄音，preview 部署後請確認進度條可拖拉、顯示正確總長度

@claude 請幫我 review 這個 PR
