### PR TITLE
feat(qa-board): send x-qa-token from localStorage (#2534 frontend arm)

### DIFF
--- a/frontend/public/keypoints-qa/app.js
+++ b/frontend/public/keypoints-qa/app.js
@@ -39,6 +39,18 @@
   }
   const API = apiBase();
 
+  // #2534: arm QA-board with the shared secret. Visit once with ?qa_token=<secret>
+  // to persist it; sent as x-qa-token on save/reviews/review. No token → header
+  // omitted → backend stays open (no regression until QA_TOOLS_SHARED_SECRET is set).
+  try {
+    const _qt = new URLSearchParams(location.search).get("qa_token");
+    if (_qt) localStorage.setItem(NS + "qaToken", _qt);
+  } catch (e) {}
+  function qaAuthHeaders() {
+    const t = localStorage.getItem(NS + "qaToken");
+    return t ? { "x-qa-token": t } : {};
+  }
+
   // 問題標籤(docx ↔ 重點表渲染的保真檢查導向)
   const ISSUE_TAGS = [
     ["blank_wrong", "空格位置/數量/答案錯"],
@@ -883,7 +895,7 @@
     try {
       const res = await fetch(`${API}/api/keypoints-qa/save`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...qaAuthHeaders() },
         body: JSON.stringify(out),
       });
       const j = await res.json().catch(() => ({}));
@@ -907,7 +919,7 @@
     box.style.display = "block";
     box.innerHTML = "<div class='cloud-row'>載入清單中…</div>";
     try {
-      const res = await fetch(`${API}/api/keypoints-qa/reviews`);
+      const res = await fetch(`${API}/api/keypoints-qa/reviews`, { headers: qaAuthHeaders() });
       const j = await res.json();
       const list = (j && j.reviews) || [];
       if (!list.length) {
@@ -936,7 +948,7 @@
   async function loadCloudReview(path) {
     if (!confirm("載回這筆 review?會覆寫本機對應課的標記/備註。")) return;
     try {
-      const res = await fetch(`${API}/api/keypoints-qa/review?path=` + encodeURIComponent(path));
+      const res = await fetch(`${API}/api/keypoints-qa/review?path=` + encodeURIComponent(path), { headers: qaAuthHeaders() });
       const payload = await res.json();
       const lessons = (payload && payload.lessons) || [];
       // 回填成本工具的 review 結構(findings 綁 row_key)

--- a/frontend/public/spotlight-qa/app.js
+++ b/frontend/public/spotlight-qa/app.js
@@ -27,6 +27,17 @@
     return "https://lingoleap-backend-staging-958347263320.asia-east1.run.app";
   }
   const API = apiBase();
+  // #2534: arm QA-board with the shared secret. Visit once with ?qa_token=<secret>
+  // to persist it; sent as x-qa-token on save/reviews/review. No token → header
+  // omitted → backend stays open (no regression until QA_TOOLS_SHARED_SECRET is set).
+  try {
+    const _qt = new URLSearchParams(location.search).get("qa_token");
+    if (_qt) localStorage.setItem(NS + "qaToken", _qt);
+  } catch (e) {}
+  function qaAuthHeaders() {
+    const t = localStorage.getItem(NS + "qaToken");
+    return t ? { "x-qa-token": t } : {};
+  }
   // render iframe base:部署在 staging 同源(IS_REMOTE)→ 用同源;否則(file:// / 本機 http.server)吃輸入框(預設 staging)
   function renderBase() {
     return IS_REMOTE ? location.origin : baseUrl.replace(/\/+$/, "");
@@ -1220,7 +1231,7 @@
     try {
       const res = await fetch(`${API}/api/spotlight-qa/save`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...qaAuthHeaders() },
         body: JSON.stringify(out),
       });
       const j = await res.json().catch(() => ({}));
@@ -1244,7 +1255,7 @@
     box.style.display = "block";
     box.innerHTML = "<div class='cloud-row'>載入清單中…</div>";
     try {
-      const res = await fetch(`${API}/api/spotlight-qa/reviews`);
+      const res = await fetch(`${API}/api/spotlight-qa/reviews`, { headers: qaAuthHeaders() });
       const j = await res.json();
       const list = (j && j.reviews) || [];
       if (!list.length) {
@@ -1273,7 +1284,7 @@
   async function loadCloudReview(path) {
     if (!confirm("載回這筆 review?會覆寫本機對應課的標記/備註。")) return;
     try {
-      const res = await fetch(`${API}/api/spotlight-qa/review?path=` + encodeURIComponent(path));
+      const res = await fetch(`${API}/api/spotlight-qa/review?path=` + encodeURIComponent(path), { headers: qaAuthHeaders() });
       const payload = await res.json();
       const lessons = (payload && payload.lessons) || [];
       // 把 payload 各課回填成本工具的 review 結構(findings 綁 block_id + steps)


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Refs #2534 — 完成前端半（後端 gate 已在 #2548 上線）。

spotlight-qa / keypoints-qa 兩個 QA board（`frontend/public/*/app.js`）現在：
- 帶 `?qa_token=<secret>` 開一次 → 存進 localStorage
- save / reviews / review 三個呼叫都送 `x-qa-token`
- **無 token → 不送 header → 後端 open（無回歸）**；等你在 Cloud Run 設 `QA_TOOLS_SHARED_SECRET` 才真正 armed

node --check 兩檔語法 OK。static public JS（不在 vite src / vitest 範圍）。