### PR TITLE
fix(reading): 逐段朗讀「朗讀對照／這次成績」導航往返後不再消失＋紀錄落 DB (#2530)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -26,6 +26,7 @@ import { useSentenceRetry } from './hooks/useSentenceRetry';
 import LiveTutorControls from './LiveTutorControls';
 import type { LocalEvalResult } from '../../../utils/localEval';
 import type { RetrySentenceInfo } from './hooks/useSentenceRetry';
+import type { TutorStepData } from '../../../types/stepProgress';
 import { getLineResultForParagraph } from './liveTutorTypes';
 import {
   planParagraphEvalRestore,
@@ -129,6 +130,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     onFinish,
     onParagraphComplete,
     initialCompletedParagraphs,
+    initialProgress, // Issue #2530: restore lineResults/summaries from DB step_data
   );
 
   const {
@@ -622,6 +624,34 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       );
     } catch {}
   }, [lineResults, paragraphSummaries, completedParagraphs, currentLineIndex, storageKey]);
+
+  // ── Issue #2530: 同步把逐段結果寫進 DB step_data['tutor']，讓「朗讀對照／這次成績」
+  //     在導航去總結報告再回來、以及跨 session（換裝置/重新登入）時都能回歸 ──────────
+  useEffect(() => {
+    if (isToolboxMode()) return;            // toolbox 為暫時模式，不寫 session DB
+    if (lineResults.length === 0 && completedParagraphs.size === 0) return; // 無資料不寫，避免覆蓋還原值
+    onProgressChange?.(
+      {
+        completed_paragraphs: Array.from(completedParagraphs),
+        paragraph_summaries: Object.entries(paragraphSummaries).map(([k, v]) => {
+          const lr = getLineResultForParagraph(lineResults, Number(k));
+          return {
+            paragraph_index: Number(k),
+            attempts: 1,
+            match_rate: v.matchRate,
+            cpm: lr?.cpm ?? 0,
+            duration_ms: lr?.durationMs ?? 0,
+          };
+        }),
+        current_line_index: currentLineIndex,
+        line_results: lineResults,
+        paragraph_summaries_data: Object.fromEntries(
+          Object.entries(paragraphSummaries).map(([k, v]) => [k, { ...v, geminiPending: false }]),
+        ),
+      },
+      false,
+    );
+  }, [lineResults, paragraphSummaries, completedParagraphs, currentLineIndex, onProgressChange]);
 
   // ── Pre-warm mic ─────────────────────────────────────────────────────────
   useEffect(() => {

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -637,7 +637,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           const lr = getLineResultForParagraph(lineResults, Number(k));
           return {
             paragraph_index: Number(k),
-            attempts: 1,
+            attempts: 1, // placeholder：目前無逐段重試累計；此欄位尚無 consumer（review #2531）
             match_rate: v.matchRate,
             cpm: lr?.cpm ?? 0,
             duration_ms: lr?.durationMs ?? 0,

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
@@ -6,6 +6,7 @@ import { extractPracticeChars } from '../../../../utils/liveTutorHelpers';
 import { isToolboxMode, scopedStepStorageKey } from '../../../../services/learningStorageScope';
 import { LineResult, ParagraphSummaryData } from '../liveTutorTypes';
 import { ParagraphStatus } from '../../ParagraphProgress';
+import type { TutorStepData } from '../../../../types/stepProgress';
 
 export type ProgressPhase =
   | 'idle'
@@ -61,6 +62,9 @@ export function useLiveTutorProgress(
   onFinish: (attempt: ReadingAttempt) => void,
   onParagraphComplete?: (completedParagraphIndex: number) => void,
   initialCompletedParagraphs?: Set<number>,
+  /** Issue #2530: DB step_data['tutor'] — restore fallback when localStorage is empty
+   *  (e.g. cross-session / cleared), so 逐段朗讀紀錄回歸. */
+  initialProgress?: TutorStepData,
 ) {
   const { token } = useAuth();
   const storageKey = scopedStepStorageKey('liveTutor_progress_', story.id);
@@ -68,21 +72,24 @@ export function useLiveTutorProgress(
 
   const [currentLineIndex, setCurrentLineIndex] = useState<number>(() => {
     const saved = savedProgress.current;
-    return saved ? (saved.currentLineIndex ?? 0) : 0;
+    if (saved) return saved.currentLineIndex ?? 0;
+    return initialProgress?.current_line_index ?? 0;
   });
 
   const [lineResults, setLineResults] = useState<LineResult[]>(
-    savedProgress.current?.lineResults ?? [],
+    savedProgress.current?.lineResults ?? initialProgress?.line_results ?? [],
   );
 
   const [completedParagraphs, setCompletedParagraphs] = useState<Set<number>>(
     savedProgress.current?.completedParagraphs
       ? new Set(savedProgress.current.completedParagraphs)
-      : initialCompletedParagraphs ?? new Set<number>(),
+      : initialProgress?.completed_paragraphs
+        ? new Set(initialProgress.completed_paragraphs)
+        : initialCompletedParagraphs ?? new Set<number>(),
   );
 
   const [paragraphSummaries, setParagraphSummaries] = useState<Record<number, ParagraphSummaryData>>(
-    savedProgress.current?.paragraphSummaries ?? {},
+    savedProgress.current?.paragraphSummaries ?? initialProgress?.paragraph_summaries_data ?? {},
   );
 
   const [isAdvancing, setIsAdvancing] = useState(false);
@@ -234,7 +241,9 @@ export function useLiveTutorProgress(
   const handleFinish = useCallback(
     (stopSession: () => void) => {
       stopSession();
-      try { localStorage.removeItem(storageKey); } catch {}
+      // Issue #2530: do NOT clear localStorage here. 「觀看總結報告」導航去 report 後
+      // 學生常會返回逐段朗讀頁；清掉會讓「朗讀對照／這次成績」在 remount 後全部消失。
+      // 只有明確「重練」(resetForRetry) 才清除。
       const avgMatchRate =
         lineResults.length > 0
           ? lineResults.reduce((s, r) => s + r.matchRate, 0) / lineResults.length
@@ -266,7 +275,7 @@ export function useLiveTutorProgress(
         })),
       });
     },
-    [story, lineResults, onFinish, storageKey],
+    [story, lineResults, onFinish],
   );
 
   const resetForRetry = useCallback(() => {

--- a/frontend/src/hooks/useStepProgressPersistence.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.ts
@@ -229,13 +229,25 @@ export function useStepProgressPersistence({
         const completed = new Set<string>(prev.steps_completed);
         if (opts.completeStep) completed.add(opts.completeStep);
 
+        // Issue #2530: merge each step's patch ONE LEVEL deep instead of replacing the
+        // whole step entry. A partial finish patch (e.g. tutor's { readingAttempt }) must
+        // not wipe detailed data another writer already put under the same step key
+        // (e.g. LiveTutor's line_results / paragraph_summaries_data). Also fixes the
+        // latent same issue for full-reading (#2503). Non-object values still replace.
+        const mergedStepData: Record<string, unknown> = { ...prev.step_data };
+        const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+          !!v && typeof v === 'object' && !Array.isArray(v);
+        for (const [key, patchVal] of Object.entries(opts.stepDataPatch ?? {})) {
+          const prevVal = mergedStepData[key];
+          mergedStepData[key] = isPlainObject(prevVal) && isPlainObject(patchVal)
+            ? { ...prevVal, ...patchVal }
+            : patchVal;
+        }
+
         const next: StepProgressData = {
           current_step: opts.currentStep ?? prev.current_step,
           steps_completed: Array.from(completed),
-          step_data: {
-            ...prev.step_data,
-            ...(opts.stepDataPatch ?? {}),
-          },
+          step_data: mergedStepData,
         };
 
         const prevSig = JSON.stringify(prev);

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -6,6 +6,8 @@
  * Step IDs match `STEP_REGISTRY` keys in `config/stepConfig.ts`.
  */
 
+import type { LineResult, ParagraphSummaryData } from '../components/reading-steps/live-tutor/liveTutorTypes';
+
 /** Step 1 — Intro: just a "visited" marker so teachers can see the student entered the lesson. */
 export interface IntroStepData {
   visited: true;
@@ -37,6 +39,11 @@ export interface TutorStepData {
     transcription?: string;
     timestamp: number;
   };
+  /** Issue #2530: full per-paragraph results (含 transcript / diffTokens) so the
+   *  「朗讀對照」與「這次成績」在導航去總結報告再回來、以及跨 session 都能還原，
+   *  逐段朗讀紀錄不再遺失。 */
+  line_results?: LineResult[];
+  paragraph_summaries_data?: Record<number, ParagraphSummaryData>;
 }
 
 /** Step 3 — Comprehension (multi-tab chat / mcq / strategy). */


### PR DESCRIPTION
## 修復 #2530 — 逐段朗讀「朗讀對照／這次成績」導航往返後消失

### 根因
`lineResults`（每段 matchRate/cpm/transcript/diffTokens）與 `paragraphSummaries` **只存記憶體 + localStorage**：
- `useLiveTutorProgress.ts:237`（原）`handleFinish`（「觀看總結報告」）`localStorage.removeItem` 清掉唯一持久層
- 初始化只讀 localStorage、無 DB fallback
- `LiveTutor.tsx` 的 `initialProgress` / `onProgressChange` 是 **dead props**（沒寫 DB、沒還原）

→ 導航去總結報告(step 7) 再回逐段頁 remount 後 `lineResults=[]` → `overallMetrics=null`（這次成績不 render）、對照 tokens 為空（朗讀對照消失）。與 #2503 同型。

### 修改（比照 #2503）
- **`types/stepProgress.ts`**：`TutorStepData` 新增 `line_results` / `paragraph_summaries_data`（含 transcript/diffTokens，承載重建「朗讀對照」所需）。
- **`useLiveTutorProgress.ts`**：hook 接收 `initialProgress`；`lineResults`/`paragraphSummaries`/`completedParagraphs`/`currentLineIndex` 在 localStorage 為空時 fallback 從 DB `initialProgress` 還原；`handleFinish` **不再清 localStorage**（只有 `resetForRetry`「重練」才清）。
- **`LiveTutor.tsx`**：把 `initialProgress` 傳進 hook；新增 effect 把逐段結果寫回 DB `step_data['tutor']`（toolbox 模式與空資料不寫，避免覆蓋還原值），讓**逐段朗讀紀錄跨 session 回歸**。

### 紀錄回歸
- 同瀏覽器導航往返：localStorage 不再被清 → remount 立即還原（核心 bug 修好）。
- 跨 session / 換裝置 / 清 localStorage：從 DB `step_data['tutor']` 還原 → 逐段朗讀紀錄回歸。

### Frontend Render-Safety 驗證（ui-pr-verify SOP）
- **ESLint**：✅ 0 errors（`npm run lint`；僅既有 warning）
- **tsc**：✅ 改動檔無型別錯誤（並補上 LiveTutor 早該有的 `TutorStepData` import）
- **vitest smoke**：✅ 15/15；live-tutor 測試 34/34 pass
- ⚠️ 互動式 /qa（登入→完成逐段→觀看總結報告→返回→確認對照/成績仍在）需真麥克風，preview 部署後人工驗收（見下方 comment）

@claude 請幫我 review 這個 PR
