### PR TITLE
fix(worksheets): #2018 font preflight + pdffonts postflight gates

### DIFF
--- a/scripts/convert_docx_to_pdf.py
+++ b/scripts/convert_docx_to_pdf.py
@@ -25,10 +25,14 @@ Requirements:
 
 import argparse
 import concurrent.futures
+from collections import defaultdict
+from functools import lru_cache
 import os
 import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
+import zipfile
 from pathlib import Path
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -63,6 +67,76 @@ OUTPUT_DIR = Path("/tmp/lingoleap-worksheets")
 
 MAX_WORKERS = 4
 
+DOCX_FONT_FILES = ("word/document.xml", "word/styles.xml")
+DOCX_FONT_ATTRS = ("ascii", "eastAsia", "hAnsi", "cs")
+WORD_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+
+MACOS_FONT_DIRS = [
+    Path.home() / "Library" / "Fonts",
+    Path("/Library/Fonts"),
+    Path("/System/Library/Fonts"),
+]
+
+FONT_EXTENSIONS = {".ttf", ".otf", ".ttc"}
+
+FONT_STYLE_SUFFIX_RE = re.compile(
+    r"([ _-](regular|bold|semibold|semi bold|medium|light|black|heavy|"
+    r"thin|extralight|extra light|ultralight|ultra light|italic|oblique|"
+    r"w[0-9]+))*$",
+    re.IGNORECASE,
+)
+
+FONT_ALIASES = {
+    "芫荽": ("Iansui",),
+    "Iansui": ("芫荽",),
+    "源泉圓體 B": ("GenSenRounded", "GenSenRoundedTW", "GenSenRoundedTW-Bold"),
+    "GenSenRounded": ("源泉圓體", "源泉圓體 B", "GenSenRoundedTW"),
+    "BpmfIansui": ("Bpmf Iansui",),
+    "標楷體": ("BiauKai", "Kaiti TC", "DFKai-SB"),
+    "jf open 粉圓": ("jf open huninn", "jf-openhuninn", "jf-open 粉圓"),
+    "ㄅ源樣注音黑體": ("BpmfGenYoGothic", "Bpmf GenYo Gothic", "源樣注音黑體"),
+}
+
+# Distinctive DESIGN fonts whose substitution visibly breaks the worksheet
+# (typeface wrong + layout drift). Preflight HARD-BLOCKS only when one of these
+# is missing. Incidental Office/system fonts (Calibri, Aptos, Cambria, Segoe UI,
+# 新細明體, MS Mincho, Arial…) are WARN-only: they either appear on non-visible
+# runs or LibreOffice substitutes them acceptably. The pdffonts POSTFLIGHT is the
+# real safety net that fails on any substitution that actually lands in output.
+CRITICAL_FONT_RE = re.compile(
+    r"(芫荽|iansui|源泉圓體|gensenrounded|標楷|biaukai|kaiti|dfkai|"
+    r"粉圓|huninn|源樣注音黑體|genyo|bpmf)",
+    re.IGNORECASE,
+)
+
+
+def is_critical_font(name: str) -> bool:
+    """True if a missing font would visibly break the worksheet (design font)."""
+    return bool(CRITICAL_FONT_RE.search(name or ""))
+
+# Known font substitutions that must never pass a worksheet PDF gate.
+BAD_FONT_PATTERNS = [
+    "DFHaiBao",
+    "STSongti",
+    "STHeiti",
+    "HiraMin",
+    "HiraKaku",
+    "ArialUnicodeMS",
+    "LiberationSans",
+    "LiberationSerif",
+    "SimSun",
+    "SimHei",
+    "PingFangSC",
+    "-SC-",
+    "SCSong",
+    "SCHei",
+    "GB5",
+    "STSongti-SC",
+    "STHeitiSC",
+    "DFFangYuanW7-GB5",
+    "DFPFangYuanW7",
+]
+
 # LibreOffice binary search order
 SOFFICE_CANDIDATES = [
     "/opt/homebrew/bin/soffice",
@@ -86,6 +160,238 @@ def find_soffice() -> str:
         except Exception:
             pass
     return ""
+
+
+def _normalize_font_key(name: str) -> str:
+    compact = name.replace("\\", "")
+    return re.sub(r"[\s_\-]+", "", compact).casefold()
+
+
+def _font_name_keys(name: str) -> set[str]:
+    stripped = name.strip()
+    if not stripped:
+        return set()
+    base = FONT_STYLE_SUFFIX_RE.sub("", stripped).strip()
+    version_base = re.sub(r"\s+\d+(?:\.\d+)+$", "", stripped).strip()
+    keys = {_normalize_font_key(stripped)}
+    if base:
+        keys.add(_normalize_font_key(base))
+    if version_base:
+        keys.add(_normalize_font_key(version_base))
+    return {key for key in keys if key}
+
+
+def _add_font_name(available: set[str], name: str) -> None:
+    for part in name.split(","):
+        available.update(_font_name_keys(part))
+
+
+@lru_cache(maxsize=1)
+def load_available_font_keys() -> frozenset[str]:
+    available: set[str] = set()
+
+    try:
+        result = subprocess.run(
+            ["fc-list", ":", "family"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                _add_font_name(available, line)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    for font_dir in MACOS_FONT_DIRS:
+        if not font_dir.exists():
+            continue
+        for path in font_dir.rglob("*"):
+            if path.is_file() and path.suffix.lower() in FONT_EXTENSIONS:
+                _add_font_name(available, path.stem)
+
+    return frozenset(available)
+
+
+def font_family_is_available(
+    family: str,
+    available_keys: frozenset[str] | None = None,
+) -> bool:
+    keys = set()
+    for candidate in (family, *FONT_ALIASES.get(family, ())):
+        keys.update(_font_name_keys(candidate))
+    available = available_keys if available_keys is not None else load_available_font_keys()
+    return any(key in available for key in keys)
+
+
+def extract_required_font_families(docx_path: Path) -> set[str]:
+    families: set[str] = set()
+
+    try:
+        with zipfile.ZipFile(docx_path) as docx:
+            for member in DOCX_FONT_FILES:
+                try:
+                    root = ET.fromstring(docx.read(member))
+                except KeyError:
+                    continue
+                for rfonts in root.iter(f"{WORD_NS}rFonts"):
+                    for attr in DOCX_FONT_ATTRS:
+                        value = rfonts.attrib.get(f"{WORD_NS}{attr}")
+                        if value and value.strip():
+                            families.add(value.strip())
+    except (zipfile.BadZipFile, ET.ParseError) as exc:
+        raise ValueError(f"cannot parse DOCX fonts from {docx_path}: {exc}") from exc
+
+    return families
+
+
+def collect_missing_fonts_by_lesson(
+    pairs: list[tuple[str, Path]],
+) -> dict[str, tuple[Path, list[str]]]:
+    available = load_available_font_keys()
+    missing_by_lesson: dict[str, tuple[Path, list[str]]] = {}
+
+    for lesson_code, docx_path in pairs:
+        required = extract_required_font_families(docx_path)
+        missing = sorted(
+            family
+            for family in required
+            if not font_family_is_available(family, available)
+        )
+        if missing:
+            missing_by_lesson[lesson_code] = (docx_path, missing)
+
+    return missing_by_lesson
+
+
+def format_missing_font_report(missing_by_lesson: dict[str, tuple[Path, list[str]]]) -> str:
+    by_font: dict[str, list[str]] = defaultdict(list)
+    for lesson_code, (_, missing) in missing_by_lesson.items():
+        for family in missing:
+            by_font[family].append(lesson_code)
+
+    lines = [
+        "ERROR: missing required worksheet fonts; refusing to render PDFs.",
+        "Install these font families on the LibreOffice rendering machine:",
+    ]
+    for family in sorted(by_font):
+        lessons = ", ".join(sorted(by_font[family]))
+        lines.append(f"  - {family}: {lessons}")
+    return "\n".join(lines)
+
+
+def detect_bad_pdf_fonts_from_output(pdffonts_output: str) -> tuple[list[str], list[str]]:
+    fonts: list[str] = []
+    bad_fonts: list[str] = []
+    patterns = [pattern.casefold() for pattern in BAD_FONT_PATTERNS]
+
+    for line in pdffonts_output.splitlines():
+        stripped = line.strip()
+        if (
+            not stripped
+            or stripped.startswith("name ")
+            or stripped.startswith("---")
+        ):
+            continue
+        font_name = stripped.split()[0]
+        fonts.append(font_name)
+        if any(pattern in font_name.casefold() for pattern in patterns):
+            bad_fonts.append(font_name)
+
+    return fonts, bad_fonts
+
+
+def check_pdf_fonts(pdf_path: Path | str) -> tuple[bool, list[str], list[str]]:
+    try:
+        result = subprocess.run(
+            ["pdffonts", str(pdf_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return False, [], ["pdffonts not found"]
+    except subprocess.TimeoutExpired:
+        return False, [], ["pdffonts timed out"]
+
+    if result.returncode != 0:
+        return False, [], [f"pdffonts error: {result.stderr.strip()[:100]}"]
+
+    fonts, bad_fonts = detect_bad_pdf_fonts_from_output(result.stdout)
+    return len(bad_fonts) == 0, fonts, bad_fonts
+
+
+def run_font_preflight(pairs: list[tuple[str, Path]]) -> bool:
+    """Hard-block only when a CRITICAL design font is missing; WARN on incidental
+    Office/system fonts (they don't cause the 跑版 and postflight catches any real
+    substitution). Returns False (block) only on critical misses."""
+    missing_by_lesson = collect_missing_fonts_by_lesson(pairs)
+    if not missing_by_lesson:
+        return True
+
+    critical: dict[str, tuple[Path, list[str]]] = {}
+    incidental: dict[str, tuple[Path, list[str]]] = {}
+    for lesson_code, (path, missing) in missing_by_lesson.items():
+        crit = [f for f in missing if is_critical_font(f)]
+        inc = [f for f in missing if not is_critical_font(f)]
+        if crit:
+            critical[lesson_code] = (path, crit)
+        if inc:
+            incidental[lesson_code] = (path, inc)
+
+    if incidental:
+        print(
+            format_missing_font_report(incidental).replace(
+                "ERROR: missing required worksheet fonts; refusing to render PDFs.",
+                "WARNING: missing incidental (Office/system) fonts — rendering anyway; "
+                "postflight will catch any substitution that lands in output.",
+            ),
+            file=sys.stderr,
+        )
+    if critical:
+        print(format_missing_font_report(critical), file=sys.stderr)
+        return False
+    return True
+
+
+def print_report(pairs: list[tuple[str, Path]], output_dir: Path) -> None:
+    missing_by_lesson = collect_missing_fonts_by_lesson(pairs)
+    postflight_failed: dict[str, list[str]] = {}
+    postflight_unchecked: list[str] = []
+
+    for lesson_code, _ in pairs:
+        out_pdf = output_dir / f"{lesson_code}.pdf"
+        if not out_pdf.exists():
+            postflight_unchecked.append(lesson_code)
+            continue
+        passed, _, bad_fonts = check_pdf_fonts(out_pdf)
+        if not passed:
+            postflight_failed[lesson_code] = bad_fonts
+
+    print("Worksheet PDF font report")
+    print(f"Lessons scanned: {len(pairs)}")
+    print(f"Preflight failures: {len(missing_by_lesson)}")
+    if missing_by_lesson:
+        print(format_missing_font_report(missing_by_lesson))
+    else:
+        print("Preflight failures: none")
+
+    print()
+    print(f"Postflight failures in {output_dir}: {len(postflight_failed)}")
+    if postflight_failed:
+        for lesson_code in sorted(postflight_failed):
+            print(f"  - {lesson_code}: {', '.join(postflight_failed[lesson_code])}")
+    else:
+        print("Postflight failures: none")
+
+    if postflight_unchecked:
+        print()
+        print(
+            f"Postflight unchecked, PDF not present in {output_dir}: "
+            f"{len(postflight_unchecked)}"
+        )
+        for lesson_code in sorted(postflight_unchecked):
+            print(f"  - {lesson_code}")
 
 
 def extract_lesson_code(filename: str) -> str | None:
@@ -160,6 +466,13 @@ def convert_one(
     out_pdf = output_dir / f"{lesson_code}.pdf"
 
     if out_pdf.exists() and not force:
+        passed, _, bad_fonts = check_pdf_fonts(out_pdf)
+        if not passed:
+            print(
+                f"  ERROR {lesson_code}: existing PDF failed font gate: {bad_fonts}",
+                file=sys.stderr,
+            )
+            return lesson_code, "error"
         return lesson_code, "skipped"
 
     if dry_run:
@@ -202,6 +515,18 @@ def convert_one(
             )
             return lesson_code, "error"
 
+        passed, _, bad_fonts = check_pdf_fonts(out_pdf)
+        if not passed:
+            try:
+                out_pdf.unlink()
+            except OSError:
+                pass
+            print(
+                f"  ERROR {lesson_code}: PDF failed font gate: {bad_fonts}",
+                file=sys.stderr,
+            )
+            return lesson_code, "error"
+
         return lesson_code, "ok"
 
     except subprocess.TimeoutExpired:
@@ -218,6 +543,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Convert lesson docx files to PDF")
     parser.add_argument("--dry-run", action="store_true", help="Print plan, don't convert")
     parser.add_argument("--force", action="store_true", help="Re-convert even if PDF exists")
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Report font preflight/postflight failures without converting or uploading",
+    )
     args = parser.parse_args()
 
     # Verify LibreOffice
@@ -241,6 +571,13 @@ def main() -> None:
 
     if not pairs:
         print("No docx files found. Check SOURCE_DIRS.")
+        sys.exit(1)
+
+    if args.report:
+        print_report(pairs, OUTPUT_DIR)
+        return
+
+    if not run_font_preflight(pairs):
         sys.exit(1)
 
     # Convert in parallel

--- a/scripts/rebuild_worksheets_fonts.py
+++ b/scripts/rebuild_worksheets_fonts.py
@@ -1,131 +1,49 @@
 #!/usr/bin/env python3
 """
-Rebuild 37 worksheet PDFs that render Simplified Chinese due to font substitution.
-Run on macOS with Traditional Chinese fonts installed.
+Rebuild worksheet PDFs with the shared font gates used by convert_docx_to_pdf.py.
+Run on macOS with the required Traditional Chinese fonts installed.
 Issue #2018: https://github.com/Youngger9765/chinese-literacy-platform/issues/2018
 """
 
-import os
-import re
-import subprocess
 import json
-import time
+import os
 import shutil
+import subprocess
+import time
 from datetime import datetime
+from pathlib import Path
 
-SOURCE_ROOT = "/Users/young/project/chinese-literacy-platform/private/curriculum-source/2026-05-01/1.L1-158新版完成學習單1150415"
-OUTPUT_DIR = "/tmp/rebuilt-worksheets"
-FINAL_DIR = "/tmp/rebuilt-worksheets-final"
-SOFFICE = "/opt/homebrew/bin/soffice"
+from convert_docx_to_pdf import (
+    OUTPUT_DIR as CONVERTER_OUTPUT_DIR,
+    check_pdf_fonts,
+    find_all_docx_files,
+    find_soffice,
+    run_font_preflight,
+)
+
+OUTPUT_DIR = Path("/tmp/rebuilt-worksheets")
+FINAL_DIR = Path("/tmp/rebuilt-worksheets-final")
 BUCKET = "gs://lingoleap-assets/worksheets"
 
-# Bad font patterns (Simplified Chinese)
-BAD_FONT_PATTERNS = ["-GB5", "-SC-", "SC-Bold", "SCSong", "SCHei", "SimSun",
-                     "SimHei", "Sim", "PingFangSC", "STSongti-SC", "STHeitiSC",
-                     "DFFangYuanW7-GB5", "DFPFangYuanW7"]
-
-# Affected GCS filenames (exact, confirmed from gsutil ls)
-AFFECTED = [
-    "G4-L04", "G4-L10", "G4-L12", "G4-L15", "G4-L19", "G4-L27", "G4-L5", "G4-L6",
-    "G5-L07", "G5-L10", "G5-L11", "G5-L18", "G5-L23", "G5-L24",
-    "G6-L1",  "G6-L15", "G6-L22", "G6-L23",
-    "G7-L1",  "G7-L11", "G7-L17", "G7-L29", "G7-L9",
-    "G8-L02", "G8-L03b", "G8-L4", "G8-L7",
-    "G9-L01", "G9-L02", "G9-L09", "G9-L1", "G9-L12", "G9-L3", "G9-L9",
-    "WW-L02", "WW-L10", "文-L10",
-]
-
-# Pairs that share the same source docx (same lesson, different padding in GCS)
-SHARED_SOURCE = {
-    "G9-L1": "G9-L01",   # same source as G9-L01
-    "G9-L9": "G9-L09",   # same source as G9-L09
-}
-
-os.makedirs(OUTPUT_DIR, exist_ok=True)
-os.makedirs(FINAL_DIR, exist_ok=True)
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+FINAL_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def extract_lesson_code(gcs_name):
-    """G4-L04 -> (G4, 4), G7-L29 -> (G7, 29), WW-L02 -> (WW, 2), 文-L10 -> (文, 10)"""
-    parts = gcs_name.split("-L")
-    if len(parts) != 2:
-        return None, None
-    grade = parts[0]
-    num_str = parts[1].rstrip("b")  # strip 'b' suffix for G8-L03b
-    suffix = "b" if parts[1].endswith("b") else ""
-    try:
-        num = int(num_str)
-    except ValueError:
-        return grade, parts[1]
-    return grade, num, suffix
-
-
-def find_docx(gcs_name):
-    """Find the source .docx for a given GCS filename. Prefer student version."""
-    # Extract grade and lesson number
-    parts = gcs_name.split("-L")
-    if len(parts) != 2:
-        return None, None
-    grade = parts[0]
-    lesson_part = parts[1]  # e.g. "04", "29", "03b", "5"
-
-    # Try both padded and unpadded numbers
-    try:
-        lesson_num = int(lesson_part.rstrip("b"))
-        suffix = "b" if lesson_part.endswith("b") else ""
-        num_variants = [str(lesson_num), str(lesson_num).zfill(2), lesson_part]
-    except ValueError:
-        num_variants = [lesson_part]
-        suffix = ""
-
-    # Build search patterns: student (SL) preferred, then teacher (L)
-    search_patterns = []
-    for n in set(num_variants):
-        search_patterns.append(f"{grade}-SL{n}{suffix}")
-        search_patterns.append(f"{grade}-SL{n}")
-        search_patterns.append(f"{grade}-L{n}{suffix}")
-        search_patterns.append(f"{grade}-L{n}")
-
-    # Search order: student dirs first, then teacher dirs
-    search_dirs = [
-        os.path.join(SOURCE_ROOT, "2-1學生版(L1~122)"),
-        os.path.join(SOURCE_ROOT, "2-1學生版補L123-L157"),
-        os.path.join(SOURCE_ROOT, "第三階段(L123開始~L157)差學生版"),
-        os.path.join(SOURCE_ROOT, "1-1教師版(L1~122)"),
-    ]
-
-    candidates_student = []
-    candidates_teacher = []
-
-    for root, dirs, files in os.walk(SOURCE_ROOT):
-        for fname in files:
-            if not fname.endswith(".docx"):
-                continue
-            for pat in search_patterns:
-                # Digit-boundary match: "G7-L1" must NOT match "G7-L10"/"G7-L11".
-                # Plain substring matching corrupted single-digit codes by pulling
-                # the wrong source docx (e.g. G7-L1 → G7-L10塑膠), so the rebuilt
-                # PDF carried a different lesson's content (#2018 follow-up).
-                if re.search(re.escape(pat) + r'(?![0-9])', fname):
-                    full_path = os.path.join(root, fname)
-                    is_student = ("學生版" in root or "-SL" in fname)
-                    if is_student:
-                        candidates_student.append(full_path)
-                    else:
-                        candidates_teacher.append(full_path)
-                    break
-
-    if candidates_student:
-        return candidates_student[0], "student"
-    if candidates_teacher:
-        return candidates_teacher[0], "teacher"
-    return None, None
-
-
-def build_pdf(docx_path, output_name):
-    """Convert docx to PDF using soffice. Returns (success, built_pdf_path, elapsed_s)."""
+def build_pdf(
+    soffice: str,
+    docx_path: Path,
+    output_name: str,
+) -> tuple[bool, Path | None, float]:
     start = time.time()
-    cmd = [SOFFICE, "--headless", "--convert-to", "pdf", "--outdir", OUTPUT_DIR, docx_path]
+    cmd = [
+        soffice,
+        "--headless",
+        "--convert-to",
+        "pdf",
+        "--outdir",
+        str(OUTPUT_DIR),
+        str(docx_path),
+    ]
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
     elapsed = time.time() - start
 
@@ -133,198 +51,141 @@ def build_pdf(docx_path, output_name):
         print(f"  SOFFICE FAILED: {result.stderr[:200]}")
         return False, None, elapsed
 
-    # soffice outputs file named after docx basename
-    docx_basename = os.path.splitext(os.path.basename(docx_path))[0]
-    built_pdf = os.path.join(OUTPUT_DIR, docx_basename + ".pdf")
-
-    if not os.path.exists(built_pdf):
-        # Try to find any newly created pdf
+    built_pdf = OUTPUT_DIR / f"{docx_path.stem}.pdf"
+    if not built_pdf.exists():
         print(f"  WARNING: expected {built_pdf} not found, searching...")
-        pdfs = [f for f in os.listdir(OUTPUT_DIR) if f.endswith(".pdf")]
-        if pdfs:
-            built_pdf = os.path.join(OUTPUT_DIR, sorted(pdfs)[-1])
-            print(f"  Found: {built_pdf}")
-        else:
+        pdfs = sorted(OUTPUT_DIR.glob("*.pdf"), key=os.path.getmtime)
+        if not pdfs:
             return False, None, elapsed
+        built_pdf = pdfs[-1]
+        print(f"  Found: {built_pdf}")
 
-    # Rename to final name
-    final_pdf = os.path.join(FINAL_DIR, output_name + ".pdf")
+    final_pdf = FINAL_DIR / f"{output_name}.pdf"
     shutil.copy2(built_pdf, final_pdf)
     return True, final_pdf, elapsed
 
 
-def check_fonts(pdf_path):
-    """Run pdffonts and check for bad fonts. Returns (passed, fonts_list, bad_fonts)."""
-    result = subprocess.run(["pdffonts", pdf_path], capture_output=True, text=True, timeout=30)
-    if result.returncode != 0:
-        return False, [], [f"pdffonts error: {result.stderr[:100]}"]
-
-    lines = result.stdout.strip().split("\n")
-    fonts = []
-    bad = []
-    for line in lines[2:]:  # skip header
-        if not line.strip():
-            continue
-        font_name = line.split()[0] if line.split() else ""
-        fonts.append(font_name)
-        for pat in BAD_FONT_PATTERNS:
-            if pat.lower() in font_name.lower():
-                bad.append(font_name)
-                break
-    return len(bad) == 0, fonts, bad
-
-
-def upload_to_gcs(pdf_path, gcs_name):
-    """Upload rebuilt PDF to GCS, overwriting original."""
-    subprocess.run(["gcloud", "config", "configurations", "activate", "lingoleap"],
-                   capture_output=True)
+def upload_to_gcs(pdf_path: Path, gcs_name: str) -> tuple[bool, str]:
+    subprocess.run(
+        ["gcloud", "config", "configurations", "activate", "lingoleap"],
+        capture_output=True,
+    )
     dest = f"{BUCKET}/{gcs_name}.pdf"
-    result = subprocess.run(["gsutil", "cp", pdf_path, dest], capture_output=True, text=True)
+    result = subprocess.run(
+        ["gsutil", "cp", str(pdf_path), dest],
+        capture_output=True,
+        text=True,
+    )
     if result.returncode == 0:
         return True, dest
     print(f"  UPLOAD FAILED: {result.stderr[:200]}")
     return False, dest
 
 
-def main():
+def main() -> None:
+    pairs = find_all_docx_files()
     results = []
-    not_found = []
     font_failed = []
     uploaded = []
 
-    # Pre-build shared source map (G9-L1 reuses G9-L01's built PDF)
-    built_cache = {}  # canonical_name -> final_pdf_path
-
-    print(f"Starting rebuild of {len(AFFECTED)} worksheets...")
-    print(f"Source: {SOURCE_ROOT}")
+    print(f"Starting rebuild of {len(pairs)} worksheet PDFs...")
+    print(f"Converter output reference: {CONVERTER_OUTPUT_DIR}")
     print(f"Output: {FINAL_DIR}")
     print()
 
-    for gcs_name in AFFECTED:
+    if not pairs:
+        print("No docx files found.")
+        raise SystemExit(1)
+
+    if not run_font_preflight(pairs):
+        raise SystemExit(1)
+
+    soffice = find_soffice()
+    if not soffice:
+        print("ERROR: LibreOffice (soffice) not found.")
+        raise SystemExit(1)
+
+    for gcs_name, docx_path in pairs:
         print(f"[{gcs_name}]")
+        print(f"  Source: {docx_path.name}")
 
-        # If this is a shared-source alias, copy from already-built
-        if gcs_name in SHARED_SOURCE:
-            canonical = SHARED_SOURCE[gcs_name]
-            if canonical in built_cache:
-                src_pdf = built_cache[canonical]
-                final_pdf = os.path.join(FINAL_DIR, gcs_name + ".pdf")
-                shutil.copy2(src_pdf, final_pdf)
-                print(f"  Copied from {canonical} -> {gcs_name}")
-                # Upload
-                ok, dest = upload_to_gcs(final_pdf, gcs_name)
-                status = "uploaded" if ok else "upload_failed"
-                if ok:
-                    uploaded.append(gcs_name)
-                results.append({
-                    "gcs_name": gcs_name,
-                    "source_docx": f"[shared from {canonical}]",
-                    "version_type": "shared",
-                    "build_time_s": 0,
-                    "font_check": "PASS (shared)",
-                    "bad_fonts_found": [],
-                    "upload_status": status,
-                    "gcs_url": dest,
-                })
-                continue
-            else:
-                print(f"  WARNING: canonical {canonical} not yet built, processing normally")
-
-        # Find docx
-        docx_path, version_type = find_docx(gcs_name)
-        if not docx_path:
-            print(f"  NOT FOUND")
-            not_found.append(gcs_name)
-            results.append({
-                "gcs_name": gcs_name,
-                "source_docx": None,
-                "version_type": None,
-                "error": "source_docx_not_found",
-            })
-            continue
-
-        print(f"  Source: {os.path.basename(docx_path)} ({version_type})")
-
-        # Build PDF
-        ok, final_pdf, elapsed = build_pdf(docx_path, gcs_name)
-        if not ok:
+        ok, final_pdf, elapsed = build_pdf(soffice, docx_path, gcs_name)
+        if not ok or final_pdf is None:
             print(f"  BUILD FAILED ({elapsed:.1f}s)")
-            results.append({
-                "gcs_name": gcs_name,
-                "source_docx": docx_path,
-                "version_type": version_type,
-                "build_time_s": round(elapsed, 1),
-                "error": "build_failed",
-            })
+            results.append(
+                {
+                    "gcs_name": gcs_name,
+                    "source_docx": str(docx_path),
+                    "build_time_s": round(elapsed, 1),
+                    "error": "build_failed",
+                }
+            )
             continue
 
         print(f"  Built in {elapsed:.1f}s")
 
-        # Check fonts
-        passed, fonts, bad = check_fonts(final_pdf)
+        passed, fonts, bad = check_pdf_fonts(final_pdf)
         if not passed:
             print(f"  FONT CHECK FAILED: {bad}")
             font_failed.append(gcs_name)
-            results.append({
-                "gcs_name": gcs_name,
-                "source_docx": docx_path,
-                "version_type": version_type,
-                "build_time_s": round(elapsed, 1),
-                "font_check": "FAILED",
-                "bad_fonts_found": bad,
-                "upload_status": "skipped_bad_fonts",
-            })
+            try:
+                final_pdf.unlink()
+            except OSError:
+                pass
+            results.append(
+                {
+                    "gcs_name": gcs_name,
+                    "source_docx": str(docx_path),
+                    "build_time_s": round(elapsed, 1),
+                    "font_check": "FAILED",
+                    "bad_fonts_found": bad,
+                    "upload_status": "skipped_bad_fonts",
+                }
+            )
             continue
 
         print(f"  Font check PASSED ({len(fonts)} fonts)")
-        built_cache[gcs_name] = final_pdf  # cache for shared-source aliases
 
-        # Upload
         upload_ok, dest = upload_to_gcs(final_pdf, gcs_name)
         status = "uploaded" if upload_ok else "upload_failed"
         if upload_ok:
             uploaded.append(gcs_name)
             print(f"  Uploaded -> {dest}")
         else:
-            print(f"  UPLOAD FAILED")
+            print("  UPLOAD FAILED")
 
-        results.append({
-            "gcs_name": gcs_name,
-            "source_docx": docx_path,
-            "version_type": version_type,
-            "build_time_s": round(elapsed, 1),
-            "font_check": "PASS",
-            "fonts_after_rebuild": fonts[:10],  # first 10
-            "bad_fonts_found": [],
-            "upload_status": status,
-            "gcs_url": dest,
-        })
+        results.append(
+            {
+                "gcs_name": gcs_name,
+                "source_docx": str(docx_path),
+                "build_time_s": round(elapsed, 1),
+                "font_check": "PASS",
+                "fonts_after_rebuild": fonts[:10],
+                "bad_fonts_found": [],
+                "upload_status": status,
+                "gcs_url": dest,
+            }
+        )
 
-    # Write manifest
     manifest = {
         "rebuilt_at": datetime.utcnow().isoformat() + "Z",
         "issue": "https://github.com/Youngger9765/chinese-literacy-platform/issues/2018",
-        "total_affected": len(AFFECTED),
+        "total_attempted": len(pairs),
         "results": results,
-        "not_found": not_found,
         "failed_font_check": font_failed,
         "uploaded": uploaded,
     }
-    manifest_path = os.path.join(OUTPUT_DIR, "MANIFEST.json")
+    manifest_path = OUTPUT_DIR / "MANIFEST.json"
     with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, ensure_ascii=False, indent=2)
 
-    # Summary
     print()
     print("=" * 50)
     print("REBUILD SUMMARY")
     print("=" * 50)
-    print(f"Total attempted:          {len(AFFECTED)}")
-    print(f"Source docx found:        {len(AFFECTED) - len(not_found)}")
-    print(f"Font check passed:        {len(uploaded) + len([r for r in results if r.get('upload_status') == 'upload_failed'])}")
+    print(f"Total attempted:          {len(pairs)}")
+    print(f"Font check failed:        {len(font_failed)} {font_failed}")
     print(f"Uploaded to GCS:          {len(uploaded)}")
-    print(f"NOT FOUND (no docx):      {len(not_found)} {not_found}")
-    print(f"Font check FAILED:        {len(font_failed)} {font_failed}")
     print(f"MANIFEST:                 {manifest_path}")
 
 

--- a/tests/test_worksheet_pdf_font_gates.py
+++ b/tests/test_worksheet_pdf_font_gates.py
@@ -1,0 +1,73 @@
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "convert_docx_to_pdf.py"
+SPEC = importlib.util.spec_from_file_location("convert_docx_to_pdf", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+convert_docx_to_pdf = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(convert_docx_to_pdf)
+
+detect_bad_pdf_fonts_from_output = convert_docx_to_pdf.detect_bad_pdf_fonts_from_output
+is_critical_font = convert_docx_to_pdf.is_critical_font
+
+
+def test_critical_fonts_are_the_design_fonts() -> None:
+    # Distinctive design fonts whose absence visibly breaks the worksheet →
+    # preflight hard-blocks on these.
+    for family in ["芫荽", "Iansui", "源泉圓體 B", "標楷體",
+                   "jf open 粉圓 2.0", "ㄅ源樣注音黑體 R", "BpmfIansui"]:
+        assert is_critical_font(family) is True, family
+
+
+def test_incidental_office_fonts_do_not_block() -> None:
+    # Office/system fonts are warn-only (LibreOffice substitutes acceptably) —
+    # they must NOT hard-block preflight, else every lesson fails forever.
+    for family in ["Calibri", "Aptos", "Cambria", "Segoe UI",
+                   "新細明體", "MS Mincho", "Arial"]:
+        assert is_critical_font(family) is False, family
+
+
+def test_detect_bad_pdf_fonts_catches_known_substitutions() -> None:
+    pdffonts_output = """
+name                                 type              encoding         emb sub uni object ID
+------------------------------------ ----------------- ---------------- --- --- --- ---------
+DFHaiBaoStd-W9                       CID TrueType      Identity-H       yes no  yes     10  0
+STSongti-TC-Bold                     CID TrueType      Identity-H       yes no  yes     11  0
+HiraMinProN-W3                       CID TrueType      Identity-H       yes no  yes     12  0
+ArialUnicodeMS                       CID TrueType      Identity-H       yes no  yes     13  0
+LiberationSans                       TrueType          WinAnsi          yes no  yes     14  0
+GenSenRoundedTW-Bold                 CID TrueType      Identity-H       yes no  yes     15  0
+"""
+
+    fonts, bad_fonts = detect_bad_pdf_fonts_from_output(pdffonts_output)
+
+    assert "GenSenRoundedTW-Bold" in fonts
+    assert bad_fonts == [
+        "DFHaiBaoStd-W9",
+        "STSongti-TC-Bold",
+        "HiraMinProN-W3",
+        "ArialUnicodeMS",
+        "LiberationSans",
+    ]
+
+
+def test_detect_bad_pdf_fonts_allows_clean_traditional_fonts() -> None:
+    pdffonts_output = """
+name                                 type              encoding         emb sub uni object ID
+------------------------------------ ----------------- ---------------- --- --- --- ---------
+Iansui-Regular                       CID TrueType      Identity-H       yes no  yes     10  0
+GenSenRoundedTW-Bold                 CID TrueType      Identity-H       yes no  yes     11  0
+BpmfIansui-Regular                   CID TrueType      Identity-H       yes no  yes     12  0
+NotoSansTC-Regular                   CID TrueType      Identity-H       yes no  yes     13  0
+"""
+
+    fonts, bad_fonts = detect_bad_pdf_fonts_from_output(pdffonts_output)
+
+    assert fonts == [
+        "Iansui-Regular",
+        "GenSenRoundedTW-Bold",
+        "BpmfIansui-Regular",
+        "NotoSansTC-Regular",
+    ]
+    assert bad_fonts == []


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 問題（#2018 復發，已復現）
worksheet PDF 從 docx 渲染時，教材設計字型（芫荽/源泉圓體/標楷/粉圓/BpmfIansui/ㄅ源樣注音黑體）沒裝 → soffice 靜默代換 → pdffonts 顯示嵌入 DFHaiBao/STSongti/HiraMin/ArialUnicodeMS。151 課全中。

## 修法（gate，讓代換不可能靜默上架）
- **preflight**：渲染前檢查每課 docx 需要的字型有沒有裝；**缺關鍵設計字型才 hard-block**，Office/系統字型（Calibri/Aptos/新細明體…）只 warn（否則每課永遠卡）
- **postflight**：渲染後 pdffonts 驗證，輸出含代換字型就 fail 該課、絕不上傳
- 掃全部課（取代寫死 37 課清單）+ `--report` 模式
- 兩腳本共用 helper

## 驗證
`tests/test_worksheet_pdf_font_gates.py` 4 passed（代換偵測 + critical/incidental 分流）。codex exec 建、工頭 verify+refine。

⚠️ **真正乾淨重渲染仍需裝齊完整字型**（部分不在交接 zip）——這 PR 把那件事從「靜默失敗」變成「大聲強制的前提」。

純 scripts + tests，不動 runtime app。