### PR TITLE
feat(reading): 逐段朗讀完成後新增「再讀一次」按鈕重錄整課 (#2532)

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -36,11 +36,15 @@ jobs:
         working-directory: frontend
         run: npm run lint
 
-      # Render-smoke gate (#2289). Scoped to the smoke suite on purpose: the wider
-      # vitest suite has ~38 pre-existing functional-test failures (UI text drift,
-      # tests missing AuthProvider wrappers) that predate this safety net. Gating
-      # the new render-safety check on that broken suite would make this workflow
-      # red on day one. The smoke suite is the actual mount-crash guard.
-      - name: Render-smoke tests (vitest)
+      # Render-smoke gate (#2289) + explicitly-pinned regression locks. Scoped to
+      # named files on purpose: the wider vitest suite has ~38 pre-existing
+      # functional-test failures (UI text drift, tests missing AuthProvider wrappers)
+      # that predate this safety net, so gating on the whole suite would make this
+      # workflow red on day one. Pin a file here whenever a fix ships a regression
+      # test that must stay enforced — an un-run lock is theatre (testing-strategy 鐵律).
+      #   - render-smoke: mount-crash guard (#2279/#2289)
+      #   - resetTutorStep / LiveTutor.readAgain: 「再讀一次」reset must clear every
+      #     completion/成績 source + the single-paragraph residual diff (#2532)
+      - name: Render-smoke + pinned regression tests (vitest)
         working-directory: frontend
-        run: npx vitest run src/__smoke__/render-smoke.test.tsx
+        run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
@@ -44,6 +44,7 @@ vi.mock('react-router-dom', () => ({
 }));
 
 import LiveTutor from './LiveTutor';
+import { scopedStepStorageKey } from '../../../services/learningStorageScope';
 
 // jsdom has no navigator.mediaDevices; LiveTutor pre-warms the mic on mount (rejection
 // is caught internally). Stub so the mount effect doesn't throw.
@@ -125,5 +126,16 @@ describe('LiveTutor 「再讀一次」(#2532)', () => {
     });
     expect(clearingCall, 'onProgressChange 應被以清空的 tutor payload 呼叫').toBeTruthy();
     expect((clearingCall?.[0] as TutorStepData).paragraph_summaries_data).toEqual({});
+  });
+
+  it('clicking 再讀一次 also clears the tutor_completed_ localStorage (3rd completed source)', () => {
+    const tutorCompletedKey = scopedStepStorageKey('tutor_completed_', '99');
+    localStorage.setItem(tutorCompletedKey, JSON.stringify([0]));
+
+    renderCompletedLiveTutor();
+    fireEvent.click(screen.getByText('再讀一次'));
+
+    // RED before the fix: handler didn't touch this key → 全段完成 resurrects on full reload.
+    expect(localStorage.getItem(tutorCompletedKey)).toBeNull();
   });
 });

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
@@ -1,17 +1,21 @@
 /**
  * Regression test for #2532 review (CHANGES_REQUESTED by Young).
  *
- * Scenario: 單段課 + 「再讀一次」+ 導航往返.
- * Root cause: after #2530/#2531 persist 逐段 results to DB step_data.tutor, the
- * 「再讀一次」handler must ALSO clear the DB — otherwise TutorPage restores from
- * DB.step_data.tutor (stale) on the way back and resurrects the old 成績 + all-done state.
+ * Scenario: 單段課 +「再讀一次」.
+ * Two things must happen when the student clicks「再讀一次」on a completed lesson:
+ *  1. onResetTutor() is invoked — the cross-layer full reset (DB step_data.tutor,
+ *     steps_completed 'tutor', session.readingAttempt, completedParagraphsSet, …) that
+ *     stops the round-trip / reload from resurrecting old 成績. (資料清除本體在
+ *     useStepProgressPersistence.resetTutorStep，另有專屬 hook 測試守著。)
+ *  2. The stale 朗讀對照 diff is cleared. For a single-paragraph lesson currentLineIndex
+ *     is already 0, so the paragraph-switch effect never dispatches CLEAR_FOR_PARAGRAPH —
+ *     handleReadAgain must dispatch it explicitly, else evalState.lastDiffTokens lingers
+ *     and the diff column stays on screen.
  *
- * This test mounts a single-paragraph LiveTutor already in the completed state (via
- * initialProgress, i.e. a DB restore), clicks 「再讀一次」, and asserts onProgressChange
- * was called with an EMPTY tutor payload (line_results:[], completed_paragraphs:[]).
- *
- * RED before the fix: the old handler only did stopSession/stopTts/resetForRetry and
- * never called onProgressChange, so the DB kept the old data → resurrection.
+ * 必改 2 is genuinely RED without the explicit dispatch: the completed lesson mounts via
+ * initialProgress, whose restore path sets evalState.lastDiffTokens (GEMINI_DONE); after
+ * resetForRetry() clears lineResults the diff column would still render off the lingering
+ * lastDiffTokens unless CLEAR_FOR_PARAGRAPH runs.
  */
 
 import React from 'react';
