### PR TITLE
ci: 自動同步 Brand Book 到 gh-pages（含 live site 驗證）

### DIFF
--- a/.github/workflows/sync-brand-book.yml
+++ b/.github/workflows/sync-brand-book.yml
@@ -1,0 +1,86 @@
+name: Sync Brand Book to gh-pages
+
+# Pages serves the gh-pages branch, which carries ONLY docs/index.html.
+# Without this, editing the Brand Book on main would silently never reach
+# the live site. Pages must not serve main:/docs — that would publish the
+# whole docs/ tree, including internal meeting records.
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/index.html']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write        # required to request a Pages build (see the last step)
+
+# Two merges touching docs/index.html in quick succession would each read the
+# same PARENT, and the second push would be rejected as non-fast-forward —
+# leaving the newer Brand Book unpublished until someone noticed. Serialise
+# instead of cancelling: the later run must still get its content out.
+concurrency:
+  group: sync-brand-book-gh-pages
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish docs/index.html as gh-pages root
+        id: publish
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+          BLOB=$(git hash-object -w docs/index.html)
+          NOJ=$(printf '' | git hash-object -w --stdin)
+          TREE=$(printf '100644 blob %s\t.nojekyll\n100644 blob %s\tindex.html\n' "$NOJ" "$BLOB" | git mktree)
+          PARENT=$(git ls-remote origin refs/heads/gh-pages | cut -f1)
+          if [ -z "$PARENT" ]; then echo "::error::gh-pages branch missing"; exit 1; fi
+          if [ "$(git rev-parse "$PARENT^{tree}")" = "$TREE" ]; then
+            echo "Brand Book unchanged on gh-pages, nothing to publish"
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "chore: sync Brand Book from ${GITHUB_SHA:0:7}")
+          git push origin "${COMMIT}:refs/heads/gh-pages"
+          echo "Published $COMMIT to gh-pages"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      # A push made with GITHUB_TOKEN does not trigger a Pages build, so updating
+      # the branch alone would leave the live site stale — exactly the gap this
+      # workflow exists to close. Measured the same thing by hand on 2026-08-04:
+      # after changing the Pages source, the old build kept serving for 120s+
+      # until POST /pages/builds was called. Ask for the build explicitly.
+      - name: Request a Pages build
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/pages/builds" >/dev/null
+          echo "Requested Pages build for ${GITHUB_REPOSITORY}"
+
+      # Prove the live site actually serves the new bytes. Without this the job
+      # goes green on "pushed the branch", which is the weaker claim.
+      - name: Verify the live site picked it up
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/"
+          EXPECT=$(git hash-object docs/index.html)
+          for i in $(seq 1 20); do
+            sleep 15
+            LIVE=$(curl -fsSL "$URL" 2>/dev/null | git hash-object --stdin || echo "")
+            if [ "$LIVE" = "$EXPECT" ]; then
+              echo "Live site matches docs/index.html after $((i*15))s"; exit 0
+            fi
+          done
+          echo "::error::Pages did not serve the new Brand Book within 5 minutes ($URL)"
+          exit 1


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Refs #2590

## 補的缺口

Pages 現在服務的是只含 Brand Book 的 `gh-pages` branch，所以改 `docs/index.html` **不會**到線上，得手動跑 `CLAUDE.md` 裡那段指令。這個 workflow 補上自動化。

## codex review 抓到一個會讓它完全無效的問題

| 嚴重度 | Finding | 處置 |
|---|---|---|
| **CRITICAL** | **用 `GITHUB_TOKEN` push 到 Pages source branch 不會觸發 Pages build** → branch 更新了但線上維持舊版，剛好打不到這個 workflow 要補的缺口 | 新增顯式 `POST /pages/builds`（+ `permissions: pages: write`），並加一個 step **輪詢線上 URL 直到它服務的 bytes 等於 `docs/index.html`** |
| **MAJOR** | 並發 push 會 non-fast-forward 失敗 → 較新的 Brand Book 靜默不發布 | 加 `concurrency`（`cancel-in-progress: false` —— 後面那個 run 的內容仍必須出得去） |

CRITICAL 這點跟我 2026-08-04 手動操作時觀察到的一致：改完 Pages source 後，舊 build 繼續服務超過 120 秒，直到 `POST /pages/builds` 才生效。

**最後那個驗證 step 是重點**：沒有它，job 會在「push 了 branch」就變綠 —— 那是比較弱的宣稱。現在它會 poll 到線上真的吐出新 bytes 才算成功，否則紅燈。

## review 前我自己獨立驗過的（codex 也確認無 finding）

- **tree 只含兩個 root entry**（`.nojekyll` + `index.html`）→ `docs/` 其他內部文件**沒有任何路徑**能混進 `gh-pages`。本地實跑建 tree 驗證，且 hash 與現有 `gh-pages` 完全相同
- **零遞迴風險**：本 repo 所有 `on: push` workflow 只 listen `main` / `staging`，無一含 `gh-pages`
- **無 injection**：整份只用到 `${{ github.token }}`，沒有任何 `github.event.*` / `head_ref` / `client_payload` 進 `run:`
- `printf` 產生的 tab 格式符合 `git mktree`；`${GITHUB_SHA:0:7}` 在 runner 的 bash 沒問題；`contents: write` 範圍剛好不過寬

## ⚠️ merge 後要做一件事

workflow 檔案本身不改 `docs/index.html`，所以 **merge 不會觸發它**。要驗證它真的能跑，merge 後用 `workflow_dispatch` 手動跑一次 —— 那次會走 `published=false` 的路徑（Brand Book 目前未變），至少能確認 job 起得來、權限對。真正的端到端要等下次真的改 Brand Book。