### PR TITLE
fix(qa-tools): shared-secret gate + early Content-Length cap on QA routes (#2534)

### DIFF
--- a/backend/app/auth/qa_tools.py
+++ b/backend/app/auth/qa_tools.py
@@ -1,0 +1,75 @@
+"""Shared request guards for the public QA-board tools — Issue #2534.
+
+The spotlight-qa / keypoints-qa boards are unauthenticated, GCS-only endpoints
+served from static pages (no login, human-testing only). Two reusable FastAPI
+dependencies harden them:
+
+- ``require_qa_token`` — fail-closed shared-secret gate. When
+  ``settings.qa_tools_shared_secret`` is set, every request must carry a matching
+  ``x-qa-token`` header or get 401. When the secret is empty/unset the gate is
+  OPEN (local-dev escape hatch) and a single warning is logged.
+
+- ``enforce_qa_content_length`` — reject oversized uploads based on the
+  ``Content-Length`` request header with 413 *before* the body is read into
+  memory / before any GCS write, so a forged large Content-Length can't force the
+  server to buffer megabytes or touch storage.
+
+Both are single, shared dependencies wired into all endpoints via the router
+decorator's ``dependencies=[...]`` — not copy-pasted per endpoint.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+
+from fastapi import Header, HTTPException, Request
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# A QA review JSON is far smaller than this; matches the per-route post-parse cap.
+QA_TOOLS_MAX_BYTES = 4 * 1024 * 1024  # 4 MB
+
+_warned_open = False
+
+
+def require_qa_token(x_qa_token: str | None = Header(default=None)) -> None:
+    """Fail-closed shared-secret gate for QA-board endpoints.
+
+    - secret set + header missing/wrong → 401
+    - secret set + header matches       → allow
+    - secret empty/unset                → allow (open; log once)
+    """
+    secret = settings.qa_tools_shared_secret or ""
+    if not secret:
+        global _warned_open
+        if not _warned_open:
+            logger.warning(
+                "QA tools shared secret is not set — QA board endpoints are OPEN. "
+                "Set QA_TOOLS_SHARED_SECRET to require an x-qa-token header."
+            )
+            _warned_open = True
+        return
+
+    if not x_qa_token or not hmac.compare_digest(x_qa_token, secret):
+        raise HTTPException(status_code=401, detail="invalid or missing x-qa-token")
+
+
+def enforce_qa_content_length(request: Request) -> None:
+    """Reject oversized bodies on the Content-Length header BEFORE parsing.
+
+    Runs as a dependency (before the endpoint reads the body) so a request that
+    declares more than the cap is rejected with 413 without buffering the body
+    or reaching GCS. Endpoints keep a post-parse size check as defense-in-depth.
+    """
+    raw = request.headers.get("content-length")
+    if raw is None:
+        return
+    try:
+        declared = int(raw)
+    except (TypeError, ValueError):
+        return
+    if declared > QA_TOOLS_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="payload too large (max 4MB)")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,11 @@ class Settings(BaseSettings):
     #                  preview → lingoleap-omo-uploads-preview.
     # Falls back to original shared bucket for backward compat / local dev.
     gcs_omo_bucket: str = "lingoleap-omo-uploads"
+    # Shared secret for the public QA-board tools (spotlight-qa / keypoints-qa) — Issue #2534.
+    # Empty (default): endpoints are OPEN (local-dev escape hatch).
+    # Set QA_TOOLS_SHARED_SECRET in staging/preview Cloud Run to require an
+    # `x-qa-token` header on every QA-board request (fail-closed once set).
+    qa_tools_shared_secret: str = ""
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/routes/keypoints_qa.py
+++ b/backend/app/routes/keypoints_qa.py
@@ -28,8 +28,9 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from ..auth.qa_tools import enforce_qa_content_length, require_qa_token
 from ..services.audio_upload_service import _get_gcs_bucket
 
 logger = logging.getLogger(__name__)
@@ -69,15 +70,30 @@ def _is_production() -> bool:
     return bool(os.environ.get("K_SERVICE"))
 
 
-@router.post("/keypoints-qa/save")
-def keypoints_qa_save(payload: dict = Body(...)):
+@router.post(
+    "/keypoints-qa/save",
+    dependencies=[Depends(require_qa_token), Depends(enforce_qa_content_length)],
+)
+async def keypoints_qa_save(request: Request):
     """存一份文章重點表 QA review JSON(無登入,人工測試用)。
 
     Returns: { ok, path } on success; 4xx on validation; 403 in production; 503 if GCS down.
+
+    Auth + early Content-Length cap run as dependencies (#2534) BEFORE the body is
+    read; body is parsed manually here so a forged large Content-Length is rejected
+    without buffering it or touching GCS.
     """
     # 純人工測試用:正式環境不接受寫入
     if _is_production():
         raise HTTPException(403, "keypoints QA save is disabled in production")
+
+    body_bytes = await request.body()
+    if len(body_bytes) > _MAX_BYTES:  # post-parse cap, defense-in-depth
+        raise HTTPException(413, "payload too large (max 4MB)")
+    try:
+        payload = json.loads(body_bytes)
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(400, "payload must be valid JSON")
 
     if not isinstance(payload, dict) or "lessons" not in payload:
         raise HTTPException(400, "payload must be a keypoints-qa export object (missing 'lessons')")
@@ -107,7 +123,7 @@ def keypoints_qa_save(payload: dict = Body(...)):
     return {"ok": True, "path": path}
 
 
-@router.get("/keypoints-qa/reviews")
+@router.get("/keypoints-qa/reviews", dependencies=[Depends(require_qa_token)])
 def keypoints_qa_reviews():
     """列出已存的 review(供雲端載入清單)。reviewer / 時間直接從 path 解,不下載內容。"""
     bucket = _get_gcs_bucket()
@@ -139,7 +155,7 @@ def keypoints_qa_reviews():
     return {"ok": True, "count": len(out), "reviews": out}
 
 
-@router.get("/keypoints-qa/review")
+@router.get("/keypoints-qa/review", dependencies=[Depends(require_qa_token)])
 def keypoints_qa_review(path: str = Query(...)):
     """讀回一份 review JSON(供載回續審)。path 須落在 keypoints-qa/ prefix。"""
     if not _PATH_RE.match(path):

--- a/backend/app/routes/spotlight_qa.py
+++ b/backend/app/routes/spotlight_qa.py
@@ -28,8 +28,9 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from ..auth.qa_tools import enforce_qa_content_length, require_qa_token
 from ..services.audio_upload_service import _get_gcs_bucket
 
 logger = logging.getLogger(__name__)
@@ -69,15 +70,30 @@ def _is_production() -> bool:
     return bool(os.environ.get("K_SERVICE"))
 
 
-@router.post("/spotlight-qa/save")
-def spotlight_qa_save(payload: dict = Body(...)):
+@router.post(
+    "/spotlight-qa/save",
+    dependencies=[Depends(require_qa_token), Depends(enforce_qa_content_length)],
+)
+async def spotlight_qa_save(request: Request):
     """存一份聚光燈 QA review JSON(無登入,人工測試用)。
 
     Returns: { ok, path } on success; 4xx on validation; 403 in production; 503 if GCS down.
+
+    Auth + early Content-Length cap run as dependencies (#2534) BEFORE the body is
+    read; body is parsed manually here so a forged large Content-Length is rejected
+    without buffering it or touching GCS.
     """
     # 純人工測試用:正式環境不接受寫入
     if _is_production():
         raise HTTPException(403, "spotlight QA save is disabled in production")
+
+    body_bytes = await request.body()
+    if len(body_bytes) > _MAX_BYTES:  # post-parse cap, defense-in-depth
+        raise HTTPException(413, "payload too large (max 4MB)")
+    try:
+        payload = json.loads(body_bytes)
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(400, "payload must be valid JSON")
 
     if not isinstance(payload, dict) or "lessons" not in payload:
         raise HTTPException(400, "payload must be a spotlight-qa export object (missing 'lessons')")
@@ -107,7 +123,7 @@ def spotlight_qa_save(payload: dict = Body(...)):
     return {"ok": True, "path": path}
 
 
-@router.get("/spotlight-qa/reviews")
+@router.get("/spotlight-qa/reviews", dependencies=[Depends(require_qa_token)])
 def spotlight_qa_reviews():
     """列出已存的 review(供雲端載入清單)。reviewer / 時間直接從 path 解,不下載內容。"""
     bucket = _get_gcs_bucket()
@@ -139,7 +155,7 @@ def spotlight_qa_reviews():
     return {"ok": True, "count": len(out), "reviews": out}
 
 
-@router.get("/spotlight-qa/review")
+@router.get("/spotlight-qa/review", dependencies=[Depends(require_qa_token)])
 def spotlight_qa_review(path: str = Query(...)):
     """讀回一份 review JSON(供載回續審)。path 須落在 spotlight-qa/ prefix。"""
     if not _PATH_RE.match(path):

--- a/backend/tests/test_qa_tools_auth.py
+++ b/backend/tests/test_qa_tools_auth.py
@@ -1,0 +1,224 @@
+"""Regression locks for QA-tool shared-secret gate + early Content-Length cap (#2534).
+
+Locks:
+1. QA_TOOLS_SHARED_SECRET set + missing/wrong x-qa-token → 401 on all 6 endpoints
+2. secret set + correct header → auth passes (200 / expected non-401)
+3. secret unset/empty → open behavior preserved (local-dev escape hatch)
+4. keypoints/spotlight save with Content-Length > 4MB → 413 before body parse
+
+Run:
+    cd backend && source .venv/bin/activate && python -m pytest tests/test_qa_tools_auth.py -q
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+SECRET = "test-only-qa-tools-shared-secret-not-prod"
+GOOD_SPOTLIGHT = {"reviewer": "啟翔", "tool_version": 2, "lessons": [{"lesson_code": "G6-L22"}]}
+GOOD_KEYPOINTS = {"reviewer": "啟翔", "tool_version": 1, "lessons": [{"lesson_code": "G6-L22"}]}
+MAX_BYTES = 4 * 1024 * 1024
+
+SPOTLIGHT_BUCKET = "app.routes.spotlight_qa._get_gcs_bucket"
+KEYPOINTS_BUCKET = "app.routes.keypoints_qa._get_gcs_bucket"
+
+# (method, path, kwargs_factory) — kwargs_factory() → client call kwargs
+PROTECTED_ENDPOINTS = [
+    (
+        "POST",
+        "/api/spotlight-qa/save",
+        lambda: {"json": GOOD_SPOTLIGHT},
+        SPOTLIGHT_BUCKET,
+    ),
+    (
+        "GET",
+        "/api/spotlight-qa/reviews",
+        lambda: {},
+        SPOTLIGHT_BUCKET,
+    ),
+    (
+        "GET",
+        "/api/spotlight-qa/review",
+        lambda: {"params": {"path": "spotlight-qa/啟翔/20260707T101112-abcd1234.json"}},
+        SPOTLIGHT_BUCKET,
+    ),
+    (
+        "POST",
+        "/api/keypoints-qa/save",
+        lambda: {"json": GOOD_KEYPOINTS},
+        KEYPOINTS_BUCKET,
+    ),
+    (
+        "GET",
+        "/api/keypoints-qa/reviews",
+        lambda: {},
+        KEYPOINTS_BUCKET,
+    ),
+    (
+        "GET",
+        "/api/keypoints-qa/review",
+        lambda: {"params": {"path": "keypoints-qa/啟翔/20260707T101112-abcd1234.json"}},
+        KEYPOINTS_BUCKET,
+    ),
+]
+
+
+def _mock_bucket_for(path: str) -> MagicMock:
+    """GCS mock that supports save / list / read for either tool."""
+    bucket = MagicMock()
+    blob = MagicMock()
+    blob.upload_from_string.return_value = None
+    blob.exists.return_value = True
+    payload = GOOD_SPOTLIGHT if "spotlight" in path else GOOD_KEYPOINTS
+    blob.download_as_text.return_value = json.dumps(payload, ensure_ascii=False)
+    blob.name = (
+        "spotlight-qa/啟翔/20260707T101112-abcd1234.json"
+        if "spotlight" in path
+        else "keypoints-qa/啟翔/20260707T101112-abcd1234.json"
+    )
+    blob.size = 123
+    bucket.blob.return_value = blob
+    bucket.list_blobs.return_value = [blob]
+    return bucket
+
+
+def _set_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setattr("app.config.settings.qa_tools_shared_secret", value)
+    # dependency may import settings under its own module path
+    monkeypatch.setattr("app.auth.qa_tools.settings.qa_tools_shared_secret", value, raising=False)
+
+
+def _call(method: str, path: str, headers: dict | None = None, **kwargs):
+    headers = dict(headers or {})
+    return client.request(method, path, headers=headers, **kwargs)
+
+
+@pytest.fixture
+def non_prod(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.delenv("K_SERVICE", raising=False)
+
+
+class TestQaTokenMissingOrWrong:
+    """secret SET + no/wrong x-qa-token → 401 on each of save/reviews/review (both tools)."""
+
+    @pytest.mark.parametrize(
+        "method,path,kwargs_factory,bucket_path",
+        PROTECTED_ENDPOINTS,
+        ids=[ep[1] for ep in PROTECTED_ENDPOINTS],
+    )
+    def test_missing_header_401(
+        self, monkeypatch, non_prod, method, path, kwargs_factory, bucket_path
+    ):
+        _set_secret(monkeypatch, SECRET)
+        with patch(bucket_path, return_value=_mock_bucket_for(path)):
+            r = _call(method, path, **kwargs_factory())
+        assert r.status_code == 401, f"{method} {path}: {r.status_code} {r.text}"
+
+    @pytest.mark.parametrize(
+        "method,path,kwargs_factory,bucket_path",
+        PROTECTED_ENDPOINTS,
+        ids=[ep[1] for ep in PROTECTED_ENDPOINTS],
+    )
+    def test_wrong_token_401(
+        self, monkeypatch, non_prod, method, path, kwargs_factory, bucket_path
+    ):
+        _set_secret(monkeypatch, SECRET)
+        with patch(bucket_path, return_value=_mock_bucket_for(path)):
+            r = _call(
+                method,
+                path,
+                headers={"x-qa-token": "wrong-token-not-the-secret"},
+                **kwargs_factory(),
+            )
+        assert r.status_code == 401, f"{method} {path}: {r.status_code} {r.text}"
+
+
+class TestQaTokenCorrect:
+    """secret SET + correct header → auth passes (not 401)."""
+
+    @pytest.mark.parametrize(
+        "method,path,kwargs_factory,bucket_path",
+        PROTECTED_ENDPOINTS,
+        ids=[ep[1] for ep in PROTECTED_ENDPOINTS],
+    )
+    def test_correct_header_passes_auth(
+        self, monkeypatch, non_prod, method, path, kwargs_factory, bucket_path
+    ):
+        _set_secret(monkeypatch, SECRET)
+        with patch(bucket_path, return_value=_mock_bucket_for(path)):
+            r = _call(
+                method,
+                path,
+                headers={"x-qa-token": SECRET},
+                **kwargs_factory(),
+            )
+        assert r.status_code != 401, f"{method} {path}: unexpected 401 {r.text}"
+        assert r.status_code == 200, f"{method} {path}: {r.status_code} {r.text}"
+
+
+class TestQaTokenUnsetOpen:
+    """secret UNSET → open behavior preserved (no 401) — local-dev escape hatch."""
+
+    @pytest.mark.parametrize(
+        "method,path,kwargs_factory,bucket_path",
+        PROTECTED_ENDPOINTS,
+        ids=[ep[1] for ep in PROTECTED_ENDPOINTS],
+    )
+    def test_unset_secret_no_401(
+        self, monkeypatch, non_prod, method, path, kwargs_factory, bucket_path
+    ):
+        _set_secret(monkeypatch, "")
+        with patch(bucket_path, return_value=_mock_bucket_for(path)):
+            r = _call(method, path, **kwargs_factory())
+        assert r.status_code != 401, f"{method} {path}: got 401 with secret unset"
+        assert r.status_code == 200, f"{method} {path}: {r.status_code} {r.text}"
+
+
+class TestContentLengthPreParse:
+    """Content-Length over 4MB → 413 before body is parsed into memory."""
+
+    def test_keypoints_save_content_length_over_4mb_413(self, monkeypatch, non_prod):
+        _set_secret(monkeypatch, "")  # auth open so we isolate size-cap
+        # Small body + forged Content-Length > 4MB. Guard must reject on header
+        # alone — must NOT require uploading 4MB+ of bytes.
+        over = MAX_BYTES + 1
+        with patch(KEYPOINTS_BUCKET, return_value=_mock_bucket_for("/api/keypoints-qa/save")) as bucket:
+            r = client.post(
+                "/api/keypoints-qa/save",
+                content=b'{"reviewer":"x","lessons":[]}',
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(over),
+                },
+            )
+        assert r.status_code == 413, r.text
+        # Must reject before any GCS write (proves we didn't fully process as save)
+        bucket.return_value.blob.assert_not_called()
+
+    def test_spotlight_save_content_length_over_4mb_413(self, monkeypatch, non_prod):
+        _set_secret(monkeypatch, "")
+        over = MAX_BYTES + 1
+        with patch(SPOTLIGHT_BUCKET, return_value=_mock_bucket_for("/api/spotlight-qa/save")) as bucket:
+            r = client.post(
+                "/api/spotlight-qa/save",
+                content=b'{"reviewer":"x","lessons":[]}',
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(over),
+                },
+            )
+        assert r.status_code == 413, r.text
+        bucket.return_value.blob.assert_not_called()


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2534.

## 問題
spotlight-qa / keypoints-qa QA-board 後端 route 無 auth：staging 上任何人可寫任意 JSON 進 GCS（灌垃圾/燒 egress）或讀回所有 review（reviewer 名 + QA notes）；keypoints save 的 4MB cap 在 body parse 後才檢查（可先吃記憶體）。

## 修法
- `require_qa_token`：fail-closed x-qa-token gate（`hmac.compare_digest` timing-safe）；`QA_TOOLS_SHARED_SECRET` 未設時 OPEN + log-once（local-dev escape hatch）
- `enforce_qa_content_length`：Content-Length > 4MB → 413，在 body parse / GCS write **之前**；save route 改手動讀 body（拿掉 `Body(...)`）讓 guard 在 FastAPI buffer body 前先跑；post-parse cap 保留當 defense-in-depth
- 單一共用 dependency 掛進全部 6 endpoints（router `dependencies=[...]`）

## 驗證（工頭獨立）
- pytest test_qa_tools_auth.py：26 passed（missing/wrong/correct/unset token + 413 pre-parse）
- mutation：閹掉 auth 判斷 → 12 個 401 test 轉紅（鎖真實）
- security review：fail-closed / timing-safe compare / 413 pre+post-parse / open-when-unset 有 warn
- 無回歸：test_spotlight_qa + test_keypoints_qa 22 passed
- specs local CI：PASS（Gate2 contracts 751 passed / Gate3 205 passed）
- 無 alembic migration、無 model 改動