### PR TITLE
fix(assignments): #2539 BUG-2 notifications wiring + block submit-from-pending

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -607,6 +607,9 @@ def submit_assignment(
     if not assignment.is_active:
         raise HTTPException(status_code=400, detail="Assignment is not active")
 
+    if submission.status == "pending" and submission.session_id is None:
+        raise HTTPException(status_code=400, detail="Assignment not started")
+
     # Idempotent: already submitted/graded, just return current state
     if submission.status in ("submitted", "graded"):
         return student_assignment_to_response(assignment, submission, db)

--- a/backend/app/services/assignment_lifecycle_service.py
+++ b/backend/app/services/assignment_lifecycle_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from ..models.assignment import Assignment, AssignmentSubmission
-from ..models.school import ClassroomStudent, ClassroomText
+from ..models.school import Classroom, ClassroomStudent, ClassroomText
 from ..models.session import CharacterError, DialogueTurn, LearningSession
 from ..models.text import Text
 from ..models.user import User
@@ -22,9 +22,14 @@ from ..schemas.assignment import (
 from ..models.session import ReadingAttemptHistory
 from ..services.assignment_responses import extract_reading_metrics
 from ..services.assignment_copy_strategy import resolve_text_for_assignment
+from ..services.assignment_queries import resolve_title_for_assignment
 from ..services.audio_upload_service import delete_gcs_blobs_for_paths
 from ..services.input_sanitizer import sanitize_ai_input
 from ..services.lesson_loader import get_lesson_by_id
+from ..services.notification_service import (
+    send_assignment_graded_notification,
+    send_new_assignment_notification,
+)
 from ..utils.slug import normalize_story_slug
 
 logger = logging.getLogger(__name__)
@@ -166,6 +171,76 @@ def list_classroom_assignments_with_counts(
     return assignments, precomputed
 
 
+def _send_new_assignment_notifications_best_effort(
+    assignment: Assignment,
+    student_ids: list[int],
+    db: Session,
+) -> None:
+    try:
+        classroom = db.query(Classroom).filter(Classroom.id == assignment.classroom_id).first()
+        students = db.query(User).filter(User.id.in_(student_ids)).all() if student_ids else []
+        students_by_id = {student.id: student for student in students}
+        story_title = resolve_title_for_assignment(assignment, db)
+        classroom_name = classroom.name if classroom else f"Classroom #{assignment.classroom_id}"
+
+        for student_id in student_ids:
+            student = students_by_id.get(student_id)
+            try:
+                send_new_assignment_notification(
+                    student_id=student_id,
+                    student_name=student.name if student else str(student_id),
+                    story_title=story_title,
+                    classroom_name=classroom_name,
+                    due_date=assignment.due_date,
+                    assignment_type=assignment.assignment_type,
+                    db=db,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to send new assignment notification for assignment %d student %d",
+                    assignment.id,
+                    student_id,
+                    exc_info=True,
+                )
+    except Exception:
+        logger.warning(
+            "Failed to send new assignment notifications for assignment %d",
+            assignment.id,
+            exc_info=True,
+        )
+
+
+def _send_assignment_graded_notification_best_effort(
+    submission: AssignmentSubmission,
+    db: Session,
+) -> None:
+    try:
+        student = db.query(User).filter(User.id == submission.student_id).first()
+        assignment = (
+            db.query(Assignment)
+            .filter(Assignment.id == submission.assignment_id)
+            .first()
+        )
+        story_title = (
+            resolve_title_for_assignment(assignment, db)
+            if assignment is not None
+            else f"Assignment #{submission.assignment_id}"
+        )
+        send_assignment_graded_notification(
+            student_id=submission.student_id,
+            student_name=student.name if student else str(submission.student_id),
+            story_title=story_title,
+            score=submission.score,
+            db=db,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send assignment graded notification for submission %d",
+            submission.id,
+            exc_info=True,
+        )
+
+
 def create_assignment_with_submissions(
     classroom_id: int,
     teacher_id: int,
@@ -257,10 +332,12 @@ def create_assignment_with_submissions(
     # Defensive dedupe: legacy/corrupt data may contain repeated student links.
     # Avoid unique constraint conflicts on (assignment_id, student_id).
     unique_student_ids: set[int] = set()
+    notified_student_ids: list[int] = []
     for enrollment in enrollments:
         if enrollment.student_id in unique_student_ids:
             continue
         unique_student_ids.add(enrollment.student_id)
+        notified_student_ids.append(enrollment.student_id)
         submission = AssignmentSubmission(
             assignment_id=assignment.id,
             student_id=enrollment.student_id,
@@ -270,6 +347,11 @@ def create_assignment_with_submissions(
 
     db.commit()
     db.refresh(assignment)
+    _send_new_assignment_notifications_best_effort(
+        assignment,
+        notified_student_ids,
+        db,
+    )
 
     logger.info(
         "Created assignment %d for classroom %d (story=%s, text_id=%s, students=%d)",
@@ -444,6 +526,7 @@ def grade_assignment_submission(
 
     db.commit()
     db.refresh(submission)
+    _send_assignment_graded_notification_best_effort(submission, db)
     logger.info(
         "Teacher %d graded submission %d (score=%s, feedback=%s)",
         user_id, submission.id, payload.score,

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -467,6 +467,39 @@ class TestCreateAssignment:
         assert data["submission_count"] == 2
         assert data["completed_count"] == 0
 
+    def test_create_assignment_sends_new_assignment_notifications(
+        self, client, teacher, student1, student2, classroom_with_students
+    ):
+        from unittest.mock import patch
+
+        with patch(
+            "app.services.assignment_lifecycle_service.send_new_assignment_notification",
+        ) as mock_notify:
+            resp = client.post(
+                f"/api/classrooms/{classroom_with_students}/assignments",
+                json={
+                    "classroom_id": classroom_with_students,
+                    "story_id": VALID_STORY_ID,
+                    "title": "Notification Assignment",
+                    "assignment_type": "reading",
+                },
+                headers=auth_header(teacher["token"]),
+            )
+
+        assert resp.status_code == 201
+        assert mock_notify.call_count == 2
+        notified_student_ids = {
+            call.kwargs["student_id"] for call in mock_notify.call_args_list
+        }
+        assert notified_student_ids == {student1["user_id"], student2["user_id"]}
+        for call in mock_notify.call_args_list:
+            assert call.kwargs["student_name"]
+            assert call.kwargs["story_title"]
+            assert call.kwargs["classroom_name"] == "Assignment Test Classroom"
+            assert call.kwargs["due_date"] is None
+            assert call.kwargs["assignment_type"] == "reading"
+            assert call.kwargs["db"] is not None
+
     def test_create_assignment_syncs_classroom_text_for_story(
         self, client, teacher, school_id
     ):
@@ -1668,6 +1701,26 @@ class TestSubmitAssignment:
         resp = client.post("/api/assignments/1/submit")
         assert resp.status_code == 401
 
+    def test_submit_from_pending_without_start_returns_400(
+        self, client, teacher, school_id
+    ):
+        student, _, assignment_id = _create_assignment_for_fresh_student(
+            client,
+            teacher,
+            school_id,
+            student_suffix="submit_pending_guard_stu",
+            classroom_name="Submit Pending Guard Classroom",
+            title="Submit Pending Guard",
+        )
+
+        resp = client.post(
+            f"/api/assignments/{assignment_id}/submit",
+            headers=auth_header(student["token"]),
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Assignment not started"
+
     def test_student_can_submit_assignment(
         self, client, teacher, student1, classroom_with_students
     ):
@@ -2498,6 +2551,59 @@ class TestTeacherFeedback:
         assert data["score"] == 85
         assert data["teacher_feedback"] == "很棒！朗讀流暢，繼續加油"
         assert data["status"] == "graded"
+
+    def test_grade_submission_sends_assignment_graded_notification(
+        self, client, school_id
+    ):
+        from unittest.mock import patch
+
+        teacher = _register_and_login(client, "grade_notify_teacher")
+        student, _, assignment_id = _create_assignment_for_fresh_student(
+            client,
+            teacher,
+            school_id,
+            student_suffix="grade_notify_student",
+            classroom_name="Grade Notify Classroom",
+            title="Grade Notify Assignment",
+            story_id="2",
+        )
+
+        start_resp = client.post(
+            f"/api/assignments/{assignment_id}/start",
+            headers=auth_header(student["token"]),
+        )
+        assert start_resp.status_code == 200
+
+        submit_resp = client.post(
+            f"/api/assignments/{assignment_id}/submit",
+            headers=auth_header(student["token"]),
+        )
+        assert submit_resp.status_code == 200
+
+        detail_resp = client.get(
+            f"/api/assignments/{assignment_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert detail_resp.status_code == 200
+        submission_id = detail_resp.json()["submissions"][0]["id"]
+
+        with patch(
+            "app.services.assignment_lifecycle_service.send_assignment_graded_notification",
+        ) as mock_notify:
+            resp = client.patch(
+                f"/api/assignments/{assignment_id}/submissions/{submission_id}",
+                headers=auth_header(teacher["token"]),
+                json={"score": 92, "teacher_feedback": "Great work"},
+            )
+
+        assert resp.status_code == 200
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["student_id"] == student["user_id"]
+        assert kwargs["student_name"] == student["name"]
+        assert kwargs["story_title"]
+        assert kwargs["score"] == 92
+        assert kwargs["db"] is not None
 
     def test_feedback_visible_in_assignment_detail(self, client, setup):
         """Feedback saved appears in AssignmentDetailResponse submissions list."""


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

#2539 收尾 2 個 prod 行為修（Young 拍板「做完」；codex 執行 + Claude mutation 驗）：

**BUG-2 通知接線**：`send_new_assignment_notification` / `send_assignment_graded_notification` 原本有定義+單測但**從沒被呼叫**。接進 `create_assignment_with_submissions`（每個學生）+ `grade_assignment_submission`，**best-effort**（例外吞+log，絕不擋建課/批改）。RED-before：notifier call count 0。

**submit-from-pending 擋**：pending + 無 session（學生沒 /start）原本可直接翻 submitted（score=None）跳過整條流程。現在 400「Assignment not started」。**mutation 驗過**（neuter guard→測試轉紅）。正常 start→submit + idempotent re-submit 不受影響。

驗證：test_assignments 102 passed、3 支新測試綠、spec CI PASS。