### PR TITLE
fix(reading): FullReadingPage stepId 改 step-aware，清 #2559 pilot 技術債 (Fixes #2588)

### DIFF
--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -122,6 +122,9 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
   // 重點朗讀（保留 step id 'full-reading' → 完成/進度/作業 gate 全沿用現成佈線，不新增 step 避免完成-識別 bug）。
   // 重點段資料就緒前，FullReadingPage 暫唸全文作 fallback；Phase 1 接 key_reading 欄位後只唸指定段
   // （見 docs/reading-key-passage-TODO.md、skill build-key-reading）。
+  // ⚠️ 改這個 id 一定要同步更新後端 `backend/app/models/session.py` 的 `_FRONTEND_STEP_ALIAS`
+  // （前端 step key → 後端 canonical key → step number）。後端查無此 key 會算成 0，
+  // 完成度掉單、作業提交卡住且靜默無 error（#2588）。
   'full-reading': {
     id: 'full-reading',
     label: '重點朗讀',

--- a/frontend/src/hooks/__tests__/useCurrentStepId.test.tsx
+++ b/frontend/src/hooks/__tests__/useCurrentStepId.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * useCurrentStepId (#2588) — route-derived step id with a fail-safe fallback.
+ *
+ * Pages used to hardcode their step id (FullReadingPage wrote 'full-reading' in
+ * three places).  The hook derives it from the route so a renamed / re-mounted
+ * step cannot split progress across two keys — but it must NEVER return an
+ * unregistered id, because the backend maps step keys to step numbers and an
+ * unknown key silently drops the completion (assignment can't be submitted).
+ */
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { useCurrentStepId } from '../useCurrentStepId';
+import { STEP_REGISTRY } from '../../config/stepConfig';
+
+const wrapperFor = (initialPath: string) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
+  };
+
+const renderAt = (path: string, fallback = 'full-reading') =>
+  renderHook(() => useCurrentStepId(fallback), { wrapper: wrapperFor(path) }).result.current;
+
+describe('useCurrentStepId', () => {
+  it('returns the route segment when it is a registered step', () => {
+    expect(renderAt('/learn/1/full-reading')).toBe('full-reading');
+    expect(renderAt('/learn/42/tutor', 'full-reading')).toBe('tutor');
+  });
+
+  it('follows the route when the step is mounted under a different registered id', () => {
+    // Simulates a future rename: the page must report the id it is mounted at,
+    // not the literal it was written with.
+    const anyOtherStepId = 'vocab';
+    expect(STEP_REGISTRY[anyOtherStepId]).toBeTruthy();
+    expect(renderAt(`/learn/1/${anyOtherStepId}`, 'full-reading')).toBe(anyOtherStepId);
+  });
+
+  it('falls back to the canonical id for an UNREGISTERED segment (never persists unknown keys)', () => {
+    expect(renderAt('/learn/1/not-a-step')).toBe('full-reading');
+  });
+
+  it('falls back outside the learning flow / on trailing slashes', () => {
+    expect(renderAt('/library')).toBe('full-reading');
+    expect(renderAt('/learn/1/')).toBe('full-reading');
+    expect(renderAt('/')).toBe('full-reading');
+  });
+});

--- a/frontend/src/hooks/useCurrentStepId.ts
+++ b/frontend/src/hooks/useCurrentStepId.ts
@@ -1,0 +1,30 @@
+import { useLocation } from 'react-router-dom';
+import { STEP_REGISTRY } from '../config/stepConfig';
+
+/**
+ * Derive the learning step id from the current route instead of hardcoding it
+ * in the page component (#2588).
+ *
+ * Learning routes are generated from STEP_REGISTRY by buildLearningRoutes():
+ * `/learn/:storyId/<stepId>`, so the last path segment *is* the step id.  A page
+ * that hardcodes its own id silently drifts when the step is renamed or mounted
+ * on a second route — progress would be written under one key and read/completed
+ * under another, which breaks assignment submission with no visible error.
+ *
+ * Fail-safe: the segment is only accepted when it is a registered step.  Anything
+ * else (unknown segment, non-learning route, trailing slash) falls back to the
+ * canonical id the caller passes in, so we never persist an unknown step key.
+ *
+ * ⚠️ Step ids are also persisted to the backend, which maps them to step numbers
+ * via `_FRONTEND_STEP_ALIAS` / `STEP_NAMES` in `backend/app/models/session.py`.
+ * Renaming a step id requires updating that map too.
+ */
+export function useCurrentStepId(fallbackStepId: string): string {
+  const { pathname } = useLocation();
+
+  const segment = pathname.split('/').filter(Boolean).pop() ?? '';
+
+  return STEP_REGISTRY[segment] ? segment : fallbackStepId;
+}
+
+export default useCurrentStepId;

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -1,8 +1,12 @@
 import React, { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FullReading from '../../components/reading-steps/FullReading';
+import { useCurrentStepId } from '../../hooks/useCurrentStepId';
 import { useLearningContext } from '../../layouts/LearningLayout';
 import type { FullReadingStepData } from '../../types/stepProgress';
+
+/** Canonical step id this page is registered under in STEP_REGISTRY. */
+const CANONICAL_STEP_ID = 'full-reading';
 
 const FullReadingPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
@@ -16,16 +20,21 @@ const FullReadingPage: React.FC = () => {
   } = useLearningContext();
   const navigate = useNavigate();
 
+  // #2588: read/write progress under the step id this page is actually mounted at
+  // (falls back to CANONICAL_STEP_ID), so the progress key can never drift away
+  // from the route / transition map and silently break assignment completion.
+  const stepId = useCurrentStepId(CANONICAL_STEP_ID);
+
   const handleProgressChange = useCallback(
     (stepData: FullReadingStepData, immediate = false) => {
       saveStepProgressPatch({
-        stepId: 'full-reading',
+        stepId,
         stepData,
-        currentStep: 'full-reading',
+        currentStep: stepId,
         immediate,
       });
     },
-    [saveStepProgressPatch],
+    [saveStepProgressPatch, stepId],
   );
 
   if (!selectedStory) return null;
@@ -36,7 +45,7 @@ const FullReadingPage: React.FC = () => {
       onFinish={handleFinishFullReading}
       onBack={() => navigate(`/learn/${storyId}/tutor`)}
       initialResult={session?.fullReadingResult ?? null}
-      initialProgress={stepProgressData.step_data?.['full-reading'] as FullReadingStepData | undefined}
+      initialProgress={stepProgressData.step_data?.[stepId] as FullReadingStepData | undefined}
       onProgressChange={handleProgressChange}
       dbSessionId={dbSessionId}
     />

--- a/frontend/src/pages/learning/__tests__/FullReadingPage.test.tsx
+++ b/frontend/src/pages/learning/__tests__/FullReadingPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * FullReadingPage — step-aware step id (#2588)
+ *
+ * The page used to hardcode 'full-reading' in three places (patch stepId,
+ * currentStep, and the step_data read key).  It now derives the id from the
+ * route.  These tests pin the two properties that matter:
+ *
+ *   1. Assignment safety — at the real route `/learn/:storyId/full-reading`
+ *      the persisted id is STILL exactly 'full-reading'.  A different value
+ *      would land in an unknown key: the backend maps frontend step keys to
+ *      step numbers (`_FRONTEND_STEP_ALIAS` in backend/app/models/session.py)
+ *      and drops unknown ones, so completion stops counting and the assignment
+ *      can never be submitted — silently, with no error.
+ *   2. No drift — the key written and the key read back are always the same,
+ *      and both follow the route when the step is mounted under another id.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../layouts/LearningLayout', () => ({
+  useLearningContext: vi.fn(),
+}));
+
+// Capture what the page hands down instead of mounting the real recorder UI.
+const capturedProps: Record<string, unknown> = {};
+vi.mock('../../../components/reading-steps/FullReading', () => ({
+  default: (props: Record<string, unknown>) => {
+    Object.assign(capturedProps, props);
+    return (
+      <button
+        data-testid="emit-progress"
+        onClick={() =>
+          (props.onProgressChange as (d: unknown, i?: boolean) => void)({ cpm: 120 }, true)
+        }
+      >
+        full-reading
+      </button>
+    );
+  },
+}));
+
+import { useLearningContext } from '../../../layouts/LearningLayout';
+import FullReadingPage from '../FullReadingPage';
+import type { Story } from '../../../types';
+
+/**
+ * Frontend step keys the backend can resolve to a step number — mirrors
+ * `_FRONTEND_STEP_ALIAS` + `_STEP_NAMES` in backend/app/models/session.py.
+ * Keep in sync when adding steps that persist progress.
+ */
+const BACKEND_KNOWN_STEP_KEYS = ['full-reading', 'tutor', 'reading-annotation'];
+
+const story: Story = {
+  id: '1',
+  title: '戴資穎',
+  level: 4,
+  content: ['段落一', '段落二'],
+  thumbnail: '/t.jpg',
+  category: 'Nonfiction',
+  filename: 'G4-L01.yml',
+  vocabulary: [],
+};
+
+const mockSaveStepProgressPatch = vi.fn();
+
+const makeContext = (stepData: Record<string, unknown> = {}) => ({
+  selectedStory: story,
+  handleFinishFullReading: vi.fn(),
+  session: null,
+  stepProgressData: { current_step: null, steps_completed: [], step_data: stepData },
+  saveStepProgressPatch: mockSaveStepProgressPatch,
+  dbSessionId: 123,
+});
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/learn/:storyId/:stepId" element={<FullReadingPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(capturedProps)) delete capturedProps[k];
+  (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(makeContext());
+});
+
+describe('FullReadingPage — assignment-safety (progress key must stay full-reading)', () => {
+  it("persists stepId 'full-reading' at the real route", () => {
+    renderAt('/learn/1/full-reading');
+    fireEvent.click(screen.getByTestId('emit-progress'));
+
+    expect(mockSaveStepProgressPatch).toHaveBeenCalledWith({
+      stepId: 'full-reading',
+      stepData: { cpm: 120 },
+      currentStep: 'full-reading',
+      immediate: true,
+    });
+  });
+
+  it('persists a step id the backend can resolve to a step number', () => {
+    renderAt('/learn/1/full-reading');
+    fireEvent.click(screen.getByTestId('emit-progress'));
+
+    const { stepId } = mockSaveStepProgressPatch.mock.calls[0][0];
+    expect(BACKEND_KNOWN_STEP_KEYS).toContain(stepId);
+  });
+
+  it("reads initialProgress back from step_data['full-reading']", () => {
+    (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeContext({ 'full-reading': { cpm: 99 }, tutor: { cpm: 1 } }),
+    );
+    renderAt('/learn/1/full-reading');
+
+    expect(capturedProps.initialProgress).toEqual({ cpm: 99 });
+  });
+});
+
+describe('FullReadingPage — step-aware (no hardcoded id drift)', () => {
+  it('follows the route when mounted under another registered step id', () => {
+    (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeContext({ 'full-reading': { cpm: 99 }, tutor: { cpm: 42 } }),
+    );
+    renderAt('/learn/1/tutor');
+    fireEvent.click(screen.getByTestId('emit-progress'));
+
+    // write key follows the route…
+    expect(mockSaveStepProgressPatch).toHaveBeenCalledWith(
+      expect.objectContaining({ stepId: 'tutor', currentStep: 'tutor' }),
+    );
+    // …and the read key matches it (no split between write and read).
+    expect(capturedProps.initialProgress).toEqual({ cpm: 42 });
+  });
+
+  it('falls back to the canonical id on an unregistered route segment', () => {
+    (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeContext({ 'full-reading': { cpm: 7 } }),
+    );
+    renderAt('/learn/1/not-a-registered-step');
+    fireEvent.click(screen.getByTestId('emit-progress'));
+
+    expect(mockSaveStepProgressPatch).toHaveBeenCalledWith(
+      expect.objectContaining({ stepId: 'full-reading' }),
+    );
+    expect(capturedProps.initialProgress).toEqual({ cpm: 7 });
+  });
+});


### PR DESCRIPTION
## 清技術債：FullReadingPage stepId 寫死 → step-aware（Fixes #2588）

#2559 pilot 為了不弄壞「完成狀態記錄 / 作業提交」佈線，把 step id 寫死成 `'full-reading'`（3 處）。本 PR 改成從路由推導，**今日行為 100% 不變**。

### 改法（fail-safe，不可能寫入未知 key）
- 新增 `useCurrentStepId(fallbackStepId)`：取 route pathname 末段，**只有存在於 `STEP_REGISTRY` 才採用**，否則回退呼叫端給的 canonical id。
- `FullReadingPage` 的 `stepId` / `currentStep` / `step_data[...]` 讀取三處改用它（canonical fallback 仍是 `'full-reading'`）。目前唯一路由是 `/learn/:storyId/full-reading` → 推導值就是 `'full-reading'`，DB 寫入內容與 staging 完全相同。
- `stepConfig.ts` 補註解：改這個 id 必須同步更新後端 `backend/app/models/session.py` 的 `_FRONTEND_STEP_ALIAS`（後端查無此 key 會算成 0 → 完成度掉單、作業卡住且靜默無 error）。

### 為什麼要改（原本的雷）
路由是 `buildLearningRoutes()` 從 `STEP_REGISTRY` 產的、transition map 也吃同一個 id，只有這頁寫死字串。將來把 step 改名（例如 `key-reading`）或掛第二條路由，就會**進度寫 A key、完成判定讀 B key**，靜默不報錯 → 作業永遠無法提交。改完後這種漂移在型別上不可能發生。

### 測試（先紅後綠）
- **紅→綠證明**：把 page 改動 stash 掉重跑，`follows the route when mounted under another registered step id` 直接紅（1 failed / 4 passed）；套用後 9/9 綠。
- 新增 9 個測試：
  - **作業安全網**：在真實路由送出的 `stepId` 必須恰好是 `'full-reading'`，且必須落在後端認得的 key 集合內。
  - **讀寫不分家**：寫入 key 與讀 `initialProgress` 的 key 永遠一致（換路由時一起換）。
  - hook：已註冊 id 走路由 / 未註冊 segment 回退 / 非 learn 路由回退。

### 驗證證據（Frontend Render-Safety，#2289 net）
- ESLint：✅ **0 errors**（22 warnings，全為既有）
- vitest smoke：✅ **16/16 pass**（`src/__smoke__/`）
- vitest 全跑：本分支 **33 failed / 1294 passed (1327)**；同機 clean `origin/staging` baseline **33 failed / 1285 passed (1318)** → **失敗數完全相同、+9 為本 PR 新測試，零 regression**
- `npm run build`：✅ built in 9.43s
- ⏳ **assignment 模式實機驗證**：preview 部好後補上（完成狀態記錄 + 作業提交不卡），證據補在 PR comment

@claude 請幫我 review 這個 PR
