### PR TITLE
fix(spotlight): resolve AI-lesson paths under app root so 聚光燈 renders on staging (#2515)

### DIFF
--- a/backend/app/services/lesson_content_loader.py
+++ b/backend/app/services/lesson_content_loader.py
@@ -58,16 +58,27 @@ from app.services.lesson_code_normalization import catalog_to_parsed_code
 
 logger = logging.getLogger(__name__)
 
-# scripts/ (adapter lives here, alongside the rest of the EDD bridge tooling).
-_REPO_ROOT = Path(__file__).resolve().parents[3]
+# Path bases. This file is backend/app/services/<name>.py, so parent.parent.parent
+# is the `backend/` package root in the repo AND `/app` in the deployed container
+# (Dockerfile: WORKDIR /app, `COPY app/ ./app/` + `COPY data/ ./data/`).
+# #2515: the previous `parents[3]` + literal "backend/" prefix assumed the REPO
+# layout, so in the container it resolved to `/backend/data/...` (nonexistent) →
+# _try_ai_lesson silently returned None → lesson_content:null → the new 聚光燈
+# never rendered on staging (worked in CI/local because the repo layout matched).
+# This mirrors the container-proven base used by spotlight_contract.py /
+# curriculum_qa_*.py (`parent.parent.parent / "data" / ...`, no "backend/" prefix).
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent.parent
+# scripts/ (adapter lives here) is NOT copied into the container image; the adapter
+# fallback is repo/local-only. _try_ai_lesson (the AI-lesson path) needs no scripts.
+_REPO_ROOT = _BACKEND_ROOT.parent
 _SCRIPTS_DIR = _REPO_ROOT / "scripts"
 # AI-extracted spotlight lessons (ai-lesson-extract skill). When present for a lesson
 # code, these are PREFERRED over the deterministic bridge adapter so the real
 # reading-strategy page renders the AI-produced 聚光燈. Still flag-gated + fail-safe.
-_AI_LESSONS_DIR = _REPO_ROOT / "backend" / "data" / "lessons" / "_ai_lessons"
+_AI_LESSONS_DIR = _BACKEND_ROOT / "data" / "lessons" / "_ai_lessons"
 
 
-_PARSED_DIR = _REPO_ROOT / "backend" / "data" / "lessons" / "_parsed_2026-05-01"
+_PARSED_DIR = _BACKEND_ROOT / "data" / "lessons" / "_parsed_2026-05-01"
 
 
 def _load_canonical_parsed(code: str) -> Optional[dict]:

--- a/backend/tests/test_lesson_content_loader.py
+++ b/backend/tests/test_lesson_content_loader.py
@@ -356,3 +356,41 @@ def test_supply_regression_all_spotlight_stories(monkeypatch):
         except Exception as e:  # noqa: BLE001
             failures.append(f"{story['id']}: schema-fail ({e})")
     assert not failures, "supply regression failures:\n" + "\n".join(failures)
+
+
+# ── #2515: container-path resolution for the AI-lesson override ───────────────
+# Paths must resolve under the app package root (parent.parent.parent of the
+# module), NOT via the repo-only `parents[3] + "backend/"` form which broke in the
+# deployed container: /app/app/services → parents[3]=/ → /backend/data (nonexistent)
+# → _try_ai_lesson silently returned None → lesson_content:null → the new 聚光燈
+# never rendered on staging. CI/local passed because the repo layout matched.
+
+def test_ai_lessons_dir_container_safe_derivation():
+    """The AI-lessons dir derives from the app package root so it lands on
+    <repo>/backend/data locally AND /app/data in the container. Guards #2515."""
+    assert (
+        L._AI_LESSONS_DIR
+        == Path(L.__file__).resolve().parent.parent.parent / "data" / "lessons" / "_ai_lessons"
+    )
+    assert L._AI_LESSONS_DIR.exists(), f"{L._AI_LESSONS_DIR} must exist in this env"
+    assert (L._AI_LESSONS_DIR / "G6-L22.lesson.yml").exists()
+    # Simulate the deployed container path (Dockerfile: WORKDIR /app, COPY app/ ./app/,
+    # COPY data/ ./data/). Correct derivation → /app/data; the old buggy one → /backend/data.
+    container_file = Path("/app/app/services/lesson_content_loader.py")
+    correct = container_file.parent.parent.parent / "data" / "lessons" / "_ai_lessons"
+    buggy = container_file.parents[3] / "backend" / "data" / "lessons" / "_ai_lessons"
+    assert correct == Path("/app/data/lessons/_ai_lessons")
+    assert buggy == Path("/backend/data/lessons/_ai_lessons")  # the #2515 breakage
+    assert correct != buggy
+
+
+def test_ai_lesson_override_serves_content(monkeypatch):
+    """#2515 end-to-end: an AI-extracted lesson (has _ai_lessons/<code>.lesson.yml)
+    serves typed lesson_content via _try_ai_lesson (needs only yaml+schema, no
+    scripts/adapter). If the path base regresses, this returns None and fails."""
+    monkeypatch.delenv("LESSON_RENDERER_V1", raising=False)  # default ON
+    story = next(s for s in get_all_lessons() if s.get("grade_code") == "G6-L22")
+    out = L.get_lesson_content(story)
+    assert out is not None, "G6-L22 has an _ai_lessons file → must serve lesson_content"
+    assert out.get("blocks"), "served lesson_content must carry blocks"
+    Lesson.model_validate(out)  # contract-valid


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2515 — 啟翔 reported the new 聚光燈 (LESSON_RENDERER_V1) merged but never actually rendered on staging. He was right: it's an environment/deployment bug, not his content.

## Root cause (deterministic)
`backend/app/services/lesson_content_loader.py` derived data paths from the **repo layout**:
```python
_REPO_ROOT = Path(__file__).resolve().parents[3]
_AI_LESSONS_DIR = _REPO_ROOT / "backend" / "data" / "lessons" / "_ai_lessons"
```
In the deployed container (`Dockerfile`: `WORKDIR /app`, `COPY app/ ./app/` + `COPY data/ ./data/`), the module lives at `/app/app/services/…`, so `parents[3]` = `/` and the literal `"backend/"` prefix makes it resolve to `/backend/data/lessons/_ai_lessons` — which does not exist. `_try_ai_lesson` then **silently** returns `None` → the story-detail API serves `lesson_content: null` → the frontend falls back to the legacy renderer for every AI lesson. CI/local passed because the repo layout matched.

## Fix
Base data paths on the app-package root (`parent.parent.parent` → `backend/` in the repo, `/app` in the container), no `"backend/"` prefix — matching the container-proven pattern already used by `spotlight_contract.py` / `curriculum_qa_*.py`.

## Evidence
- Served `staging /api/stories/1076` returned `lesson_content` key **present-but-null** with `grade_code="G6-L22"`; files are git-tracked and shipped via `COPY data/`; backend revision post-dates the merge; no exception logged (silent path-miss) → path-derivation is the only explanation.
- `pytest` **109 passed** (107 + 2 new #2515 regression tests):
  - `test_ai_lessons_dir_container_safe_derivation` — asserts the derivation is container-safe and pins the `/app/…` vs buggy `/backend/…` math.
  - `test_ai_lesson_override_serves_content` — end-to-end: G6-L22 story → `get_lesson_content` returns validated blocks.

## Out of scope (follow-up)
`scripts/` is not `COPY`ed into the image, so the non-AI-lesson adapter path stays repo-only. Only affects `spotlight_v2` stories without an `_ai_lessons` YAML; tracked separately.

## Verification plan post-merge
After staging deploy: `curl staging /api/stories/1076` → confirm `lesson_content` is **populated with blocks** (not null), then real-browser /qa of the 聚光燈 step. Will NOT claim fixed until staging actually serves populated content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)