### PR TITLE
fix(learning-steps): alias worksheet section types to registry ids (#2526)

### DIFF
--- a/frontend/src/config/stepConfig.test.ts
+++ b/frontend/src/config/stepConfig.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { stepSequenceFromWorksheet, resolveActiveSteps } from './stepConfig';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  stepSequenceFromWorksheet,
+  resolveActiveSteps,
+  STEP_REGISTRY,
+  KNOWN_UNMAPPED_WORKSHEET_TYPES,
+} from './stepConfig';
 
 // The authoritative per-lesson worksheet section order, straight from a real
 // lesson YAML (backend/data/lessons/L43.yml worksheet_section_order).
@@ -57,5 +62,90 @@ describe('stepSequenceFromWorksheet — 學習步驟動態對應學習單', () =
         { number: '二', name: '閱讀理解', type: 'comprehension' },
       ]),
     ).toEqual(['intro', 'comprehension']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2526 regression — REAL parser vocabulary (not the fictional names above)
+//
+// The current curriculum SOT serves a worksheet `type` vocabulary that does NOT
+// line up with STEP_REGISTRY ids after a plain `_`→`-` swap. Straight from real
+// lesson data: backend/data/lessons/_parsed_2026-05-01/G8-L16.yml
+// (structure_table/spotlight/mcq/word_search/vocab_definitions appear in 100+
+// courses each). Under the old code these all `continue`-dropped SILENTLY, so
+// ~74% of sections vanished on ~16 courses with no manual step_sequence.
+// ---------------------------------------------------------------------------
+const G8_L16_WORKSHEET = [
+  { number: '二', name: '念順順', type: 'reading_timer' }, //     AMBIGUOUS → not mapped (warns)
+  { number: '三', name: '語詞我最棒', type: 'vocab_definitions' }, // → vocab-definition
+  { number: '四', name: '語詞應用', type: 'vocab_application' }, //  → vocab-application (dash only)
+  { number: '五', name: '文章重點表', type: 'structure_table' }, //  → story-structure
+  { number: '六', name: '知識補給站', type: 'knowledge_station' }, // → knowledge-station (dash only)
+  { number: '七', name: '閱讀聚光燈', type: 'spotlight' }, //        → reading-strategy
+  { number: '八', name: '閱讀理解', type: 'mcq' }, //               → comprehension
+  { number: '九', name: '詞語複習', type: 'word_search' }, //        → vocab-word-search
+];
+
+describe('stepSequenceFromWorksheet — REAL parser vocabulary alias map (#2526)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Each of the 5 aliased types + the 2 that already worked via the dash
+  // transform MUST resolve to a real STEP_REGISTRY id (no silent drop).
+  it.each([
+    ['vocab_definitions', 'vocab-definition'], //  ALIAS (plural → singular)
+    ['structure_table', 'story-structure'], //     ALIAS
+    ['spotlight', 'reading-strategy'], //          ALIAS
+    ['mcq', 'comprehension'], //                   ALIAS
+    ['word_search', 'vocab-word-search'], //       ALIAS
+    ['vocab_application', 'vocab-application'], //  already worked (dash transform)
+    ['knowledge_station', 'knowledge-station'], //  already worked (dash transform)
+  ])('parser type "%s" resolves to registry id "%s"', (type, expectedId) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(STEP_REGISTRY[expectedId]).toBeDefined();
+    const seq = stepSequenceFromWorksheet([{ number: '一', name: 'x', type }]);
+    expect(seq).toContain(expectedId);
+  });
+
+  it('resolves a full real worksheet in order (reading_timer dropped, other 7 kept)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(stepSequenceFromWorksheet(G8_L16_WORKSHEET)).toEqual([
+      'intro',
+      'vocab-definition',
+      'vocab-application',
+      'story-structure',
+      'knowledge-station',
+      'reading-strategy',
+      'comprehension',
+      'vocab-word-search',
+    ]);
+  });
+
+  it('warns (not silently drops) when a section type has no registry match', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stepSequenceFromWorksheet([{ number: '一', name: 'X', type: 'bogus_type' }]);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some((args) => args.some((a) => String(a).includes('bogus_type'))),
+    ).toBe(true);
+  });
+
+  it('documents reading_timer as the single known-ambiguous unmapped type', () => {
+    // Ambiguous: 逐段朗讀 (tutor) vs 全文朗讀 (full-reading). Do NOT guess —
+    // needs 方大哥/Young product confirmation. Until then it hits the warn.
+    expect([...KNOWN_UNMAPPED_WORKSHEET_TYPES]).toEqual(['reading_timer']);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const seq = stepSequenceFromWorksheet([
+      { number: '二', name: '念順順', type: 'reading_timer' },
+      { number: '八', name: '閱讀理解', type: 'mcq' },
+    ]);
+    expect(seq).not.toContain('tutor'); //        not guessed
+    expect(seq).not.toContain('full-reading'); // not guessed
+    expect(seq).toContain('comprehension'); //    mcq still resolves alongside
+    expect(
+      warnSpy.mock.calls.some((args) => args.some((a) => String(a).includes('reading_timer'))),
+    ).toBe(true);
   });
 });

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -341,6 +341,38 @@ export function resolveActiveSteps(lessonStepSequence?: string[] | null): StepCo
 }
 
 /**
+ * Parser section `type` → STEP_REGISTRY `id` aliases (#2526).
+ *
+ * The printed-worksheet parser emits a `type` vocabulary that does NOT line up
+ * 1:1 with STEP_REGISTRY ids. The plain `_`→`-` transform only rescues the
+ * cases that happen to match after that swap (e.g. `vocab_application` →
+ * `vocab-application`); everything else was silently dropped, so ~74% of
+ * sections vanished on ~16 courses that carry no manual `step_sequence`.
+ *
+ * These 5 mappings are UNAMBIGUOUS and applied BEFORE the dash transform.
+ * When the parser vocabulary drifts, add the new alias here (a console.warn in
+ * stepSequenceFromWorksheet flags any type that still resolves to nothing).
+ */
+const WORKSHEET_TYPE_ALIASES: Record<string, string> = {
+  vocab_definitions: 'vocab-definition', // 語詞我最棒 (plural type → singular id)
+  structure_table: 'story-structure', //   文章重點表
+  spotlight: 'reading-strategy', //         閱讀聚光燈
+  mcq: 'comprehension', //                  閱讀理解
+  word_search: 'vocab-word-search', //      詞語複習
+};
+
+/**
+ * Worksheet section types that are KNOWN but deliberately NOT mapped, because
+ * their target step is ambiguous and needs product confirmation.
+ *
+ * - `reading_timer` (念順順): could be 逐段朗讀 (`tutor`) OR 全文朗讀
+ *   (`full-reading`). Do NOT guess — needs 方大哥/Young confirmation. Until then
+ *   it hits the console.warn in stepSequenceFromWorksheet (intended, so the drop
+ *   stays visible).
+ */
+export const KNOWN_UNMAPPED_WORKSHEET_TYPES = ['reading_timer'] as const;
+
+/**
  * Derive a per-lesson step sequence from the printed worksheet's section order.
  *
  * Each lesson YAML carries `worksheet_section_order`: the AUTHORITATIVE ordered
@@ -352,9 +384,9 @@ export function resolveActiveSteps(lessonStepSequence?: string[] | null): StepCo
  * DEFAULT_STEP_SEQUENCE (which e.g. orders 文章重點表/閱讀聚光燈 opposite to the paper).
  *
  * 'intro' is prepended (the online flow always opens with it; the paper starts
- * at 讀全文). Unknown types are skipped here; disabled steps are dropped later by
- * resolveActiveSteps. Returns null when there is no worksheet order so callers
- * fall back to DEFAULT_STEP_SEQUENCE.
+ * at 讀全文). Unmapped types are dropped (with a console.warn — see below), and
+ * disabled steps are dropped later by resolveActiveSteps. Returns null when
+ * there is no worksheet order so callers fall back to DEFAULT_STEP_SEQUENCE.
  */
 export function stepSequenceFromWorksheet(
   worksheet?: Array<{ number?: string; name?: string; type?: string }> | null,
@@ -364,8 +396,22 @@ export function stepSequenceFromWorksheet(
   for (const section of worksheet) {
     const type = section?.type;
     if (!type) continue;
-    const id = type.replace(/_/g, '-'); // reading_annotation → reading-annotation
-    if (STEP_REGISTRY[id] && !ids.includes(id)) ids.push(id);
+    // Alias BEFORE the dash transform, then look up in the registry.
+    const aliased = WORKSHEET_TYPE_ALIASES[type] ?? type;
+    const id = aliased.replace(/_/g, '-'); // reading_annotation → reading-annotation
+    if (STEP_REGISTRY[id]) {
+      if (!ids.includes(id)) ids.push(id);
+    } else {
+      // #2526: never silently drop. Surface unmapped types so future parser
+      // vocabulary drift is visible instead of quietly deleting steps.
+      // `reading_timer` (see KNOWN_UNMAPPED_WORKSHEET_TYPES) hits this until
+      // product confirms its target — intended.
+      console.warn(
+        `[stepConfig] worksheet section type "${type}" (resolved to "${id}") has no ` +
+          `matching STEP_REGISTRY id — section dropped. Add an alias to ` +
+          `WORKSHEET_TYPE_ALIASES or confirm the mapping.`,
+      );
+    }
   }
   return ids.length > 1 ? ids : null;
 }


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2526.

## 問題
`stepSequenceFromWorksheet` 對 worksheet section `type` 只做 `_`→`-` 就查 `STEP_REGISTRY`，查不到 `continue` **靜默丟棄** → 788/1053 (74%) section 被丟，約 16 課（無手工 `step_sequence`）學習步驟大量消失（id=2 十秒的背後 8 個 section 只活 2 個）。

## 修法
- `WORKSHEET_TYPE_ALIASES`：5 個明確 parser-type → registry-id 映射（vocab_definitions / structure_table / spotlight / mcq / word_search），在 dash transform 前套用 → 一次修好 16 課，不重跑資料
- 未映射 type 改 `console.warn`（不再靜默）→ 未來 vocabulary drift 看得見
- `reading_timer` 刻意不映射（tutor vs full-reading 歧義，待方大哥/Young 確認）

## 驗證（工頭獨立）
- vitest stepConfig：14 passed（real parser-vocabulary regression fixture，取代原虛構 type 假綠燈）
- mutation：繞過 alias map → 7 test 轉紅（鎖真實）
- lint：0 errors
- 純前端邏輯，無碰 backend/data

⚠️ merge 後 staging 部署，我會 /qa 驗 /learn/2 步驟真的回來