### PR TITLE
docs: 重點朗讀/二修教材 intern handoffs + golden-set

### DIFF
--- a/.claude/skills/build-key-reading/SKILL.md
+++ b/.claude/skills/build-key-reading/SKILL.md
@@ -41,17 +41,17 @@ description: 從教師版 DOCX 抽「重點朗讀」（念順順）指定段落�
 4. **切段 + snap 句尾**：從起點取字，到**不含標點**字數 ≈ extent，**再往後 snap 到下一個句尾（。」！？）** → 不斷在句中。
 5. 輸出 schema（見下）。
 
-**輸出 schema**（寫進 lesson content YML/JSON，與 `story.content` 同源，供 `FullReadingPage` 讀）：
+**輸出 schema**（釘死；寫進 lesson content YML/JSON，與 `story.content` 同源，供 `FullReadingPage` 讀）：
 ```yaml
 key_reading:
-  start_paragraph: 3               # 課文段落 index（☞ 所在）
-  start_text: "這下孟嘗君頭大了"    # 起點錨（QA/驗證用，非渲染）
-  passage: "這下孟嘗君頭大了……命令即刻生效。"  # snap 到句尾的顯示朗讀段
-  extent_chars: 301                # max 累計字數（可讀範圍長度，不含標點）
-  source: docx-extract             # 來源標記（docx-extract / manual / fallback）
-  # CPM 流暢度 benchmark 不寫這裡 → 走既有 reading_benchmark 欄位（我的表現門檻）
+  start_text: "下班時刻，262路公車上有點擠"   # ☞ 起點錨（QA/比對用）
+  passage: "下班時刻…我說個話也不行了嗎？"      # snap 到句尾的顯示朗讀段
+  extent_chars: 371                            # max 累計字數 = 老師標的範圍長度（不含標點）
+  source: docx-extract                         # docx-extract / manual / fallback
+  needs_review: false                          # 抽不到/tail case → true
+  # CPM 流暢度 benchmark 不寫這裡 → 走既有 reading_benchmark 欄位（我的表現 <190/191~220/>221）
 ```
-- 抽不到（無 reading table / 無 ☞）→ **不寫 key_reading**，FullReadingPage fallback 唸全文 + 標 `needs_review`，**絕不 block**。
+- 抽不到（無 reading table / 無 ☞）→ **不寫 passage + 標 `needs_review: true`**，FullReadingPage fallback 唸全文，**絕不 block**。
 
 ---
 
@@ -87,7 +87,9 @@ regression lock：修任何抽取 bug → 先加一條會紅的斷言再修。
 - render DOCX 該頁 PNG → 多模態 Claude 看，比對：☞ 起點位置、累計字數 max、passage 邊界，是否與 coding 抽出一致
 - golden set：**5-10 課跨年級/排版**（G4/G5/G6/G8/G9 各抽樣），標正解 → 量命中率
 - ⚠️ 比對「真 render vs 真 DOCX」，別拿 source YAML 當 render（見 [[feedback-content-fidelity-compare-real-not-proxy]]）
-- 已驗：G6-L22（☞=這下孟嘗君, max=301）、G4-L10（☞=下班時刻262路公車, max=307）兩課 vision 完全命中；G6-L23/24 結構命中（未 vision）
+- 已驗：G6-L22（☞=這下孟嘗君,max301）、G4-L10（☞=下班時刻262路,max307）、**G4-L14 二修確認版（☞=下班時刻262路,max371,抽出377）** vision 命中；G6-L23/24 結構命中
+- **Golden-set（132 舊課真跑，2026-07-20）**：extract ok 123/132(93%)、**端到端全乾淨 114/132 ≈ 86%**。tail：6 no ☞/table、9 字數偏離、3 no DOCX。suspected 根因=挑錯 ☞ 起點（DOCX ~25 圖，取第一個 drawing 被裝飾圖騙）→ 修法：累計欄首數字行↔drawing 交叉定位或走 vision。dump `/tmp/key_reading_batch.json`
+- **二修確認版**（`private/curriculum-source/2026-07-21-二修確認版/`，G4/G5/G8/G9 共 73 課，65 課有念順順）結構與舊版一致，抽取器適用
 
 ---
 

