### PR TITLE
feat(reading): 流暢度改綠色字/分(WPM)、隱藏正確率 (Phase 1, #2568)

### DIFF
--- a/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
@@ -13,6 +13,7 @@
 import React, { useState } from 'react';
 import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
 import ReadingTrendChart from './ReadingTrendChart';
+import { SHOW_READING_ACCURACY } from '../../../config/readingScoreDisplay';
 
 interface ReadingMetricsCardProps {
   /** 正確率 0–100 (integer %) */
@@ -47,9 +48,10 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
         這次成績
       </p>
 
-      {/* Metric pills — 正確率 + 語速 */}
+      {/* Metric pills — 語速(流暢度) + 正確率（Issue #2568：正確率預設隱藏） */}
       <div className="flex gap-3">
-        {/* 正確率 */}
+        {/* 正確率 — Issue #2568: 只留流暢度，正確率隱藏（計算仍保留） */}
+        {SHOW_READING_ACCURACY && (
         <div className="flex-1 flex flex-col items-center gap-1 bg-amber-50 rounded-2xl py-4 px-3 border border-amber-200">
           <span
             className="material-symbols-outlined text-amber-500 text-2xl"
@@ -62,6 +64,7 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
           </span>
           <span className="text-xs font-headline text-amber-600">正確率</span>
         </div>
+        )}
 
         {/* 語速 */}
         <div className="flex-1 flex flex-col items-center gap-1 bg-blue-50 rounded-2xl py-4 px-3 border border-blue-200">
@@ -95,9 +98,11 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
                     {idx === 0 ? '最新' : dateStr}
                   </span>
                   <div className="flex items-center gap-4">
-                    <span className="text-amber-700 font-headline font-bold">
-                      {Math.round(item.accuracy)}%
-                    </span>
+                    {SHOW_READING_ACCURACY && (
+                      <span className="text-amber-700 font-headline font-bold">
+                        {Math.round(item.accuracy)}%
+                      </span>
+                    )}
                     <span className="text-blue-700 font-headline font-bold">
                       {Math.round(item.cpm)} 字/分
                     </span>
@@ -121,7 +126,9 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
       {/* #1597 Trend chart — all-history dual-axis line. Renders an inline
           encouragement message when < 2 points (the chart component handles
           its own empty state). */}
-      {history && history.length > 0 && <ReadingTrendChart history={history} />}
+      {history && history.length > 0 && (
+        <ReadingTrendChart history={history} showAccuracy={SHOW_READING_ACCURACY} />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
@@ -27,6 +27,8 @@ import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
 interface ReadingTrendChartProps {
   /** Reading history items — order from caller is preserved internally. */
   history: ReadingHistoryItem[];
+  /** Issue #2568: 隱藏正確率系列時傳 false（只留語速/流暢度）。預設 true 以相容既有呼叫。 */
+  showAccuracy?: boolean;
 }
 
 interface ChartPoint {
@@ -68,18 +70,21 @@ function buildChartData(
 interface TooltipProps {
   active?: boolean;
   payload?: Array<{ payload: ChartPoint }>;
+  showAccuracy?: boolean;
 }
 
-function CustomTooltip({ active, payload }: TooltipProps) {
+function CustomTooltip({ active, payload, showAccuracy = true }: TooltipProps) {
   if (!active || !payload || payload.length === 0) return null;
   const p = payload[0].payload;
   return (
     <div className="bg-surface-container-lowest border border-surface-container-high rounded-lg shadow-md px-3 py-2 text-xs">
       <div className="font-headline font-bold text-on-surface mb-1">第 {p.attempt} 次 · {p.fullDate}</div>
-      <div className="flex items-center gap-2 text-amber-700">
-        <span className="w-2 h-2 rounded-full bg-amber-500" />
-        正確率：<span className="font-bold">{p.accuracy}%</span>
-      </div>
+      {showAccuracy && (
+        <div className="flex items-center gap-2 text-amber-700">
+          <span className="w-2 h-2 rounded-full bg-amber-500" />
+          正確率：<span className="font-bold">{p.accuracy}%</span>
+        </div>
+      )}
       <div className="flex items-center gap-2 text-blue-700">
         <span className="w-2 h-2 rounded-full bg-blue-500" />
         語速：<span className="font-bold">{p.cpm} 字/分</span>
@@ -88,7 +93,7 @@ function CustomTooltip({ active, payload }: TooltipProps) {
   );
 }
 
-const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
+const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history, showAccuracy = true }) => {
   const totalAttempts = history.length;
   /* #1633: start with the latest 4 attempts; 「載入更多」 unlocks more. */
   const [visiblePoints, setVisiblePoints] = useState(DEFAULT_POINTS);
@@ -132,6 +137,7 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
           <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
             <XAxis dataKey="attempt" tick={{ fontSize: 10 }} stroke="#9ca3af" />
+            {showAccuracy && (
             <YAxis
               yAxisId="accuracy"
               orientation="left"
@@ -141,6 +147,7 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
               tickFormatter={(v) => `${v}%`}
               width={32}
             />
+            )}
             <YAxis
               yAxisId="cpm"
               orientation="right"
@@ -149,8 +156,9 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
               stroke="#2563eb"
               width={32}
             />
-            <Tooltip content={<CustomTooltip />} />
+            <Tooltip content={<CustomTooltip showAccuracy={showAccuracy} />} />
             <Legend wrapperStyle={{ fontSize: 10 }} iconSize={8} />
+            {showAccuracy && (
             <Line
               yAxisId="accuracy"
               type="monotone"
@@ -161,6 +169,7 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
               dot={{ r: 3 }}
               activeDot={{ r: 5 }}
             />
+            )}
             <Line
               yAxisId="cpm"
               type="monotone"

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -11,6 +11,7 @@ import { useKaraoke } from '../../../context/KaraokeContext';
 import { interleavePunctuation } from '../../../utils/textDiff';
 import { getEncouragement } from '../../../utils/readingEncouragement';
 import { ReadingDiffLegend, renderDiffTokenSpans } from '../readingDiffStyle';
+import { SHOW_READING_ACCURACY } from '../../../config/readingScoreDisplay';
 
 /** Per-sentence retry (record + eval). Off until short-sentence practice ships. */
 const SENTENCE_RETRY_UI_ENABLED = false;
@@ -322,12 +323,15 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
                   <span className="font-bold text-on-surface">{cpmVal}</span>
                   <span className="text-on-surface-variant text-xs">字/分</span>
                 </div>
+                {/* Issue #2568: 只留流暢度(語速)，正確率隱藏（計算仍保留） */}
+                {SHOW_READING_ACCURACY && (
                 <div className="flex items-center gap-1.5">
                   <span className="material-symbols-outlined text-base text-on-surface-variant">check_circle</span>
                   <span className="text-on-surface-variant">正確率</span>
                   <span className={`font-bold ${rateColor}`}>{Math.round(rate * 100)}%</span>
                   <span className="text-on-surface-variant text-xs">（不含標點、注音）</span>
                 </div>
+                )}
               </div>
             );
           })()}

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
@@ -119,9 +119,10 @@ export function useLiveTutorProgress(
     if (lineResults.length === 0) return null;
     const avgMatchRate =
       lineResults.reduce((s, r) => s + r.matchRate, 0) / lineResults.length;
+    // Issue #2568: 流暢度 = 綠色(correct)字數 / 分鐘。只算 correct（純綠），
+    // 不含 forgiven（藍/相似發音）——與全文朗讀 fluencyAnalyzer 的 correctCount 對齊。
     const totalCorrectChars = lineResults.reduce(
-      (s, r) =>
-        s + r.diffTokens.filter((t) => t.type === 'correct' || t.type === 'forgiven').length,
+      (s, r) => s + r.diffTokens.filter((t) => t.type === 'correct').length,
       0,
     );
     const totalDurationSec = lineResults.reduce((s, r) => s + r.durationMs, 0) / 1000;

--- a/frontend/src/config/readingScoreDisplay.ts
+++ b/frontend/src/config/readingScoreDisplay.ts
@@ -1,0 +1,10 @@
+/**
+ * 朗讀計分「顯示」設定 (Issue #2568)。
+ *
+ * 會議決議：捨棄「正確率」、只保留「流暢度（綠色字/分 = WPM）」作為單一指標，
+ * 方便現場對學生解說。
+ *
+ * Phase 1：只「隱藏正確率的顯示」——計算（matchRate / accuracy）仍保留，
+ * 之後若要調整或做 Phase 2 的 label 呈現時可直接翻回 true。
+ */
+export const SHOW_READING_ACCURACY = false;


### PR DESCRIPTION
## 實作 #2568 Phase 1 — 流暢度改 WPM、隱藏正確率

依會議決議：捨棄正確率、只留流暢度（單一指標，方便現場對學生解說）。

### 流暢度算法（統一為「綠色字/分」= WPM）
```
流暢度(WPM) = 綠色(correct)字數 ÷ (durationMs / 60000)
```
- **只算 correct（純綠）**，不含 forgiven（藍/相似發音）——採 Young「只算綠色的字」的字面定義。
- 唸錯/漏念/贅字/自我校正不進分子，但它們花的時間仍在分母 → 自動壓低 WPM。
- **統一三處定義**：全文 `fluencyAnalyzer.ts`（本來就 correctCount／純綠）、逐段單段 `localEval`（同）、逐段整體 `useLiveTutorProgress` overallMetrics（**本次從 correct+forgiven 改為只 correct**）。

### 隱藏正確率（計算保留、只不顯示）
新增 feature flag `config/readingScoreDisplay.ts` → `SHOW_READING_ACCURACY = false`（好回退／Phase 2 調整）。套用於：
- `ReadingMetricsCard`：正確率 pill、歷史表的正確率%
- `ParagraphCard` 逐段 summary：正確率行
- `ReadingTrendChart`：正確率系列（新增 `showAccuracy` prop，預設 true 相容）

**保留**：語速(WPM) 卡/行、鼓勵星等（星等無數字，屬鼓勵）。

### 我在 issue 標的決策已採預設值（請 Young 確認）
- 「綠色」= **只算 correct（A）**。若要含通融(藍) 再說，改一行即可。
- pass/fail gate 未動（本來就不 block 進度），只換顯示。
- 鼓勵星等仍依 matchRate（無顯示數字）；若要星等也改綁流暢度屬 Phase 2。

### 驗證（ui-pr-verify SOP）
- ESLint：**0 errors**；tsc：改動檔無新錯
- vitest：smoke + full-reading + live-tutor **54 passed**；`ReadingTrendChart.test` 有 1 個**既有**失敗（"caps at 20 points" label，與本 PR 無關，已 stash 比對確認 staging 本來就紅）
- ⚠️ 朗讀結果畫面需真麥克風，/qa 截圖待 preview 部署後人工驗收（確認畫面只剩流暢度、無正確率）

@claude 請幫我 review 這個 PR
