### PR TITLE
fix(guided-steps): 範例子流程 free_text 用自己的 context 判分 (#2553)

### DIFF
--- a/frontend/src/components/lesson-content/inputs/GuidedStepsInput.tsx
+++ b/frontend/src/components/lesson-content/inputs/GuidedStepsInput.tsx
@@ -179,7 +179,11 @@ const GuidedStepsInput: React.FC<Props> = ({
         studentAnswer: text,
         strategyName,
         storyTitle,
-        passage,
+        // A worked-example step (子流程) carries its OWN story in `context` (e.g. 例一:烏鴉喝水).
+        // Grade it against that, NOT the whole-lesson passage — otherwise the AI checks the
+        // answer against the main story (小兵立大功/孟嘗君) and wrongly accepts 孟嘗君 for
+        // 烏鴉喝水's 主角. Fall back to the lesson passage for steps without their own context. (#2553)
+        passage: step.context ?? passage,
       });
       setGrades((prev) => ({ ...prev, [i]: grade }));
       setFeedback((prev) => ({ ...prev, [i]: true }));

--- a/frontend/src/components/lesson-content/inputs/__tests__/GuidedStepsInput.test.tsx
+++ b/frontend/src/components/lesson-content/inputs/__tests__/GuidedStepsInput.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
+
+// Auth mock so the AI grading path runs (token present).
+vi.mock('../../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock the AI grader so we can inspect the payload it receives.
+const validateStrategyAnswer = vi.fn();
+vi.mock('../../../../services/learningApi', () => ({
+  validateStrategyAnswer: (...args: unknown[]) => validateStrategyAnswer(...args),
+}));
+
+import GuidedStepsInput, { type GuidedQuestion } from '../GuidedStepsInput';
+
+const LESSON_PASSAGE = '主課文：公元前299年，秦昭王軟禁了孟嘗君……（小兵立大功）';
+const EXAMPLE_PASSAGE =
+  '天氣炎熱，烏鴉又渴又累。牠找到一個有水的瓶子，但瓶子太深，水太少，烏鴉喝不到。烏鴉叼來小石頭丟進瓶子，讓水面升高，最後順利喝到水。';
+
+// guided_steps with a worked-example first step that carries its OWN story in `context`.
+const question = {
+  kind: 'guided_steps',
+  strategyName: '摘要策略──問題.解決.結果結構',
+  steps: [
+    {
+      prompt: '❶主角是誰？',
+      type: 'free_text',
+      referenceAnswer: '烏鴉',
+      context: EXAMPLE_PASSAGE,
+      section: '例一：烏鴉喝水',
+    },
+  ],
+} as unknown as GuidedQuestion;
+
+function Harness() {
+  // Seed with step 0 empty so the one-time `restoredRef` restore effect fires on mount
+  // and skips the empty step — leaving it live-editable so the 送出 → AI grading path runs
+  // (a fresh {} would let the restore effect swallow the first keystroke as a local grade).
+  const [val, setVal] = useState<Record<number, unknown>>({ 0: '' });
+  return (
+    <GuidedStepsInput
+      question={question}
+      strategyName="摘要策略──問題.解決.結果結構"
+      storyTitle="小兵立大功"
+      passage={LESSON_PASSAGE}
+      value={val}
+      onChange={setVal}
+    />
+  );
+}
+
+describe('GuidedStepsInput free_text grading passage (#2553)', () => {
+  beforeEach(() => {
+    validateStrategyAnswer.mockReset();
+    validateStrategyAnswer.mockResolvedValue({ is_correct: false, feedback: '再想想看', suggestion: '' });
+  });
+
+  // 迴歸(#2553):範例子流程(例一:烏鴉喝水)的 free_text 若拿整課 passage(孟嘗君的故事)判分,
+  // AI 會誤把「孟嘗君」判成烏鴉喝水的主角。修好後該步驟必須用它自己的 context(烏鴉喝水)判分。
+  it('grades a worked-example step against its own context, not the lesson passage', async () => {
+    render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('自由作答'), { target: { value: '孟嘗君' } });
+    fireEvent.click(screen.getByText('送出'));
+
+    await waitFor(() => expect(validateStrategyAnswer).toHaveBeenCalledTimes(1));
+    const payload = validateStrategyAnswer.mock.calls[0][1] as { passage?: string; studentAnswer?: string };
+    expect(payload.studentAnswer).toBe('孟嘗君');
+    expect(payload.passage).toBe(EXAMPLE_PASSAGE);       // 用範例自己的故事判分
+    expect(payload.passage).not.toBe(LESSON_PASSAGE);    // 不是整課(孟嘗君)課文
+  });
+});


### PR DESCRIPTION
Closes #2553

## Bug
聚光燈 guided_steps「例一:烏鴉喝水」的「❶主角是誰?」(free_text,正解烏鴉),輸入 **孟嘗君** 被 AI 判 ✓。

## Root cause
`GuidedStepsInput.submitFreeText`(登入走 AI `validateStrategyAnswer`)一律餵**整課 passage**(= 小兵立大功/孟嘗君)。範例子流程自己的 `context`(烏鴉喝水)+ `reference_answer`(烏鴉)都沒被使用 → AI 拿孟嘗君對孟嘗君的故事檢查 → 判合理 → ✓。

## Fix
範例步驟(有自己 `context`)改用 `step.context ?? passage` 判分,讓範例對範例的故事判。純判分**輸入**修正,不動 model / prompt / 資料。

## Verify
- 新增迴歸測試:斷言範例步驟送給 grader 的 `passage` = 該步驟 `context`(烏鴉喝水),非整課 passage。**移除修正則 red**(已驗:未修 fail / 修後 pass)。
- render-smoke 15 passed、`npm run lint` 0 errors。
- ⏳ 視覺 `/qa` 待 preview:登入 → G6-L22 reading-strategy → 烏鴉喝水「主角是誰?」答孟嘗君應被打回、答烏鴉過。

## 注意
屬**聚光燈重構系統**(Young 區塊)。只掃了 G6-L22;其他摘要策略課(G6-L23/24/25…)若有同款範例子流程,同一修正即覆蓋(邏輯層修,非逐課)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)