### PR TITLE
fix(testset): _LIST_CAP 500→100k 避免 owner 列表截斷漏掉貢獻者錄音 (#2524)

### DIFF
--- a/backend/app/routes/testset.py
+++ b/backend/app/routes/testset.py
@@ -50,7 +50,13 @@ _ALLOWED_MIME = {"audio/webm", "audio/ogg", "audio/mp4", "audio/mpeg", "audio/wa
 _ALLOWED_VERSION = {"correct", "error"}
 # lesson_id 進 GCS path → 必須白名單格式，否則可 ../ 跨 prefix 寫入學生錄音 (security #2304)
 _LESSON_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,20}$")
-_LIST_CAP = 500  # list_blobs hard cap，避免 unbounded read/signBlob
+# list_blobs 上限。原本 500 是「硬砍」：GCS 照物件名字典序回傳，一旦 test-dataset/
+# 底下 blob 總數超過 500（每筆錄音佔 2~3 個：.webm/.json/.eval.json，約 166 筆就觸頂），
+# 名字碼位偏後的貢獻者（中文名如「陳」U+9673、「睿」U+777F 排在英文名/「小明」之後）
+# 會整批被截掉、在 owner 列表消失（資料仍在 GCS，只是沒列出來）(#2524)。
+# 改成實務上「一定用不完」的大上限：不再截斷真實資料，仍保留防跑掉的最終 backstop；
+# list_blobs(max_results=N) 會由 SDK 自動分頁讀完全部。
+_LIST_CAP = 100_000
 
 # 批次評估單次硬上限：每次最多評 N 筆（cost guard，#2340）
 # Gemini transcribe 每筆約 2-5s，30 筆 = ~150s；超過截斷並回 truncated:true

--- a/backend/tests/test_testset_list_cap.py
+++ b/backend/tests/test_testset_list_cap.py
@@ -1,0 +1,144 @@
+"""Regression lock for testset owner list truncation (#2524).
+
+`GET /api/testset/recordings` had a hard-coded `_LIST_CAP = 500` passed to
+`list_blobs(max_results=...)`. GCS returns objects in lexicographic name order,
+so once `test-dataset/` held >500 blobs (each recording = 2~3 blobs), contributors
+whose name sorted late (high-codepoint CJK like 陳/睿) were silently dropped from
+the owner dashboard even though the audio was still in GCS.
+
+These tests lock the fix:
+  1. `_LIST_CAP` is a practically-unlimited value (won't truncate real data).
+  2. the endpoint passes that high cap to `list_blobs` (no low ceiling sneaks back).
+  3. the endpoint returns ALL metas the bucket yields — no app-side `[:500]` slice.
+
+Run: cd backend && python -m pytest tests/test_testset_list_cap.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.dependencies import get_current_user
+from app.routes import testset
+
+engine = create_engine(
+    "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+)
+
+
+@event.listens_for(engine, "connect")
+def _pragma(conn, _):
+    cur = conn.cursor(); cur.execute("PRAGMA foreign_keys=ON"); cur.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _fresh_user(uid: int, uname: str) -> User:
+    return User(id=uid, username=uname, name=uname, email=f"{uname}@x.com", password_hash="x")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    for rd in [
+        {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    ]:
+        if not db.query(Role).filter(Role.name == rd["name"]).first():
+            db.add(Role(**rd))
+    db.commit()
+    db.add(_fresh_user(1, "admin_u"))
+    db.commit()
+    sa = db.query(Role).filter(Role.name == "system_admin").first()
+    db.add(UserRole(user_id=1, role_id=sa.id, scope_type="platform", scope_id=None))
+    db.commit()
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _wire_db():
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = lambda: _fresh_user(1, "admin_u")
+    yield
+    app.dependency_overrides.clear()
+
+
+class _FakeBlob:
+    """Minimal blob stub exposing the two attrs testset list touches."""
+
+    def __init__(self, name: str, text: str):
+        self.name = name
+        self._text = text
+
+    def download_as_text(self) -> str:
+        return self._text
+
+
+def _meta_blob(i: int) -> _FakeBlob:
+    """One .json meta blob for recording #i (lexical order == numeric order here)."""
+    path = f"test-dataset/contrib_{i:04d}/1/correct-{i:04d}.json"
+    audio_path = f"test-dataset/contrib_{i:04d}/1/correct-{i:04d}.webm"
+    meta = {
+        "contributor_name": f"contrib_{i:04d}",
+        "lesson_id": "1",
+        "version": "correct",
+        "audio_path": audio_path,
+        "created_at": f"2026-07-13T00:00:{i % 60:02d}Z",
+    }
+    return _FakeBlob(path, json.dumps(meta, ensure_ascii=False))
+
+
+def _bucket_with(n: int) -> MagicMock:
+    """Bucket whose list_blobs yields n meta blobs, ignoring max_results (like GCS
+    would once the cap is above the object count)."""
+    b = MagicMock()
+    b.list_blobs.return_value = iter([_meta_blob(i) for i in range(n)])
+    return b
+
+
+def test_list_cap_is_practically_unlimited():
+    """The cap must be high enough that real datasets never truncate (#2524)."""
+    assert testset._LIST_CAP >= 100_000
+
+
+def test_recordings_returns_all_beyond_old_500_cap():
+    """600 recordings (> old 500 cap) must ALL come back — no truncation, no slice."""
+    N = 600
+    bucket = _bucket_with(N)
+    with patch("app.routes.testset._get_gcs_bucket", return_value=bucket), patch(
+        "app.routes.testset.generate_audio_signed_url", return_value="http://signed"
+    ):
+        with TestClient(app, raise_server_exceptions=False) as c:
+            r = c.get("/api/testset/recordings")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["count"] == N, f"expected all {N} recordings, got {body['count']}"
+    # And the high cap was actually handed to GCS (locks the fix, not just the constant)
+    _, kwargs = bucket.list_blobs.call_args
+    assert kwargs.get("max_results", 0) >= 100_000


### PR DESCRIPTION
## 關聯 Issue

Fixes #2524

## 問題

人聲測試集 owner 儀表板看不到部分貢獻者的錄音（例如「陳和睿」「睿璟」），一度以為錄音遺失。實際原因：`GET /api/testset/recordings` 有寫死的硬上限 `_LIST_CAP = 500` 且無分頁。GCS `list_blobs` 照物件名字典序回傳，`test-dataset/` 底下 blob 一旦超過 500（每筆錄音佔 2~3 個 blob，約 166 筆完整錄音就觸頂）就從後面截掉；名字碼位偏後的貢獻者（中文名如「陳」U+9673、「睿」U+777F 排在英文名／「小明」之後）整批被擠出列表。**錄音本身仍安全存在 GCS，只是沒被列出來。**

## 修正內容

- `backend/app/routes/testset.py`：`_LIST_CAP` 從 `500` 提高到 `100_000`（實務上一定用不完），保留防跑掉的最終 backstop 但不再截斷真實資料。`list_blobs(max_results=N)` 由 SDK 自動分頁讀完全部。同一常數也套用在 `batch-eval` 收集 meta 階段，一併修好。
- 補充註解說明成因與碼位排序效應。
- 新增 `backend/tests/test_testset_list_cap.py`：
  - 鎖 `_LIST_CAP >= 100_000`。
  - 餵 600 筆（超過舊的 500）meta，斷言全部回傳、`count == 600`，且傳給 `list_blobs` 的 `max_results >= 100_000`（鎖住修正本身，不只是常數）。

## 測試

```
cd backend && ./.venv/bin/python -m pytest tests/test_testset_list_cap.py tests/test_testset_recordings_auth.py tests/test_testset_batch_eval.py -q
# 18 passed
```

- `bash specs/run-ci.sh --quick` → registry freshness OK。

## 已知取捨（非本 PR 範圍，另議）

`GET /api/testset/recordings` 每筆 meta 會產生一個 signed URL（IAM SignBlob，每筆一次網路往返）。資料量若成長到數千筆，此端點會變慢。此為既有行為（500 筆時本已偏慢），本 PR 只解決「資料被截斷看不到」；signed URL lazy 化 / 前端點擊才簽 屬後續效能優化。

## 補充

此為**顯示層截斷**，非資料遺失 — 合併後 owner 端即可重新看到「陳和睿」「睿璟」等被截掉的貢獻者錄音，無需資料復原。
