### PR TITLE
fix(story-structure): 單空格重點表填了卻送不出(#2193 key regression)

### DIFF
--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -391,13 +391,18 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
     const nodes: React.ReactNode[] = [];
     let last = 0;
     let blankIdx = 0;
+    // Single-blank cells must key WITHOUT a -bN suffix, to match the answer tally
+    // (totalAnswered) and submit payload — both use `blankCount > 1 ? b : undefined`.
+    // Keying single blanks as -b0 here made filled cells count as empty → 送不出 (#2193 regression).
+    const blankTotal = countBlanks(text);
     const re = new RegExp(INLINE_BLANK_RE.source, 'g');
     let match: RegExpExecArray | null;
     while ((match = re.exec(text)) !== null) {
       if (match.index > last) {
         nodes.push(<span key={`t-${last}`}>{text.slice(last, match.index)}</span>);
       }
-      const key = answerKey(rowIdx, subIdx, blankIdx);
+      const bIdx = blankTotal > 1 ? blankIdx : undefined;
+      const key = answerKey(rowIdx, subIdx, bIdx);
       nodes.push(
         <span key={`b-${blankIdx}`} className="inline-flex items-baseline">
           <span>【</span>
@@ -406,7 +411,7 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
             onChange={(v) => setAnswer(key, v)}
             submitted={submitted}
             gradeItem={
-              submitted ? findGradeItem(gradeResults, rowIdx, subIdx, blankIdx) : undefined
+              submitted ? findGradeItem(gradeResults, rowIdx, subIdx, bIdx) : undefined
             }
             compact
           />

--- a/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // StoryStructureTable 內部呼叫 useAuth；測試不掛 AuthProvider，
@@ -181,6 +181,58 @@ describe('StoryStructureTable', () => {
     // 空格總數 = 1 + 2 + 1 = 4；bug 時每列只畫 1 個光禿 input（共 3 個）→ 少畫
     const inputs = container.querySelectorAll('input');
     expect(inputs.length).toBe(4);
+  });
+
+  // 迴歸測試（#2193 single-blank key regression）：
+  // worksheet_table 的 InlineWorksheetContent 對單空格 cell 用 -b0 key 存答案，
+  // 但 tally/submit 用「單空格 → 無 -bN suffix」→ 填了卻算 0 → totalAnswered<totalInteractive
+  // → 提交鈕鎖住、送不出。修好後填單空格要算「已填 1/1」且提交鈕解鎖。
+  it('counts a filled single-blank cell as answered and enables submit (#2193 key)', async () => {
+    const singleBlankStructure = {
+      layout: 'worksheet_table',
+      title: '文章重點表',
+      worksheet_rows: [
+        {
+          kind: 'section_block',
+          section: '解決',
+          items: [{ label: '解決1', value: '食客中有一位會模仿【　　　】的樣子' }],
+        },
+      ],
+      rows: [
+        {
+          label: '解決',
+          value: '',
+          interactive_type: 'display',
+          sub_rows: [
+            {
+              label: '解決1',
+              value: '食客中有一位會模仿【　　　】的樣子',
+              interactive_type: 'fill_blank',
+            },
+          ],
+        },
+      ],
+    };
+
+    mockFetchSuccess(singleBlankStructure);
+    const { container } = render(
+      <StoryStructureTable storyId="lesson-g6-l22" showCoach={false} />
+    );
+
+    await waitFor(() => expect(screen.getByText('解決1')).toBeTruthy());
+
+    const submitBtn = screen.getByRole('button', { name: /提交答案/ }) as HTMLButtonElement;
+    // 尚未填 → 鎖住
+    expect(submitBtn.disabled).toBe(true);
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    fireEvent.change(input, { target: { value: '狗' } });
+
+    // 單空格 cell 填了要算「已填 1/1」→ 提交鈕解鎖(bug 時仍鎖住)
+    await waitFor(() => expect(submitBtn.disabled).toBe(false));
+    const filled = container.textContent?.replace(/\s+/g, '') ?? '';
+    expect(filled).toContain('已填1/1題');
   });
 
   it('re-fetches when storyId prop changes', async () => {


### PR DESCRIPTION
## Bug
文章重點表(worksheet_table 版面)有些**單一空格的格子**,學生**填了字卻被判定沒填**,導致「已填 X/Y」湊不滿 → **提交鈕鎖住、送不出**。啟翔用 QA board 審 G6-L22(小兵立大功,解決子列都是單空格)時發現。

## Root cause(#2193 引入的 key 不一致)
- **render**：`InlineWorksheetContent`(worksheet_table 的填空 cell)對**每個**空格用 `answerKey(rowIdx, subIdx, blankIdx)`,單空格也給 `-b0` → 答案存在 key `…-b0`。
- **計數 / 送出**：`totalAnswered` 與 submit payload 用「**單空格 → 無 `-bN` 後綴**」的 key(`blankCount > 1 ? b : undefined`)→ 讀 key `…`(無 `-b0`)。
- key 對不上 → 填了的格子讀不到 → 算成空 → `totalAnswered < totalInteractive` → `allAnswered=false` → 提交鈕永遠 disabled。
- 多空格 cell 不受影響(render 與計數都用 `-bN`),所以是**只有含單空格 cell 的課**中招 → 06-17(#2193 worksheet-table render)起。

## Fix
`InlineWorksheetContent` 依該 cell 的空格總數決定 key:**單空格用無後綴 key、多空格才用 `-bN`**,與 tally / submit payload / 後端 grading 慣例對齊。純前端 key 對齊,**資料與後端不動**。

## Verify
- 新增迴歸測試(`StoryStructureTable.test.tsx`):填單空格 cell → 「已填 1/1」+ 提交鈕解鎖。**移除修正則此測試 red**(已驗:未修 1 failed / 修後 8 passed)。
- `render-smoke` 15 passed；`npm run lint` 0 errors。
- ⏳ 視覺 `/qa` 待此 PR preview:開 `/learn/1076/story-structure`(G6-L22)填單空格 → 能送出、console 乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)