### PR TITLE
feat(reading): 朗讀頁改左課文／右 AI 判斷雙欄排版 (#2502)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -383,9 +383,32 @@ const FullReading: React.FC<FullReadingProps> = ({
 
       {/* ── Single-column centered layout ─────────────────────────────── */}
       <div className="flex-1 overflow-y-auto pb-48 custom-scrollbar">
-        <div className="max-w-4xl mx-auto px-6 md:px-16 pt-4">
+        <div className={`mx-auto px-6 md:px-16 pt-4 ${result ? 'max-w-6xl' : 'max-w-4xl'}`}>
 
-          {/* Full text card */}
+          {/* I4 (Issue #2156): Gemini fallback alert banner — 置於雙欄之上（全寬） */}
+          {fallbackReason && result && (
+            <div className="mt-6 flex items-start gap-3 px-5 py-4 rounded-2xl bg-amber-50 border border-amber-300 shadow-sm">
+              <span className="material-symbols-outlined text-amber-600 shrink-0 mt-0.5">warning</span>
+              <div className="flex-1">
+                <p className="text-base font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
+                <p className="text-sm text-amber-700 mt-0.5">
+                  AI 音訊分析未能完成（{fallbackReason}），評分僅依瀏覽器語音辨識，準確度較低。建議重試以獲得精準評分。
+                </p>
+              </div>
+              <button
+                onClick={clearFallbackReason}
+                className="text-amber-600 hover:text-amber-800 transition-colors shrink-0 mt-0.5"
+                aria-label="關閉提示"
+              >
+                <span className="material-symbols-outlined text-base">close</span>
+              </button>
+            </div>
+          )}
+
+          {/* Issue #2502: 完成後左課文／右 AI 判斷雙欄；未完成時課文單欄，窄螢幕自動堆疊 */}
+          <div className={result ? 'grid lg:grid-cols-2 gap-6 items-start' : ''}>
+
+          {/* 左欄：Full text card（全文課文）*/}
           <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-10 mt-4">
             {/* Instructions */}
             {!result && !isSessionActive && !isPreparing && !isTtsPlaying && (
@@ -420,34 +443,11 @@ const FullReading: React.FC<FullReadingProps> = ({
                 </div>
               ))}
             </div>
-          </div>
+          </div>{/* /左欄課文卡 */}
 
-
-          {/* I4 (Issue #2156): Gemini fallback alert banner — must be visible, never silent.
-              Shown when backend returns method='fallback' so user knows the result is
-              based on Web Speech only (lower quality) and can retry for a better score. */}
-          {fallbackReason && result && (
-            <div className="mt-6 flex items-start gap-3 px-5 py-4 rounded-2xl bg-amber-50 border border-amber-300 shadow-sm">
-              <span className="material-symbols-outlined text-amber-600 shrink-0 mt-0.5">warning</span>
-              <div className="flex-1">
-                <p className="text-base font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
-                <p className="text-sm text-amber-700 mt-0.5">
-                  AI 音訊分析未能完成（{fallbackReason}），評分僅依瀏覽器語音辨識，準確度較低。建議重試以獲得精準評分。
-                </p>
-              </div>
-              <button
-                onClick={clearFallbackReason}
-                className="text-amber-600 hover:text-amber-800 transition-colors shrink-0 mt-0.5"
-                aria-label="關閉提示"
-              >
-                <span className="material-symbols-outlined text-base">close</span>
-              </button>
-            </div>
-          )}
-
-          {/* ── Result section ──────────────────────────────────────── */}
+          {/* ── 右欄：AI 判斷結果（Issue #2502）──────────────────────── */}
           {result && (
-            <div ref={resultRef} className="mt-6 space-y-6">
+            <div ref={resultRef} className="space-y-6 mt-4">
               {/* Stars + encouragement + transcript + audio (Issue #1960 — FullReadingScoreCard) */}
               <FullReadingScoreCard
                 result={result}
@@ -510,6 +510,7 @@ const FullReading: React.FC<FullReadingProps> = ({
               )}
             </div>
           )}
+          </div>{/* /grid 左課文右判斷（Issue #2502）*/}
         </div>
       </div>
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -681,6 +681,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     paragraphSummary,
     hideStaleEval,
   );
+  // Issue #2502 (review): widen the container when ParagraphCard shows the
+  // left課文/right判斷 two-column, so the right column isn't cramped at lg.
+  const showEvalColumn = !!(displayLastDiffTokens || displayParagraphSummary);
 
   /* ================================================================ */
   /*  JSX                                                             */
@@ -693,7 +696,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     >
       {/* ── Single-column centered layout ──────────────────────────────── */}
       <div className="flex-1 overflow-y-auto pb-48" style={{ scrollbarWidth: 'thin' }}>
-        <div className="max-w-4xl mx-auto px-6 md:px-16 pt-4">
+        <div className={`mx-auto px-6 md:px-16 pt-4 ${showEvalColumn ? 'max-w-6xl' : 'max-w-4xl'}`}>
           <div className="mt-4" ref={activeLineRef}>
             <ParagraphCard
               idx={currentLineIndex}

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -155,6 +155,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
     return getEncouragement(paragraphSummary.matchRate);
   }, [paragraphSummary?.matchRate]);
 
