### PR TITLE
test(teacher-flows): #2539 P0 — conftest jsonb fix + grade authz/IDOR locks

### DIFF
--- a/backend/specs/test_teacher_comment_spec.py
+++ b/backend/specs/test_teacher_comment_spec.py
@@ -1,0 +1,87 @@
+import re
+
+import pytest
+
+from app.services.ai_generation.teacher_comment import generate_teacher_comment
+
+
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F300-\U0001FAFF"
+    "\U00002700-\U000027BF"
+    "\U00002600-\U000026FF"
+    "]"
+)
+
+
+@pytest.mark.asyncio
+async def test_teacher_comment_no_data_returns_empty_without_model_call(monkeypatch):
+    calls = {"count": 0}
+
+    async def fake_generate_structured_response(**kwargs):
+        calls["count"] += 1
+        return {"comment": "should not be generated"}
+
+    monkeypatch.setattr(
+        "app.services.ai_generation.teacher_comment.generate_structured_response",
+        fake_generate_structured_response,
+    )
+
+    result = await generate_teacher_comment(
+        story_title="沒有資料的課文",
+        accuracy=None,
+        cpm=None,
+        error_chars=["錯"],
+        comprehension_score=None,
+    )
+
+    assert result == ""
+    assert calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_teacher_comment_model_exception_returns_empty(monkeypatch):
+    async def fake_generate_structured_response(**kwargs):
+        raise RuntimeError("mock teacher comment model outage")
+
+    monkeypatch.setattr(
+        "app.services.ai_generation.teacher_comment.generate_structured_response",
+        fake_generate_structured_response,
+    )
+
+    result = await generate_teacher_comment(
+        story_title="模型失敗的課文",
+        accuracy=82.0,
+        cpm=118.0,
+        error_chars=["藍", "籃"],
+        comprehension_score=73.0,
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_teacher_comment_normal_path_returns_comment_str_with_error_chars_and_no_emoji(monkeypatch):
+    async def fake_generate_structured_response(**kwargs):
+        return {"comment": "你已經能穩定朗讀，請再練習藍、籃這兩個容易混淆的字"}
+
+    monkeypatch.setattr(
+        "app.services.ai_generation.teacher_comment.generate_structured_response",
+        fake_generate_structured_response,
+    )
+
+    result = await generate_teacher_comment(
+        story_title="容易混淆的字",
+        accuracy=91.0,
+        cpm=146.0,
+        error_chars=["藍", "籃"],
+        comprehension_score=88.0,
+    )
+
+    # Contract: generate_teacher_comment returns the comment STRING (not a dict);
+    # it extracts result.get("comment", "") from the structured LLM response.
+    assert isinstance(result, str)
+    assert result  # non-empty comment on the normal path
+    assert "藍" in result
+    assert "籃" in result
+    assert EMOJI_RE.search(result) is None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,8 +5,10 @@ Patches PostgreSQL-specific column types (JSONB) to SQLite-compatible types (JSO
 before table creation, so all tests can use SQLite in-memory databases.
 
 Also patches server_default values that contain PostgreSQL-specific syntax (::jsonb casts)
-which SQLite cannot parse.
+which SQLite cannot parse, and mirrors PostgreSQL partial-index predicates to
+SQLite partial indexes.
 """
+import json
 import sys
 import os
 
@@ -15,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.schema import DefaultClause
 from app.models import Base
 
 
@@ -29,8 +32,9 @@ def _patch_jsonb_columns():
 def _patch_pg_server_defaults():
     """Remove PostgreSQL-specific server_default values (e.g. ::jsonb casts).
 
-    SQLite cannot parse expressions like ``'{}'::jsonb``, so we strip any
-    server_default whose text contains '::', leaving Python-side defaults intact.
+    SQLite cannot parse expressions like ``'{}'::jsonb``. For JSON literals,
+    replace them with SQLite-safe JSON text defaults; otherwise strip the
+    PostgreSQL-only default and leave Python-side defaults intact.
     """
     for table in Base.metadata.sorted_tables:
         for column in table.columns:
@@ -42,13 +46,63 @@ def _patch_pg_server_defaults():
             if arg is None:
                 continue
             arg_text = getattr(arg, "text", None)
+            if not isinstance(arg_text, str) and isinstance(arg, str):
+                arg_text = arg
             if isinstance(arg_text, str) and "::" in arg_text:
+                sqlite_default = _sqlite_json_default_from_pg_cast(arg_text)
+                if sqlite_default is not None:
+                    column.server_default = sqlite_default
+                    continue
                 column.server_default = None
 
 
+def _sqlite_json_default_from_pg_cast(default_text):
+    """Return a SQLite-safe JSON default for quoted JSON PostgreSQL casts."""
+    literal = default_text.split("::", 1)[0].strip()
+    if len(literal) < 2 or literal[0] != literal[-1] or literal[0] not in {"'", '"'}:
+        return None
+
+    quote = literal[0]
+    value = literal[1:-1]
+    if quote == "'":
+        value = value.replace("''", "'")
+
+    try:
+        json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+    return DefaultClause(value)
+
+
+def _patch_pg_partial_indexes():
+    """Mirror PostgreSQL partial indexes to SQLite for test DB parity."""
+    for table in Base.metadata.sorted_tables:
+        for index in table.indexes:
+            pg_where = index.dialect_options["postgresql"].get("where")
+            sqlite_where = index.dialect_options["sqlite"].get("where")
+            if pg_where is not None and sqlite_where is None:
+                index.dialect_options["sqlite"]["where"] = pg_where
+
+
+def _apply_sqlite_metadata_patches():
+    _patch_jsonb_columns()
+    _patch_pg_server_defaults()
+    _patch_pg_partial_indexes()
+
+
+_original_create_all = Base.metadata.create_all
+
+
+def _create_all_with_sqlite_patches(*args, **kwargs):
+    _apply_sqlite_metadata_patches()
+    return _original_create_all(*args, **kwargs)
+
+
+Base.metadata.create_all = _create_all_with_sqlite_patches
+
 # Run once at import time, before any test creates tables.
-_patch_jsonb_columns()
-_patch_pg_server_defaults()
+_apply_sqlite_metadata_patches()
 
 
 def pytest_runtest_setup(item):

--- a/backend/tests/security/test_dynamic_security.py
+++ b/backend/tests/security/test_dynamic_security.py
@@ -431,6 +431,44 @@ def _create_classroom_direct(school_id: int, teacher_id: int, name: str) -> int:
         db.close()
 
 
+def _create_assignment_submission_direct(classroom_id: int, teacher_id: int, student_id: int) -> tuple[int, int]:
+    from app.models.assignment import Assignment, AssignmentSubmission
+    from app.models.school import ClassroomStudent
+
+    db = TestingSessionLocal()
+    try:
+        enrolled = (
+            db.query(ClassroomStudent)
+            .filter(
+                ClassroomStudent.classroom_id == classroom_id,
+                ClassroomStudent.student_id == student_id,
+            )
+            .first()
+        )
+        if enrolled is None:
+            db.add(ClassroomStudent(classroom_id=classroom_id, student_id=student_id))
+            db.flush()
+
+        assignment = Assignment(
+            classroom_id=classroom_id,
+            teacher_id=teacher_id,
+            story_id="1",
+            assignment_type="reading",
+        )
+        db.add(assignment)
+        db.flush()
+        submission = AssignmentSubmission(
+            assignment_id=assignment.id,
+            student_id=student_id,
+            status="submitted",
+        )
+        db.add(submission)
+        db.commit()
+        return assignment.id, submission.id
+    finally:
+        db.close()
+
+
 def test_med1d_org_admin_lists_only_own_org_classrooms(client):
     # #2470 MED-1d: GET /api/classrooms must scope org_admin to their own org's
     # classrooms, not the whole platform (was is_admin → any org_admin saw all).
@@ -452,3 +490,102 @@ def test_med1d_org_admin_lists_only_own_org_classrooms(client):
     ids = [c["id"] for c in r.json()["items"]]
     assert cls_a in ids, "org_admin should see own org's classroom"
     assert cls_b not in ids, "org_admin must NOT see another org's classroom (MED-1d)"
+
+
+def test_org_admin_cannot_create_classroom_in_another_org_school(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"WrbacA_{u}")
+    org_b = _create_org(f"WrbacB_{u}")
+    school_b = _create_school(org_b)
+    admin_a = _create_user(f"wrbac_oa_{u}@example.com")
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+
+    r = client.post(
+        "/api/classrooms",
+        json={"name": f"Cross org create {u}", "school_id": school_b, "grade": 6},
+        headers=_auth(create_access_token(admin_a)),
+    )
+
+    assert r.status_code == 403, r.text
+
+
+def test_teacher_without_school_membership_cannot_create_classroom(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"NoMemberA_{u}")
+    org_b = _create_org(f"NoMemberB_{u}")
+    school_a = _create_school(org_a)
+    school_b = _create_school(org_b)
+    teacher = _create_user(f"nomember_t_{u}@example.com")
+    _grant_role(teacher, "teacher", "school", str(school_a))
+
+    r = client.post(
+        "/api/classrooms",
+        json={"name": f"Not my school {u}", "school_id": school_b, "grade": 5},
+        headers=_auth(create_access_token(teacher)),
+    )
+
+    assert r.status_code == 403, r.text
+
+
+def test_org_admin_cannot_add_student_to_another_org_classroom(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"AddA_{u}")
+    org_b = _create_org(f"AddB_{u}")
+    school_b = _create_school(org_b)
+    teacher_b = _create_user(f"add_tb_{u}@example.com")
+    student_b = _create_user(f"add_sb_{u}@example.com")
+    classroom_b = _create_classroom_direct(school_b, teacher_b, f"AddBClass_{u}")
+    admin_a = _create_user(f"add_oa_{u}@example.com")
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+
+    r = client.post(
+        f"/api/classrooms/{classroom_b}/students",
+        json={"student_id": student_b},
+        headers=_auth(create_access_token(admin_a)),
+    )
+
+    assert r.status_code == 403, r.text
+
+
+def test_org_admin_cannot_create_assignment_in_another_org_classroom(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"AsnA_{u}")
+    org_b = _create_org(f"AsnB_{u}")
+    school_b = _create_school(org_b)
+    teacher_b = _create_user(f"asn_tb_{u}@example.com")
+    classroom_b = _create_classroom_direct(school_b, teacher_b, f"AsnBClass_{u}")
+    admin_a = _create_user(f"asn_oa_{u}@example.com")
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+
+    r = client.post(
+        f"/api/classrooms/{classroom_b}/assignments",
+        json={"story_id": "1", "title": f"Cross org assignment {u}"},
+        headers=_auth(create_access_token(admin_a)),
+    )
+
+    assert r.status_code == 403, r.text
+
+
+def test_org_admin_cannot_grade_submission_in_another_org_classroom(client):
+    u = uuid.uuid4().hex[:6]
+    org_a = _create_org(f"GradeA_{u}")
+    org_b = _create_org(f"GradeB_{u}")
+    school_b = _create_school(org_b)
+    teacher_b = _create_user(f"grade_tb_{u}@example.com")
+    student_b = _create_user(f"grade_sb_{u}@example.com")
+    classroom_b = _create_classroom_direct(school_b, teacher_b, f"GradeBClass_{u}")
+    assignment_id, submission_id = _create_assignment_submission_direct(
+        classroom_b,
+        teacher_b,
+        student_b,
+    )
+    admin_a = _create_user(f"grade_oa_{u}@example.com")
+    _grant_role(admin_a, "org_admin", "organization", org_a)
+
+    r = client.patch(
+        f"/api/assignments/{assignment_id}/submissions/{submission_id}",
+        json={"score": 92, "teacher_feedback": "Cross-org grading must be denied"},
+        headers=_auth(create_access_token(admin_a)),
+    )
+
+    assert r.status_code == 403, r.text

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -2076,6 +2076,113 @@ class TestTeacherFeedback:
         assert resp.json()["teacher_feedback"] == "更新後的評語"
 
 
+# ====================================================================
+# Teacher Grading Authorization / IDOR Contract Tests
+# ====================================================================
+
+class TestTeacherGradingAuthorization:
+    """Locks authz and assignment-scoped submission lookup for teacher grading."""
+
+    @pytest.fixture(scope="class")
+    def setup(self, client, school_id):
+        teacher = _register_and_login(client, "grade_auth_teacher")
+        other_teacher = _register_and_login(client, "grade_auth_other_teacher")
+        student = _register_and_login(client, "grade_auth_student")
+        _make_student_role(student["user_id"], school_id)
+
+        cls_resp = client.post(
+            "/api/classrooms",
+            headers=auth_header(teacher["token"]),
+            json={"name": "Grade Auth Contract Class", "school_id": school_id},
+        )
+        assert cls_resp.status_code == 201
+        classroom_id = cls_resp.json()["id"]
+
+        enroll_resp = client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            headers=auth_header(teacher["token"]),
+            json={"student_id": student["user_id"]},
+        )
+        assert enroll_resp.status_code in (200, 201)
+
+        assignment_ids = []
+        submission_ids = []
+        for idx in range(2):
+            asn_resp = client.post(
+                f"/api/classrooms/{classroom_id}/assignments",
+                headers=auth_header(teacher["token"]),
+                json={
+                    "classroom_id": classroom_id,
+                    "story_id": str(idx + 1),
+                    "title": f"Grade Auth Assignment {idx + 1}",
+                },
+            )
+            assert asn_resp.status_code == 201
+            assignment_id = asn_resp.json()["id"]
+            assignment_ids.append(assignment_id)
+
+            detail_resp = client.get(
+                f"/api/assignments/{assignment_id}",
+                headers=auth_header(teacher["token"]),
+            )
+            assert detail_resp.status_code == 200
+            submissions = detail_resp.json()["submissions"]
+            assert len(submissions) == 1
+            submission_ids.append(submissions[0]["id"])
+
+        return {
+            "teacher": teacher,
+            "other_teacher": other_teacher,
+            "assignment_ids": assignment_ids,
+            "submission_ids": submission_ids,
+        }
+
+    def test_non_owner_teacher_cannot_grade_submission(self, client, setup):
+        """A teacher who does not own the assignment classroom gets 403."""
+        resp = client.patch(
+            f"/api/assignments/{setup['assignment_ids'][0]}/submissions/{setup['submission_ids'][0]}",
+            headers=auth_header(setup["other_teacher"]["token"]),
+            json={"score": 91, "teacher_feedback": "Unauthorized grade attempt"},
+        )
+
+        assert resp.status_code == 403
+
+    def test_submission_id_must_belong_to_path_assignment(self, client, setup):
+        """A submission from another assignment must not be graded through this path."""
+        path_assignment_id = setup["assignment_ids"][0]
+        other_assignment_id = setup["assignment_ids"][1]
+        other_submission_id = setup["submission_ids"][1]
+
+        resp = client.patch(
+            f"/api/assignments/{path_assignment_id}/submissions/{other_submission_id}",
+            headers=auth_header(setup["teacher"]["token"]),
+            json={"score": 100, "teacher_feedback": "Wrong assignment path"},
+        )
+
+        assert resp.status_code == 404
+
+        detail_resp = client.get(
+            f"/api/assignments/{other_assignment_id}",
+            headers=auth_header(setup["teacher"]["token"]),
+        )
+        assert detail_resp.status_code == 200
+        submission = next(
+            sub for sub in detail_resp.json()["submissions"] if sub["id"] == other_submission_id
+        )
+        assert submission["status"] == "pending"
+        assert submission["score"] is None
+        assert submission["teacher_feedback"] is None
+
+    def test_grade_submission_not_found(self, client, teacher):
+        resp = client.patch(
+            "/api/assignments/999999999/submissions/999999999",
+            headers=auth_header(teacher["token"]),
+            json={"score": 88, "teacher_feedback": "Missing records"},
+        )
+
+        assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Issue #414 — Reading goals in StartAssignmentResponse
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_co_teaching_api.py
+++ b/backend/tests/test_co_teaching_api.py
@@ -19,6 +19,7 @@ Run with:
 """
 import sys
 import os
+import uuid
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -201,6 +202,63 @@ def _h(token):
     return {"Authorization": f"Bearer {token}"}
 
 
+def _fresh_co_teacher(client, owner_token, classroom_id) -> str:
+    suffix = uuid.uuid4().hex[:8]
+    email = f"readonly_{suffix}@test.com"
+    token = _register(client, "Read Only Co Teacher", email)
+    invite = client.post(
+        f"/api/classrooms/{classroom_id}/teachers",
+        json={"email": email},
+        headers=_h(owner_token),
+    )
+    assert invite.status_code == 201, invite.text
+    return token
+
+
+def _fresh_student(client) -> dict:
+    suffix = uuid.uuid4().hex[:8]
+    token = _register(client, "Boundary Student", f"boundary_student_{suffix}@test.com")
+    me = client.get("/api/users/me", headers=_h(token))
+    assert me.status_code == 200, me.text
+    return {"token": token, "user_id": me.json()["id"]}
+
+
+def _create_assignment(client, owner_token, classroom_id) -> int:
+    r = client.post(
+        f"/api/classrooms/{classroom_id}/assignments",
+        json={"story_id": "1", "title": f"Co-teacher Boundary {uuid.uuid4().hex[:6]}"},
+        headers=_h(owner_token),
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _create_boundary_classroom(client, owner_token) -> int:
+    r = client.post(
+        "/api/classrooms",
+        json={"name": f"Boundary Class {uuid.uuid4().hex[:6]}", "school_id": _test_school_id},
+        headers=_h(owner_token),
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _first_submission_id(assignment_id: int) -> int:
+    from app.models.assignment import AssignmentSubmission
+
+    db = TestingSessionLocal()
+    try:
+        submission = (
+            db.query(AssignmentSubmission)
+            .filter(AssignmentSubmission.assignment_id == assignment_id)
+            .first()
+        )
+        assert submission is not None, "assignment setup should create at least one submission"
+        return submission.id
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -260,6 +318,64 @@ def test_co_teacher_sees_classroom_in_dashboard(client, co_teacher_token, classr
     assert r.status_code == 200
     ids = [c["id"] for c in r.json()["items"]]
     assert classroom_id in ids
+
+
+def test_co_teacher_cannot_create_assignment(client, owner_token):
+    """Co-teacher can read the classroom but cannot create assignments."""
+    classroom_id = _create_boundary_classroom(client, owner_token)
+    token = _fresh_co_teacher(client, owner_token, classroom_id)
+
+    read = client.get(f"/api/classrooms/{classroom_id}", headers=_h(token))
+    assert read.status_code == 200
+
+    r = client.post(
+        f"/api/classrooms/{classroom_id}/assignments",
+        json={"story_id": "1", "title": "Co-teacher should be read-only"},
+        headers=_h(token),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_co_teacher_cannot_add_student(client, owner_token):
+    """Co-teacher can read the classroom but cannot add students."""
+    classroom_id = _create_boundary_classroom(client, owner_token)
+    token = _fresh_co_teacher(client, owner_token, classroom_id)
+    student = _fresh_student(client)
+
+    read = client.get(f"/api/classrooms/{classroom_id}", headers=_h(token))
+    assert read.status_code == 200
+
+    r = client.post(
+        f"/api/classrooms/{classroom_id}/students",
+        json={"student_id": student["user_id"]},
+        headers=_h(token),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_co_teacher_cannot_grade_submission(client, owner_token):
+    """Co-teacher can read the classroom but cannot grade submissions."""
+    classroom_id = _create_boundary_classroom(client, owner_token)
+    token = _fresh_co_teacher(client, owner_token, classroom_id)
+    student = _fresh_student(client)
+    add = client.post(
+        f"/api/classrooms/{classroom_id}/students",
+        json={"student_id": student["user_id"]},
+        headers=_h(owner_token),
+    )
+    assert add.status_code == 201, add.text
+    assignment_id = _create_assignment(client, owner_token, classroom_id)
+    submission_id = _first_submission_id(assignment_id)
+
+    read = client.get(f"/api/classrooms/{classroom_id}", headers=_h(token))
+    assert read.status_code == 200
+
+    r = client.patch(
+        f"/api/assignments/{assignment_id}/submissions/{submission_id}",
+        json={"score": 88, "teacher_feedback": "Co-teacher grading must be denied"},
+        headers=_h(token),
+    )
+    assert r.status_code == 403, r.text
 
 
 def test_co_teacher_cannot_invite_others(client, co_teacher_token, classroom_id):

--- a/backend/tests/test_teacher_api.py
+++ b/backend/tests/test_teacher_api.py
@@ -168,6 +168,25 @@ def auth_header(token: str) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _seed_teacher_report_session(student_id: int, **overrides) -> int:
+    db = TestingSessionLocal()
+    try:
+        session = LearningSession(
+            student_id=student_id,
+            story_slug=f"teacher-report-{uuid.uuid4().hex[:8]}",
+            status=overrides.pop("status", "completed"),
+            started_at=datetime.now(timezone.utc),
+            full_reading_attempts=[],
+            **overrides,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+        return session.id
+    finally:
+        db.close()
+
+
 def _make_admin(user_id: int):
     db = TestingSessionLocal()
     role = db.query(Role).filter(Role.name == "system_admin").first()
@@ -657,6 +676,128 @@ class TestTeacherDashboardFullFlow:
         for p in progress:
             assert p["total_sessions"] == 0
             assert p["last_session_date"] is None
+
+
+# ===========================================================================
+# Teacher session report review/comment contract
+# ===========================================================================
+
+
+class TestTeacherSessionReportReviewContract:
+    def test_report_first_view_sets_teacher_reviewed_at(self, client, teacher, student1, school_id):
+        create_resp = client.post(
+            "/api/classrooms",
+            json={"name": "Review Timestamp Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = create_resp.json()["id"]
+        add_resp = client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            json={"student_id": student1["user_id"]},
+            headers=auth_header(teacher["token"]),
+        )
+        assert add_resp.status_code == 201
+        session_id = _seed_teacher_report_session(
+            student1["user_id"],
+            teacher_reviewed_at=None,
+        )
+
+        resp = client.get(
+            f"/api/teacher/students/{student1['user_id']}/sessions/{session_id}/report",
+            headers=auth_header(teacher["token"]),
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["teacher_reviewed_at"] is not None
+        db = TestingSessionLocal()
+        try:
+            session = db.query(LearningSession).filter(LearningSession.id == session_id).one()
+            assert session.teacher_reviewed_at is not None
+        finally:
+            db.close()
+
+    def test_save_teacher_comment_persists_and_unauthorized_teacher_gets_403(
+        self, client, teacher, other_teacher, student2, school_id
+    ):
+        create_resp = client.post(
+            "/api/classrooms",
+            json={"name": "Teacher Comment Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = create_resp.json()["id"]
+        add_resp = client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            json={"student_id": student2["user_id"]},
+            headers=auth_header(teacher["token"]),
+        )
+        assert add_resp.status_code == 201
+        session_id = _seed_teacher_report_session(student2["user_id"])
+        comment = "已確認朗讀狀況，請下次多練習容易混淆的字"
+
+        save_resp = client.post(
+            f"/api/teacher/students/{student2['user_id']}/sessions/{session_id}/comment",
+            json={"comment": comment},
+            headers=auth_header(teacher["token"]),
+        )
+
+        assert save_resp.status_code == 200, save_resp.text
+        assert save_resp.json()["teacher_comment"] == comment
+        db = TestingSessionLocal()
+        try:
+            session = db.query(LearningSession).filter(LearningSession.id == session_id).one()
+            assert session.teacher_comment == comment
+            assert session.teacher_reviewed_at is not None
+        finally:
+            db.close()
+
+        forbidden = client.post(
+            f"/api/teacher/students/{student2['user_id']}/sessions/{session_id}/comment",
+            json={"comment": "unauthorized edit"},
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert forbidden.status_code == 403, forbidden.text
+
+    def test_generate_ai_comment_uses_cached_comment_without_second_model_call(
+        self, client, teacher, student1, monkeypatch, school_id
+    ):
+        create_resp = client.post(
+            "/api/classrooms",
+            json={"name": "AI Cache Contract Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = create_resp.json()["id"]
+        add_resp = client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            json={"student_id": student1["user_id"]},
+            headers=auth_header(teacher["token"]),
+        )
+        assert add_resp.status_code in (201, 409), add_resp.text
+        session_id = _seed_teacher_report_session(
+            student1["user_id"],
+            accuracy=91.0,
+            reading_result={"cpm": 142},
+            comprehension_score=86.0,
+        )
+        calls = {"count": 0}
+
+        async def fake_generate_teacher_comment(**kwargs):
+            calls["count"] += 1
+            return "Cached AI comment after first generation"
+
+        monkeypatch.setattr(
+            "app.services.ai_generation.generate_teacher_comment",
+            fake_generate_teacher_comment,
+        )
+
+        url = f"/api/teacher/students/{student1['user_id']}/sessions/{session_id}/generate-ai-comment"
+        first = client.post(url, headers=auth_header(teacher["token"]))
+        second = client.post(url, headers=auth_header(teacher["token"]))
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        assert first.json()["ai_comment"] == "Cached AI comment after first generation"
+        assert second.json()["ai_comment"] == "Cached AI comment after first generation"
+        assert calls["count"] == 1
 
 
 # ===========================================================================


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

#2539 P0 兩項（走 spec/contract 路線，非 e2e 點擊；codex 執行 + Claude 逐項親驗）：

**P0-1 conftest jsonb 修復**（58541dae）— `_patch_pg_server_defaults` 原只處理 text() 包裝的 PG server_default，漏了純字串 `server_default="'[]'::jsonb"`（session.full_reading_attempts / omo_upload）→ SQLite 存字面值 → 2 支 teacher_api contract test 是死的。修後兩者活。prod PostgreSQL server_default 未動。

**P0-2 批改路由 authz + IDOR 回歸鎖**（941d7a1c）— `TestTeacherGradingAuthorization`：非 owner 批改→403、跨 assignment 的 submission_id→404(IDOR，並驗無副作用)、not-found→404。鎖 `PATCH /assignments/{id}/submissions/{sid}` 既有安全行為。**mutation 驗過**（neuter authz→403 測試轉紅），非劇場。

驗證：test_teacher_api 29/0、teacher+classrooms+assignments+join 183 passed、test_assignments 77 passed，皆 test-only 無 prod 改動。P1（跨 org 寫入 RBAC / teacher_comment EDD / 檢閱線 / co-teacher 邊界）進行中。