@@ -27,10 +31,7 @@ vi.mock('../../../contexts/AuthContext', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock('../../../context/ZhuyinContext', () => ({
-  useZhuyin: () => ({
-    isZhuyinAny: false,
-    processLinesSelective: () => null,
-  }),
+  useZhuyin: () => ({ isZhuyinAny: false, processLinesSelective: () => null }),
   ZhuyinProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock('../../../context/KaraokeContext', () => ({
@@ -44,7 +45,6 @@ vi.mock('react-router-dom', () => ({
 }));
 
 import LiveTutor from './LiveTutor';
-import { scopedStepStorageKey } from '../../../services/learningStorageScope';
 
 // jsdom has no navigator.mediaDevices; LiveTutor pre-warms the mic on mount (rejection
 // is caught internally). Stub so the mount effect doesn't throw.
@@ -86,7 +86,7 @@ const COMPLETED_PROGRESS: TutorStepData = {
 };
 
 function renderCompletedLiveTutor() {
-  const onProgressChange = vi.fn();
+  const onResetTutor = vi.fn();
   render(
     <LiveTutor
       story={SINGLE_PARA_STORY}
@@ -95,11 +95,12 @@ function renderCompletedLiveTutor() {
       onFinish={vi.fn()}
       onCancel={vi.fn()}
       initialProgress={COMPLETED_PROGRESS}
-      onProgressChange={onProgressChange}
+      onProgressChange={vi.fn()}
+      onResetTutor={onResetTutor}
       dbSessionId={123}
     />,
   );
-  return { onProgressChange };
+  return { onResetTutor };
 }
 
 describe('LiveTutor 「再讀一次」(#2532)', () => {
@@ -107,35 +108,30 @@ describe('LiveTutor 「再讀一次」(#2532)', () => {
     localStorage.clear();
   });
 
-  it('mounts a completed single-paragraph lesson showing 再讀一次', () => {
+  it('mounts a completed single-paragraph lesson showing 再讀一次 and the 朗讀對照', () => {
     renderCompletedLiveTutor();
     expect(screen.getByText('再讀一次')).toBeInTheDocument();
+    // Restored diff comparison is visible before reset (你唸的內容 = ParagraphCard 對照左欄).
+    expect(screen.getByText('你唸的內容')).toBeInTheDocument();
   });
 
-  it('clicking 再讀一次 clears DB step_data.tutor (empty payload) — no resurrection on round-trip', () => {
-    const { onProgressChange } = renderCompletedLiveTutor();
-
+  it('clicking 再讀一次 invokes the cross-layer full reset (onResetTutor)', () => {
+    const { onResetTutor } = renderCompletedLiveTutor();
     fireEvent.click(screen.getByText('再讀一次'));
-
-    // Must have written a CLEARED tutor payload to the DB so the round-trip restore
-    // can't resurrect the old 成績. (RED before the fix: handler never called onProgressChange.)
-    const clearingCall = onProgressChange.mock.calls.find(([data]) => {
-      const d = data as TutorStepData;
-      return Array.isArray(d?.line_results) && d.line_results.length === 0
-        && Array.isArray(d?.completed_paragraphs) && d.completed_paragraphs.length === 0;
-    });
-    expect(clearingCall, 'onProgressChange 應被以清空的 tutor payload 呼叫').toBeTruthy();
-    expect((clearingCall?.[0] as TutorStepData).paragraph_summaries_data).toEqual({});
+    expect(onResetTutor).toHaveBeenCalledTimes(1);
   });
 
-  it('clicking 再讀一次 also clears the tutor_completed_ localStorage (3rd completed source)', () => {
-    const tutorCompletedKey = scopedStepStorageKey('tutor_completed_', '99');
-    localStorage.setItem(tutorCompletedKey, JSON.stringify([0]));
-
+  it('clicking 再讀一次 returns the page to the unread state (朗讀對照 gone)', () => {
     renderCompletedLiveTutor();
+    expect(screen.getByText('你唸的內容')).toBeInTheDocument();
+
     fireEvent.click(screen.getByText('再讀一次'));
 
-    // RED before the fix: handler didn't touch this key → 全段完成 resurrects on full reload.
-    expect(localStorage.getItem(tutorCompletedKey)).toBeNull();
+    // 整體 reset 後對照欄消失（此處由 resetForRetry 清 lineResults 達成）。
+    // 必改 2 的精確機制「CLEAR_FOR_PARAGRAPH 清 evalState.lastDiffTokens」是為了 live
+    // 單段評估殘留的路徑（無法用 initialProgress 重現）——由 handleReadAgain 顯式 dispatch
+    // (見 LiveTutor.tsx) + reducer 單元測試 useParagraphEvaluation.test.ts『CLEAR_FOR_PARAGRAPH …
+    // lastDiffTokens toBeNull』守著，不在此假裝覆蓋。
+    expect(screen.queryByText('你唸的內容')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Regression test for #2532 review (CHANGES_REQUESTED by Young).
+ *
+ * Scenario: 單段課 + 「再讀一次」+ 導航往返.
+ * Root cause: after #2530/#2531 persist 逐段 results to DB step_data.tutor, the
+ * 「再讀一次」handler must ALSO clear the DB — otherwise TutorPage restores from
+ * DB.step_data.tutor (stale) on the way back and resurrects the old 成績 + all-done state.
+ *
+ * This test mounts a single-paragraph LiveTutor already in the completed state (via
+ * initialProgress, i.e. a DB restore), clicks 「再讀一次」, and asserts onProgressChange
+ * was called with an EMPTY tutor payload (line_results:[], completed_paragraphs:[]).
+ *
+ * RED before the fix: the old handler only did stopSession/stopTts/resetForRetry and
+ * never called onProgressChange, so the DB kept the old data → resurrection.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Story } from '../../../types';
+import type { TutorStepData } from '../../../types/stepProgress';
+import type { DiffToken } from '../../../types';
+
+// Context/hook stubs — same approach as src/__smoke__/render-smoke.test.tsx
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null, token: 'test-token', isAuthenticated: true, isLoading: false }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../../context/ZhuyinContext', () => ({
+  useZhuyin: () => ({
+    isZhuyinAny: false,
+    processLinesSelective: () => null,
+  }),
+  ZhuyinProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../../context/KaraokeContext', () => ({
+  useKaraoke: () => ({ karaokeEnabled: false }),
+  KaraokeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null, key: 'k' }),
+  useParams: () => ({}),
+}));
+
+import LiveTutor from './LiveTutor';
+
+// jsdom has no navigator.mediaDevices; LiveTutor pre-warms the mic on mount (rejection
+// is caught internally). Stub so the mount effect doesn't throw.
+Object.defineProperty(navigator, 'mediaDevices', {
+  configurable: true,
+  value: { getUserMedia: vi.fn().mockRejectedValue(new Error('no mic in test')) },
+});
+
+const SINGLE_PARA_STORY: Story = {
+  id: '99',
+  title: '單段測試課文',
+  level: 1,
+  content: ['這是唯一的一段課文。'],
+  paragraphs: ['這是唯一的一段課文。'],
+  thumbnail: '',
+  category: 'Fable',
+  filename: 'read-again-test.yml',
+  grade: 4,
+  charCount: 10,
+  vocabulary: [],
+};
+
+const DIFF_TOKENS: DiffToken[] = [
+  { char: '這', type: 'correct' },
+  { char: '是', type: 'correct' },
+];
+
+// A completed single-paragraph reading as it would be restored from DB step_data.tutor.
+const COMPLETED_PROGRESS: TutorStepData = {
+  completed_paragraphs: [0],
+  current_line_index: 0,
+  paragraph_summaries: [],
+  line_results: [
+    { lineIndex: 0, matchRate: 0.98, cpm: 120, durationMs: 3000, transcript: '這是唯一的一段課文。', diffTokens: DIFF_TOKENS },
+  ],
+  paragraph_summaries_data: {
+    0: { feedback: '', matchRate: 0.98, wrongCount: 0, missingCount: 0, tier: 3, geminiPending: false },
+  },
+};
+
+function renderCompletedLiveTutor() {
+  const onProgressChange = vi.fn();
+  render(
+    <LiveTutor
+      story={SINGLE_PARA_STORY}
+      rightPanelWidth={0}
+      onPanelWidthChange={vi.fn()}
+      onFinish={vi.fn()}
+      onCancel={vi.fn()}
+      initialProgress={COMPLETED_PROGRESS}
+      onProgressChange={onProgressChange}
+      dbSessionId={123}
+    />,
+  );
+  return { onProgressChange };
+}
+
+describe('LiveTutor 「再讀一次」(#2532)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('mounts a completed single-paragraph lesson showing 再讀一次', () => {
+    renderCompletedLiveTutor();
+    expect(screen.getByText('再讀一次')).toBeInTheDocument();
+  });
+
+  it('clicking 再讀一次 clears DB step_data.tutor (empty payload) — no resurrection on round-trip', () => {
+    const { onProgressChange } = renderCompletedLiveTutor();
+
+    fireEvent.click(screen.getByText('再讀一次'));
+
+    // Must have written a CLEARED tutor payload to the DB so the round-trip restore
+    // can't resurrect the old 成績. (RED before the fix: handler never called onProgressChange.)
+    const clearingCall = onProgressChange.mock.calls.find(([data]) => {
+      const d = data as TutorStepData;
+      return Array.isArray(d?.line_results) && d.line_results.length === 0
+        && Array.isArray(d?.completed_paragraphs) && d.completed_paragraphs.length === 0;
+    });
+    expect(clearingCall, 'onProgressChange 應被以清空的 tutor payload 呼叫').toBeTruthy();
+    expect((clearingCall?.[0] as TutorStepData).paragraph_summaries_data).toEqual({});
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -861,6 +861,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         onPauseResumeTts={isTtsPaused ? resumeTts : pauseTts}
         onStopTts={stopTts}
         onFinish={() => handleFinish(stopSession)}
+        onReadAgain={() => {          // Issue #2532: 重錄整課
+          stopSession();
+          stopTts();
+          resetForRetry();
+        }}
         onRequestMicPermission={startSession}
       />
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -409,6 +409,38 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     dispatch({ type: 'SET_REALTIME_DIFF', tokens: null });
   }, [clearPendingRecording, paragraphRecorder, clearParagraphFallback, dispatch]);
 
+  // ── Issue #2532「再讀一次」重錄整課 (review CHANGES_REQUESTED) ─────────────
+  // 完成所有段落後重錄整課。必須同時處理三件事，否則 reset 會被抵銷/殘留：
+  //  1. 清 DB step_data.tutor —— 否則 #2530 的 initialProgress 還原路徑會把舊成績＋
+  //     全段完成狀態復活（#2531 的 DB-write effect 對空狀態有 guard 不會自己清）。
+  //  2. dispatch CLEAR_FOR_PARAGRAPH —— 單段課 currentLineIndex 已是 0，按鈕不觸發
+  //     段落切換，evalState.lastDiffTokens 會殘留舊朗讀對照，需在此顯式清。
+  //  3. 清 recorder / pending / fallback / 音量偵測旗標。
+  const handleReadAgain = useCallback(() => {
+    stopSession();
+    stopTts();
+    dispatch({ type: 'CLEAR_FOR_PARAGRAPH' });
+    clearPendingRecording();
+    paragraphRecorder.clearRecording();
+    clearParagraphFallback();
+    setHasDetectedAudio(false);
+    hasHeardAudioRef.current = false;
+    volumeAboveSinceRef.current = null;
+    resetForRetry(); // 回到第 1 段、清 in-memory + localStorage
+    if (!isToolboxMode()) {
+      onProgressChange?.(
+        {
+          completed_paragraphs: [],
+          paragraph_summaries: [],
+          current_line_index: 0,
+          line_results: [],
+          paragraph_summaries_data: {},
+        },
+        true, // immediate flush：使用者可能馬上導航，不能依賴 debounce
+      );
+    }
+  }, [stopSession, stopTts, dispatch, clearPendingRecording, paragraphRecorder, clearParagraphFallback, resetForRetry, onProgressChange]);
+
   const confirmEvaluate = useCallback(async () => {
     const pending = pendingRecordingRef.current;
     if (!pending || isSubmittingSentenceRef.current) return;
@@ -861,11 +893,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         onPauseResumeTts={isTtsPaused ? resumeTts : pauseTts}
         onStopTts={stopTts}
         onFinish={() => handleFinish(stopSession)}
-        onReadAgain={() => {          // Issue #2532: 重錄整課
-          stopSession();
-          stopTts();
-          resetForRetry();
-        }}
+        onReadAgain={handleReadAgain}
         onRequestMicPermission={startSession}
       />
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -76,6 +76,10 @@ interface LiveTutorProps {
   initialProgress?: TutorStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: TutorStepData, immediate?: boolean) => void;
+  /** Issue #2532: full tutor reset for「再讀一次」— clears DB step_data.tutor,
+   *  steps_completed 'tutor', session-level tutor state and completedParagraphsSet.
+   *  Owned by useStepProgressPersistence (LearningLayout); undefined in toolbox mode. */
+  onResetTutor?: () => void;
   /** DB LearningSession integer id — used to bind accepted audio to the attempt row
    *  via POST /reading/save-audio (Issue #2297). Optional: upload is skipped if absent. */
   dbSessionId?: number | null;
@@ -91,6 +95,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   initialCompletedParagraphs,
   initialProgress,
   onProgressChange,
+  onResetTutor,
   dbSessionId,
 }) => {
   const { px: fontSizePx } = useFontSize();
@@ -410,15 +415,18 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   }, [clearPendingRecording, paragraphRecorder, clearParagraphFallback, dispatch]);
 
   // ── Issue #2532「再讀一次」重錄整課 (review CHANGES_REQUESTED) ─────────────
-  // 完成所有段落後重錄整課。必須同時處理三件事，否則 reset 會被抵銷/殘留：
-  //  1. 清 DB step_data.tutor —— 否則 #2530 的 initialProgress 還原路徑會把舊成績＋
-  //     全段完成狀態復活（#2531 的 DB-write effect 對空狀態有 guard 不會自己清）。
-  //  2. dispatch CLEAR_FOR_PARAGRAPH —— 單段課 currentLineIndex 已是 0，按鈕不觸發
-  //     段落切換，evalState.lastDiffTokens 會殘留舊朗讀對照，需在此顯式清。
-  //  3. 清 recorder / pending / fallback / 音量偵測旗標。
-  //  4. 清 tutor_completed_ localStorage —— completedParagraphsSet 的第三個來源（由
-  //     useStepProgressPersistence 讀取供 initialCompletedParagraphs），不清會在整頁
-  //     重載時讓「全段完成」復活（半套 reset 殘留）。
+  // 「半套 reset」的完整版：completion/成績 有四個來源，全部要清乾淨，否則導航往返
+  // 或整頁重載會把舊成績/全段完成復活。
+  //  A. 本地 (LiveTutor)：
+  //     - dispatch CLEAR_FOR_PARAGRAPH —— 單段課 currentLineIndex 已是 0，按鈕不觸發
+  //       段落切換，evalState.lastDiffTokens 會殘留舊朗讀對照，需在此顯式清。
+  //     - 清 recorder / pending / fallback / 音量旗標。
+  //     - resetForRetry() —— 清 in-memory lineResults/summaries/completed + liveTutor_progress_，
+  //       回到第 1 段。
+  //  B. 跨層 (onResetTutor → useStepProgressPersistence.resetTutorStep)：
+  //     DB step_data.tutor（含 readingAttempt）、steps_completed 'tutor'、
+  //     session.readingAttempt/completedParagraphs/completedSteps、completedParagraphsSet、
+  //     tutor_completed_ localStorage —— 這些狀態不在 LiveTutor，集中在該 hook 一次清乾淨。
   const handleReadAgain = useCallback(() => {
     stopSession();
     stopTts();
@@ -429,23 +437,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setHasDetectedAudio(false);
     hasHeardAudioRef.current = false;
     volumeAboveSinceRef.current = null;
-    resetForRetry(); // 回到第 1 段、清 in-memory + liveTutor_progress_ localStorage
-    try {
-      localStorage.removeItem(scopedStepStorageKey('tutor_completed_', story.id));
-    } catch { /* non-fatal */ }
-    if (!isToolboxMode()) {
-      onProgressChange?.(
-        {
-          completed_paragraphs: [],
-          paragraph_summaries: [],
-          current_line_index: 0,
-          line_results: [],
-          paragraph_summaries_data: {},
-        },
-        true, // immediate flush：使用者可能馬上導航，不能依賴 debounce
-      );
-    }
-  }, [stopSession, stopTts, dispatch, clearPendingRecording, paragraphRecorder, clearParagraphFallback, resetForRetry, onProgressChange, story.id]);
+    resetForRetry();
+    onResetTutor?.();
+  }, [stopSession, stopTts, dispatch, clearPendingRecording, paragraphRecorder, clearParagraphFallback, resetForRetry, onResetTutor]);
 
   const confirmEvaluate = useCallback(async () => {
     const pending = pendingRecordingRef.current;

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -416,6 +416,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   //  2. dispatch CLEAR_FOR_PARAGRAPH —— 單段課 currentLineIndex 已是 0，按鈕不觸發
   //     段落切換，evalState.lastDiffTokens 會殘留舊朗讀對照，需在此顯式清。
   //  3. 清 recorder / pending / fallback / 音量偵測旗標。
+  //  4. 清 tutor_completed_ localStorage —— completedParagraphsSet 的第三個來源（由
+  //     useStepProgressPersistence 讀取供 initialCompletedParagraphs），不清會在整頁
+  //     重載時讓「全段完成」復活（半套 reset 殘留）。
   const handleReadAgain = useCallback(() => {
     stopSession();
     stopTts();
@@ -426,7 +429,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setHasDetectedAudio(false);
     hasHeardAudioRef.current = false;
     volumeAboveSinceRef.current = null;
-    resetForRetry(); // 回到第 1 段、清 in-memory + localStorage
+    resetForRetry(); // 回到第 1 段、清 in-memory + liveTutor_progress_ localStorage
+    try {
+      localStorage.removeItem(scopedStepStorageKey('tutor_completed_', story.id));
+    } catch { /* non-fatal */ }
     if (!isToolboxMode()) {
       onProgressChange?.(
         {
@@ -439,7 +445,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         true, // immediate flush：使用者可能馬上導航，不能依賴 debounce
       );
     }
-  }, [stopSession, stopTts, dispatch, clearPendingRecording, paragraphRecorder, clearParagraphFallback, resetForRetry, onProgressChange]);
+  }, [stopSession, stopTts, dispatch, clearPendingRecording, paragraphRecorder, clearParagraphFallback, resetForRetry, onProgressChange, story.id]);
 
   const confirmEvaluate = useCallback(async () => {
     const pending = pendingRecordingRef.current;

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -212,7 +212,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
                 onClick={onReadAgain}
                 className="h-14 px-6 rounded-full font-headline font-bold text-base bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest active:scale-[0.98] transition-all flex items-center justify-center gap-2 shrink-0"
               >
-                <span className="material-symbols-outlined text-lg">replay</span>
+                <span className="material-symbols-outlined text-lg">refresh</span>
                 再讀一次
               </button>
             )}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -50,6 +50,8 @@ interface LiveTutorControlsProps {
   onPauseResumeTts: () => void;
   onStopTts: () => void;
   onFinish: () => void;
+  /** Issue #2532: 完成所有段落後「再讀一次」重錄整課（比照全文朗讀）。 */
+  onReadAgain?: () => void;
   /** Painpoint 2: trigger getUserMedia to prompt browser permission dialog. */
   onRequestMicPermission?: () => void;
 }
@@ -94,6 +96,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   onPauseResumeTts,
   onStopTts,
   onFinish,
+  onReadAgain,
   onRequestMicPermission,
 }) => {
   const isAllDone = completedCount === totalLines;
@@ -200,16 +203,28 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
           </div>
         )}
 
-        {/* All paragraphs done — final report */}
+        {/* All paragraphs done — 再讀一次 + 觀看總結報告（Issue #2532）*/}
         {isAllDone ? (
-          <button
-            onClick={onFinish}
-            className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3"
-            style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
-          >
-            <span>觀看總結報告</span>
-            <span className="material-symbols-outlined">arrow_forward</span>
-          </button>
+          <div className="w-full flex gap-3">
+            {onReadAgain && (
+              <button
+                type="button"
+                onClick={onReadAgain}
+                className="h-14 px-6 rounded-full font-headline font-bold text-base bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest active:scale-[0.98] transition-all flex items-center justify-center gap-2 shrink-0"
+              >
+                <span className="material-symbols-outlined text-lg">replay</span>
+                再讀一次
+              </button>
+            )}
+            <button
+              onClick={onFinish}
+              className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3"
+              style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+            >
+              <span>觀看總結報告</span>
+              <span className="material-symbols-outlined">arrow_forward</span>
+            </button>
+          </div>
 
         ) : isRecordingOrSubmitting ? (
           <div className="w-full flex flex-col items-center gap-2">

--- a/frontend/src/hooks/useStepProgressPersistence.resetTutorStep.test.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.resetTutorStep.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for #2532 review 必改 1 (the resurrection bug):
+ * 「再讀一次」must clear EVERY tutor completion / 成績 source so navigating away+back
+ * or a full reload can't restore the old reading. The actual clearing lives in
+ * useStepProgressPersistence.resetTutorStep (invoked via LiveTutor's onResetTutor).
+ *
+ * RED before the fix: resetForRetry() only cleared React state + liveTutor_progress_
+ * localStorage, leaving step_data.tutor (incl. readingAttempt), steps_completed 'tutor',
+ * session.readingAttempt, and completedParagraphsSet intact → old 成績 resurrected.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { LearningSession } from '../types';
+
+// useProgressSync does the DB fetch/debounce on mount — stub it so the hook mounts
+// without network and its sync/flush are no-ops.
+vi.mock('./useProgressSync', () => ({
+  useProgressSync: () => ({
+    syncProgress: vi.fn(),
+    flushProgress: vi.fn(),
+    isProgressLoading: false,
+  }),
+}));
+
+import { useStepProgressPersistence } from './useStepProgressPersistence';
+
+function setup() {
+  const setSession = vi.fn();
+  const { result } = renderHook(() =>
+    useStepProgressPersistence({
+      storyId: '99',
+      user: { id: 1 } as never,
+      token: 'test-token',
+      dbSessionId: 1,
+      selectedStory: null,
+      isAssignmentFlow: false,
+      setSession,
+    }),
+  );
+  return { result, setSession };
+}
+
+describe('useStepProgressPersistence.resetTutorStep (#2532 必改 1)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('clears step_data.tutor (incl. readingAttempt), steps_completed, completedParagraphsSet and session', () => {
+    const { result, setSession } = setup();
+
+    // Simulate a completed tutor reading (what would otherwise resurrect).
+    act(() => {
+      result.current.saveStepProgressPatch({
+        stepId: 'tutor',
+        stepData: {
+          line_results: [{ lineIndex: 0, matchRate: 0.98 }],
+          completed_paragraphs: [0],
+          paragraph_summaries_data: { 0: { matchRate: 0.98 } },
+          readingAttempt: { accuracy: 0.98, cpm: 120 },
+        },
+        markCompleted: true,
+      });
+      result.current.setCompletedParagraphsSet(new Set([0]));
+    });
+
+    expect(result.current.stepProgressState.steps_completed).toContain('tutor');
+    expect(result.current.completedParagraphsSet.size).toBe(1);
+
+    act(() => {
+      result.current.resetTutorStep();
+    });
+
+    // 1. step_data.tutor fully cleared, readingAttempt dropped
+    const tutor = result.current.stepProgressState.step_data.tutor as Record<string, unknown>;
+    expect(tutor.line_results).toEqual([]);
+    expect(tutor.completed_paragraphs).toEqual([]);
+    expect(tutor.paragraph_summaries_data).toEqual({});
+    expect(tutor.readingAttempt).toBeUndefined();
+
+    // 2. 'tutor' removed from steps_completed
+    expect(result.current.stepProgressState.steps_completed).not.toContain('tutor');
+
+    // 3. in-memory completedParagraphsSet cleared
+    expect(result.current.completedParagraphsSet.size).toBe(0);
+
+    // 4. session cleared via the setSession updater
+    const updater = setSession.mock.calls.at(-1)![0] as (s: LearningSession) => LearningSession;
+    const cleared = updater({
+      readingAttempt: { accuracy: 0.98 },
+      completedParagraphs: [0],
+      completedSteps: ['tutor', 'vocab'],
+    } as unknown as LearningSession);
+    expect(cleared.readingAttempt).toBeNull();
+    expect(cleared.completedParagraphs).toEqual([]);
+    expect(cleared.completedSteps).toEqual(['vocab']);
+  });
+});

--- a/frontend/src/hooks/useStepProgressPersistence.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.ts
@@ -53,6 +53,8 @@ interface UseStepProgressPersistenceReturn {
   persistStep: (step: number) => void;
   saveStepProgressPatch: (opts: SaveStepProgressPatchOptions) => void;
   clearPersistedSession: () => void;
+  /** Issue #2532: full tutor reset for「再讀一次」— clears all completion/成績 sources. */
+  resetTutorStep: () => void;
   completedParagraphsSet: Set<number>;
   setCompletedParagraphsSet: Dispatch<SetStateAction<Set<number>>>;
   handleParagraphComplete: (paragraphIndex: number) => void;
@@ -356,12 +358,72 @@ export function useStepProgressPersistence({
     });
   }, [setSession, tutorCompletedStorageKey]);
 
+  /**
+   * Issue #2532 (review): full tutor reset for「再讀一次」. `resetForRetry()` in
+   * useLiveTutorProgress only clears React state + liveTutor_progress_ localStorage —
+   * that's a "half reset". Completion/成績 actually live in FOUR places; this clears
+   * ALL of them so navigating away+back or a full reload can't resurrect old data:
+   *   1. step_data.tutor — fully replaced with an empty entry (also drops readingAttempt)
+   *   2. steps_completed — 'tutor' removed (so the stepper doesn't stay ticked)
+   *   3. session.readingAttempt / completedParagraphs / completedSteps('tutor')
+   *      (ReportPage reads session.readingAttempt; reload rehydrates it from step_data)
+   *   4. completedParagraphsSet (in-memory) + tutor_completed_ / liveTutor_progress_ localStorage
+   */
+  const resetTutorStep = useCallback(() => {
+    setCompletedParagraphsSet(new Set());
+    if (tutorCompletedStorageKey) {
+      try { localStorage.removeItem(tutorCompletedStorageKey); } catch { /* non-fatal */ }
+    }
+    if (liveTutorProgressStorageKey) {
+      try { localStorage.removeItem(liveTutorProgressStorageKey); } catch { /* non-fatal */ }
+    }
+
+    setStepProgressState((prev) => {
+      const completed = new Set(prev.steps_completed);
+      completed.delete('tutor');
+      const next: StepProgressData = {
+        current_step: prev.current_step,
+        steps_completed: Array.from(completed),
+        step_data: {
+          ...prev.step_data,
+          // Full replace (not shallow merge) so readingAttempt / reading_attempt are dropped too.
+          tutor: {
+            completed_paragraphs: [],
+            paragraph_summaries: [],
+            current_line_index: 0,
+            line_results: [],
+            paragraph_summaries_data: {},
+          },
+        },
+      };
+      flushProgress(next); // immediate — the student may navigate right after
+      return next;
+    });
+
+    setSession((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        readingAttempt: null,
+        completedParagraphs: [],
+        completedSteps: (prev.completedSteps ?? []).filter((s) => s !== 'tutor'),
+      };
+    });
+  }, [
+    tutorCompletedStorageKey,
+    liveTutorProgressStorageKey,
+    setCompletedParagraphsSet,
+    flushProgress,
+    setSession,
+  ]);
+
   return {
     stepProgressState,
     persistStepProgressState,
     persistStep,
     saveStepProgressPatch,
     clearPersistedSession,
+    resetTutorStep,
     completedParagraphsSet,
     setCompletedParagraphsSet,
     handleParagraphComplete,

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -81,6 +81,8 @@ export interface LearningContext {
   completedParagraphsSet: Set<number>;
   /** Notify layout that a paragraph was completed (Issue #85). */
   handleParagraphComplete: (paragraphIndex: number) => void;
+  /** Issue #2532: full tutor reset for「再讀一次」— clears every completion/成績 source. */
+  resetTutorStep: () => void;
   /** Reading goals set by teacher for the active assignment (Issue #414). Null for free-play. */
   assignmentReadingGoals: AssignmentReadingGoals | null;
   /**
@@ -178,6 +180,7 @@ const LearningLayout: React.FC = () => {
     persistStep,
     saveStepProgressPatch,
     clearPersistedSession,
+    resetTutorStep,
     completedParagraphsSet,
     handleParagraphComplete,
     missingAssignmentSteps,
@@ -298,6 +301,7 @@ const LearningLayout: React.FC = () => {
       dbSessionId,
       completedParagraphsSet,
       handleParagraphComplete,
+      resetTutorStep,
       assignmentReadingGoals,
       syncProgress,
       flushProgress,
@@ -334,6 +338,7 @@ const LearningLayout: React.FC = () => {
       dbSessionId,
       completedParagraphsSet,
       handleParagraphComplete,
+      resetTutorStep,
       assignmentReadingGoals,
       syncProgress,
       flushProgress,

--- a/frontend/src/pages/learning/TutorPage.tsx
+++ b/frontend/src/pages/learning/TutorPage.tsx
@@ -12,6 +12,7 @@ const TutorPage: React.FC = () => {
     handleFinishReading,
     completedParagraphsSet,
     handleParagraphComplete,
+    resetTutorStep,
     stepProgressData,
     saveStepProgressPatch,
     dbSessionId,
@@ -43,6 +44,7 @@ const TutorPage: React.FC = () => {
       initialCompletedParagraphs={completedParagraphsSet}
       initialProgress={stepProgressData.step_data?.tutor as TutorStepData | undefined}
       onProgressChange={handleProgressChange}
+      onResetTutor={resetTutorStep}
       dbSessionId={dbSessionId}
     />
   );

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -31,8 +31,14 @@ export interface TutorStepData {
   paragraph_summaries: TutorParagraphSummary[];
   /** Current paragraph the learner is on (for resume). */
   current_line_index?: number;
-  /** Final reading attempt summary, written when the whole flow finishes. */
-  reading_attempt?: {
+  /**
+   * Final reading attempt summary, written when the whole flow finishes.
+   * NOTE (#2533 review): the key is camelCase `readingAttempt` to match what is
+   * actually written/read at runtime (useLearningStepNavigation.ts writes
+   * `{ readingAttempt }`; useStepProgressPersistence.ts reads `tutorData.readingAttempt`).
+   * The previous snake_case `reading_attempt` never matched the stored key.
+   */
+  readingAttempt?: {
     storyId: string;
     accuracy: number;
     cpm: number;


### PR DESCRIPTION
## 實作 #2532 — 逐段朗讀「再讀一次」按鈕

全文朗讀完成畫面有「再讀一次」可重錄整篇；逐段朗讀完成所有段落後只有「觀看總結報告」。比照全文在逐段完成狀態加「再讀一次」，方便重新錄製整課。

### 修改
- **`LiveTutorControls`**：`isAllDone` 狀態由單一「觀看總結報告」改為「再讀一次 ＋ 觀看總結報告」並排；新增 `onReadAgain` prop（次要樣式，replay icon）。
- **`LiveTutor`**：`onReadAgain` = `stopSession()` + `stopTts()` + `resetForRetry()`（回到第 1 段、清 in-memory 與 localStorage，可立即重錄）。

### 與 #2530/#2531 的關係（逐段紀錄 DB 持久化，尚未 merge）
本 PR 從 staging 開分支（#2531 尚未 merge）。**目前 staging 上 `resetForRetry` 清 localStorage + in-memory 即足以重錄**，本 PR 在現行 staging 上功能完整。

待 #2531 merge（帶入 DB 持久化 + `line_results`/`paragraph_summaries_data` 欄位）後：非 toolbox 的「再讀一次」需讓 `onReadAgain` **額外清除 DB `step_data.tutor`**（否則 remount 會被 DB 舊資料還原）。此清除邏輯屬於本 PR 的 `onReadAgain`，會在**本 PR rebase 到已 merge 的 #2531**時補上（需要 #2531 才有的欄位）。#2531 自身的 `resetForRetry` 僅由 toolbox（不寫 DB）呼叫，故 #2531 本體不需改動。兩 PR 都動 `LiveTutor.tsx`，merge 時可能需 rebase。

### Frontend Render-Safety 驗證（ui-pr-verify SOP）
- **ESLint**：✅ 0 errors（僅既有 warning）
- **vitest smoke**：✅ 15/15
- tsc：LiveTutor 的 `TutorStepData` TS2304 為 staging 既有（本 PR 未觸及、#2531 會補 import），非本 PR 造成
- ⚠️ 互動式 /qa（完成逐段 → 點「再讀一次」→ 確認回到第 1 段可重錄）需真麥克風，preview 部署後人工驗收