--- a/.claude/skills/build-key-reading/batch_key_reading.py
+++ b/.claude/skills/build-key-reading/batch_key_reading.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Batch-run key-reading extractor over all reading_timer lessons with a teacher DOCX.
+Measures generalization hit-rate (structure detection is content-agnostic — valid pre-2nd-draft).
+"""
+import sys, os, re, glob, json
+sys.path.insert(0, os.path.dirname(__file__))
+from extract_key_reading import extract
+
+ROOT = "/Users/young/project/chinese-literacy-platform"
+SRC = os.path.join(ROOT, "private/curriculum-source")
+
+# reading_timer lesson codes
+rt = set()
+for f in glob.glob(os.path.join(ROOT, "backend/data/lessons/_parsed_2026-05-01/*.yml")):
+    code = os.path.basename(f)[:-4]
+    try:
+        if "reading_timer" in open(f, encoding="utf-8").read():
+            rt.add(code)
+    except Exception:
+        pass
+
+# map code -> teacher docx (prefer 教師版/第三階段 folders, first match)
+def find_docx(code):
+    cands = []
+    for f in glob.glob(os.path.join(SRC, "**", "*.docx"), recursive=True):
+        b = os.path.basename(f)
+        m = re.match(r"^(G\d+-L\d+)", b)
+        if m and m.group(1) == code and ("教師版" in f or "第三階段" in f or "1-1" in f):
+            cands.append(f)
+    return cands[0] if cands else None
+
+results = []
+for code in sorted(rt):
+    docx = find_docx(code)
+    if not docx:
+        results.append({"code": code, "status": "no_docx"})
+        continue
+    try:
+        r = extract(docx)
+    except Exception as e:
+        results.append({"code": code, "status": "crash", "err": str(e)[:80]})
+        continue
+    if not r.get("ok"):
+        results.append({"code": code, "status": "no_extract", "reason": r.get("reason", "")})
+        continue
+    ext = r["benchmark"]
+    chars = r["passage_chars_no_punct"]
+    sane_extent = 150 <= ext <= 600
+    close = abs(chars - ext) <= 60  # snap adds up to ~1 sentence
+    results.append({
+        "code": code, "status": "ok",
+        "extent": ext, "chars_no_punct": chars, "diff": chars - ext,
+        "sane_extent": sane_extent, "ends_clean": r["ends_clean"], "close": close,
+        "start": r["start_text"][:12],
+    })
+
+# summary
+ok = [r for r in results if r["status"] == "ok"]
+good = [r for r in ok if r["sane_extent"] and r["ends_clean"] and r["close"]]
+by_status = {}
+for r in results:
+    by_status[r["status"]] = by_status.get(r["status"], 0) + 1
+
+print("=== KEY-READING EXTRACTOR HIT-RATE (reading_timer lessons w/ teacher DOCX) ===")
+print(f"total reading_timer lessons: {len(rt)}")
+print(f"status breakdown: {json.dumps(by_status)}")
+not_sane = [f"{r['code']}({r['extent']})" for r in ok if not r['sane_extent']]
+not_clean = [r['code'] for r in ok if not r['ends_clean']]
+far = [f"{r['code']}(d{r['diff']})" for r in ok if not r['close']]
+print(f"extracted ok: {len(ok)}")
+print(f"  fully-good (sane extent + ends clean + char≈extent): {len(good)}/{len(ok)}  ({100*len(good)//max(1,len(ok))}%)")
+print(f"  not sane extent: {not_sane}")
+print(f"  not ends-clean:  {not_clean}")
+print(f"  char far from extent (>60): {far}")
+print()
+print("=== NON-OK (need manual/vision) ===")
+for r in results:
+    if r["status"] != "ok":
+        print(f"  {r['code']}: {r['status']} {r.get('reason','')}{r.get('err','')}")
+
+# dump full for inspection
+json.dump(results, open("/tmp/key_reading_batch.json", "w"), ensure_ascii=False, indent=2)
+print("\nfull → /tmp/key_reading_batch.json")

--- a/docs/2026-07-21-啟翔-二修教材整合-handoff.md
+++ b/docs/2026-07-21-啟翔-二修教材整合-handoff.md
@@ -1,0 +1,69 @@
+# 二修確認版教材整合 — 啟翔 handoff（草案，待 Young 拍板再開 issue）
+
+> 這份是「二修教材來了，請啟翔怎麼做」的規劃。Young 確認後可轉成 GitHub issue 指派啟翔。
+> 檔案已歸檔：`private/curriculum-source/2026-07-21-二修確認版/`（gitignored）
+
+## 背景
+2026-07-20 教授審查後，淑麗/曾老師交出**二修確認版教材**（G4/G5/G8/G9 共 73 課；G6/G7 待二修）。二修做了大動作：**課次重排 + 內容重寫 + 聚光燈高比率重做**。所以線上版要跟著更新。三條線（Young 指定優先序）：**① 排序校正 ② 內容更新 ③ 聚光燈/重點表檢查**。
+
+## 歸檔內容（都在 `private/curriculum-source/2026-07-21-二修確認版/`）
+| 檔/夾 | 用途 |
+|-------|------|
+| `自學教材總表.xlsx` sheet「1.總表」 | **排序校正 SOT**：舊課次→新課次→課名→年級→聚光燈策略對照 |
+| `自學教材教師版確認版-修改完成/{4,5,8,9}年級/*.docx` | **內容 + 聚光燈 + 重點表 + 念順順的抽取來源**（73 課，準） |
+| `修改前後差異/{修改幅度大,修改幅度小}/` | 淑麗標的「哪些課改很多」→ 決定聚光燈要不要整個重跑 |
+| `淑麗師自學教材AI使用指令.docx` | 淑麗的 AI 指令庫（她怎麼精緻化的，做參考） |
+| `教師版＋學生版＋解答樣式/` | 教師版/學生版/簡答版三版型（未來一鍵轉版參考） |
+
+---
+
+## ① 排序校正（先做，其他都依賴它）
+
+**問題**：二修重排了課次/年級，線上版的 lesson code / `display_order` / `manifest.yml` 可能對到舊順序 → 不校正的話，後面內容更新會貼到錯的課。
+
+**做法**：
+1. 讀 `自學教材總表.xlsx` sheet「1.總表」→ 建 **舊課次 ↔ 新課次(年級+課次)** 對照表
+2. 比對線上現況（`backend/data/curriculum/manifest.yml` + `backend/data/curriculum/lessons/*.yml` 的 `lesson_code`/`display_order`/`original_order`）
+3. 產出「校正清單」：哪些課要改 code、哪些要調 display_order、哪些是新增/移除
+4. ⚠️ **不要盲改** —— 先產對照清單給 Young/淑麗 確認，再動 manifest（改錯順序全站錯位）
+
+**驗收**：對照表涵蓋 73 課、每筆標「不變/改 code/改序/新增」、Young 或淑麗簽過再落地。
+
+## ② 內容更新（依賴①）
+
+**做法**：從二修確認版 DOCX 重抽**課文/story 內容**，更新到對應（已校正的）lesson。
+- 來源 = `自學教材教師版確認版-修改完成/` DOCX，**不是**舊 `_parsed_2026-05-01`
+- 用你現有的 DOCX→schema pipeline（`build_lesson_schema.py`）
+- **每一課都有文字改動**（連改很小的也是），所以 73 課全要重抽一次
+
+**驗收**：更新後的線上課文 = 二修 DOCX 課文（抽樣 render 比對，不是只看 diff 綠）。
+
+## ③ 聚光燈、重點表檢查（依賴①②）
+
+**做法**：用你的 `build-spotlight` / `build-keypoints` skill 對二修 DOCX 重跑 + 驗證。**用「修改前後差異」分流省力**：
+- **修改幅度大**的課 → 聚光燈可能整個重做 → **完整重抽 + vision 檢查**
+- **修改幅度小**的課 → 多半只換文字 → 重抽後跑你的 content evidence gate 確認沒跑掉即可
+- 跑你既有的 **content evidence gate**（`content_evidence_gate.py` + ship gate）→ 必須 `CONTENT_EVIDENCE_GATE=PASS`（fail_cells=0 + unknown_cells=0）
+- 真缺口登錄 `content_known_gaps.yaml`（誠實標，禁 fake pass）
+
+**驗收**：聚光燈/重點表 render 出來跟二修 DOCX 一致（真 render vs 原始 DOCX 比對，不比代理物）；gate PASS。
+
+---
+
+## 分工邊界（重點朗讀不在啟翔這份）
+- **重點朗讀（念順順）= 靖杭**（他是朗讀 owner）→ 見 `docs/2026-07-21-靖杭-重點朗讀-handoff.md`
+- 啟翔專注 ①②③（排序/內容/聚光燈重點表，他的 DOCX→schema 強項）
+- ⚠️ 兩人同抽一份二修 DOCX：**同一份 DOCX 可一次抽出課文+聚光燈+重點表+念順順**，避免重工——啟翔的 `build_lesson_schema.py` 產出時，念順順的 `key_reading` 欄位可順手一起產（靖杭再接前端）。抽取層合作、前端/QA 各自負責
+
+## 通則 / 注意
+- **③依賴②依賴①** —— 順序別亂，先把排序釘死
+- 一律以**二修確認版 DOCX 為準**，舊 parsed YAML 作廢
+- pipeline 要 idempotent（教材可能還會滾動修，要能重跑）
+- **不動 Phase 0 已上的 nav/step config**（在 staging，動了要重驗）
+- 誠實標缺口，禁 fake pass（gate 只認 evidence 檔）
+
+## 建議 issue
+- 標題：`[Feature] 二修確認版教材整合：排序校正 + 內容更新 + 聚光燈/重點表檢查`
+- assignee：啟翔（**Young 先跟啟翔對過再指派**，照 assignee policy）
+- 拆 3 個 sub-task（①②③）或一個 issue 分 3 段
+- 連結：本 handoff + 二修歸檔路徑 + build-spotlight/build-keypoints/build-key-reading skill

--- a/docs/2026-07-21-靖杭-重點朗讀-handoff.md
+++ b/docs/2026-07-21-靖杭-重點朗讀-handoff.md
@@ -1,0 +1,60 @@
+# 重點朗讀 Phase 1 — 靖杭 handoff（草案，待 Young 拍板再開 issue）
+
+> 靖杭是朗讀 owner，重點朗讀（念順順）派他。Young/Claude 已把 Phase 0 + 抽取演算法 + 規格做完驗過，靖杭接 Phase 1（整合 + 前端唸指定段）。
+> 完整規格 skill `.claude/skills/build-key-reading/`。
+
+## 一句話
+朗讀從「唸全文」改成「只唸老師指定的重點段」（念順順，紙本課文旁 ☞ 手指頭標起點、右欄累計字數標長度）。**Phase 0 已上 staging（nav 顯示「重點朗讀」），Phase 1 = 把重點段資料接進去，讓它真的只唸指定段。**
+
+## Pilot 狀態（Young/Claude 已完成，靖杭不用重做）
+- ✅ **Phase 0 nav 已上 staging**（PR #2557）：full-reading step 改造成「重點朗讀」「朗」、隱藏逐段、`reading_timer→full-reading`。真環境 QA 過（nav 顯示對、作業提交不卡）
+- ✅ **抽取演算法驗證**：`.claude/skills/build-key-reading/extract_key_reading.py`
+  - 二修確認版 **G4-L14 vision 命中**（☞「下班時刻262路公車」、max 371、抽出 377≈371、斷句尾）
+  - **golden-set 132 舊課真跑：端到端 86%（114/132）**
+- ✅ 二修確認版教材已歸檔：`private/curriculum-source/2026-07-21-二修確認版/`（**65 課有念順順**）
+- ✅ 規格釘死（見下）
+
+## 規格（釘死，別改）
+
+### 抽取（可跟啟翔的 build_lesson_schema 合作，同一份 DOCX 一起抽）
+1. 課文在教師版 DOCX 的**表格**：某 cell 是累計字數欄（遞增數字、末值 150-600）；同 row 去標點最長 cell = 課文欄
+2. **☞ 起點** = 課文欄第一個含 `w:drawing`/`w:pict` 的段落
+3. **範圍** = `max(累計字數)`（不含標點的字數）
+4. 從起點取到不含標點字數 ≈ max，**再 snap 到下一句尾（。」！？）**
+
+### 輸出 schema（寫進 lesson content，前端讀）
+```yaml
+key_reading:
+  start_text: "下班時刻，262路公車上有點擠"   # ☞ 起點錨
+  passage: "下班時刻…我說個話也不行了嗎？"      # snap 到句尾的顯示朗讀段
+  extent_chars: 371                            # max 累計字數（不含標點）
+  source: docx-extract
+  needs_review: false
+```
+- ⚠️ CPM 流暢度門檻**不寫這裡** → 走既有 `reading_benchmark`（我的表現 <190/191~220/>221）
+
+## 靖杭要做的（3 步）
+
+### Step 1 — 抽取整合（跟啟翔協調）
+把 `extract_key_reading.py` 邏輯併進 pipeline（啟翔的 `build_lesson_schema.py` 抽二修 DOCX 時，順手產 `key_reading` 欄位最省事）→ 輸出進 lesson content。來源用**二修確認版 DOCX**。
+
+### Step 2 — 前端唸 passage（你的強項：朗讀/state）
+`FullReadingPage.tsx`：有 `key_reading.passage` 就唸 passage（slice `story.content`），無則 fallback 唸全文。
+- ⛔ **只改內容來源，絕不動 `stepId='full-reading'` 佈線**（`FullReadingPage.tsx:22-24,39` 寫死 stepId，那是完成/進度/作業 gate 的線，動了會害作業提交卡死——code review 抓過這地雷）
+- CPM 計分 benchmark 仍走 `reading_benchmark`（不用改）
+
+### Step 3 — 處理 tail + QA
+- golden-set 86% OK，tail ~14% suspected 主因 = **挑錯 ☞ 起點**（DOCX ~25 張圖，取第一個 drawing 被裝飾圖騙）→ 修法：累計欄首數字行 ↔ drawing 段落**交叉定位**，或該幾課走 vision。無 ☞ 的課標 `needs_review` + fallback，不硬塞
+- **TDD**：`strip_punct(passage) ≈ max(±60)`、`passage[-1] in 。」！？`、`passage ⊂ story.content`。先紅後綠，禁 special-case
+- **前端**：`/qa` 真瀏覽器——學生登入 → 有念順順的課 → 重點朗讀只顯示指定段（非全文）→ 唸 → CPM 計分 → **作業提交不卡**（render-smoke + 你熟的朗讀 e2e）
+
+## 注意
+- 一律以**二修確認版 DOCX 為準**
+- G6/G7 二修還沒來 → 先做 G4/G5/G8/G9 的 65 課
+- **不動 Phase 0 已上的 nav/step config**（在 staging）
+- 跟啟翔在「抽取層」合作（同一份 DOCX），前端/朗讀 QA 你負責
+
+## 建議 issue
+- 標題：`[Feature] 重點朗讀 Phase 1：抽 key_reading 段 + 前端唸指定段（念順順）`
+- assignee：靖杭（**Young 先對過再指派**，照 assignee policy）
+- 連結：本 handoff + skill build-key-reading + PR #2557（Phase 0）+ 啟翔二修整合 handoff（抽取層協調）


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Land the intern handoff docs (二修教材整合 + 重點朗讀 Phase 1) + build-key-reading skill golden-set result (86%) + batch runner. Doc/skill only, no runtime code.

Files:
- docs/2026-07-21-啟翔-二修教材整合-handoff.md
- docs/2026-07-21-靖杭-重點朗讀-handoff.md
- .claude/skills/build-key-reading/ (SKILL.md golden-set + batch_key_reading.py)