+  // Issue #2502: 有評估結果時課文（左）／AI 判斷（右）左右分欄；否則課文單欄。
+  const showEvalColumn = !!((readingResultTokens && !isSessionActive) || paragraphSummary);
+
   return (
     <div
       className={`transition-all duration-500 rounded-3xl p-5 md:p-14 ${
@@ -196,6 +199,12 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           }}
         />
       </div>
+
+      {/* Issue #2502: 左課文／右 AI 判斷雙欄（有評估結果時）；窄螢幕自動堆疊 */}
+      <div className={showEvalColumn ? 'grid lg:grid-cols-2 gap-8 items-start' : ''}>
+
+      {/* ── 左欄：該段課文 ── */}
+      <div>
 
       {/* Paragraph text — with TTS character highlight */}
       <p
@@ -247,6 +256,12 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           </button>
         </div>
       )}
+
+      </div>{/* /左欄課文（Issue #2502）*/}
+
+      {/* ── 右欄：AI 判斷結果（對照 + 摘要）（Issue #2502）── */}
+      {showEvalColumn && (
+      <div className="space-y-2">
 
       {/* ── Painpoint 4: 原文 vs 朗讀結果 — 左右並陳（桌機），上下排（手機） ── */}
       {readingResultTokens && !isSessionActive && (
@@ -447,6 +462,11 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           })()}
         </div>
       )}
+
+      </div>
+      )}{/* /右欄 AI 判斷（Issue #2502）*/}
+
+      </div>{/* /grid 左課文右判斷（Issue #2502）*/}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -261,7 +261,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
       {/* ── 右欄：AI 判斷結果（對照 + 摘要）（Issue #2502）── */}
       {showEvalColumn && (
-      <div className="space-y-2">
+      <div>
 
       {/* ── Painpoint 4: 原文 vs 朗讀結果 — 左右並陳（桌機），上下排（手機） ── */}
       {readingResultTokens && !isSessionActive && (
@@ -270,8 +270,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           <div className="px-4 pt-3 pb-2 border-b border-on-surface/5">
             <ReadingDiffLegend />
           </div>
-          {/* 左右並陳 (md+) / 上下排 (sm) */}
-          <div className="flex flex-col md:flex-row divide-y md:divide-y-0 md:divide-x divide-on-surface/8">
+          {/* Issue #2502: 移到右欄後改為永遠上下排（你唸的／朗讀結果），
+              避免在窄的右欄內再被 md:flex-row 二度切欄導致中文擠壓 */}
+          <div className="flex flex-col divide-y divide-on-surface/8">
             {/* 左欄：學生實際唸的內容（Issue #2500 — 逐字 STT transcript，取代課文原文）*/}
             <div className="flex-1 p-4">
               <p className="text-xs font-bold text-on-surface-variant mb-2">你唸的內容</p>


### PR DESCRIPTION
## 實作 #2502 — 朗讀頁排版：左課文／右 AI 判斷

依需求，逐段與全文朗讀改為左右分欄：**左邊課文、右邊 AI 判斷結果**，窄螢幕（<lg）自動堆疊回單欄。

### 修改
- **FullReading（全文）**：有結果時容器加寬 `max-w-6xl` + `grid lg:grid-cols-2`；
  - 左欄＝全文課文卡
  - 右欄＝AI 判斷（分數星等 / 朗讀結果色碼 / 重聽錄音 / 統計 / 自評 / 進度圖）
  - Gemini fallback 提示移到雙欄之上（全寬）
- **ParagraphCard（逐段）**：header + 進度條全寬置頂；有評估結果時 `grid lg:grid-cols-2`：
  - 左欄＝該段課文
  - 右欄＝AI 判斷（你唸的對照 + 摘要/分數/重練）
  - 尚未評估（朗讀中/未讀）時課文維持單欄

### Frontend Render-Safety Verification（#2289 net）
- ESLint：✅ **0 errors**（`npm run lint`；僅既有 warning）
- vitest smoke：✅ **14/14 pass**（`src/__smoke__/`，含 LiveTutorControls mount）
- 全 reading-steps 測試：357 passed / 23 failed —— 23 個全為 staging **既有** baseline 失敗（FillInBlank/MultipleChoice/Vocab* 等，與本 PR 無關），**零新增失敗**
- ⚠️ /qa 截圖 + console：preview 部署後補（見下方 comment）

### 待 preview QA
朗讀流程需真麥克風，請在 preview 用學生小明登入後，於 `/learn/{id}/tutor`（逐段）與 `/learn/{id}/full-reading`（全文）確認左右分欄、窄螢幕堆疊、console 乾淨。

@claude 請幫我 review 這個 PR
