### PR TITLE
fix(ci): Brand Book workflow 在 shallow clone 下讀不到 gh-pages 的 tree

### DIFF
--- a/.github/workflows/sync-brand-book.yml
+++ b/.github/workflows/sync-brand-book.yml
@@ -38,11 +38,19 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: |
           set -euo pipefail
+          # actions/checkout is a shallow clone (fetch-depth: 1), so the gh-pages
+          # commit is NOT a local object — `git ls-remote` returns its SHA but
+          # `rev-parse <sha>^{tree}` then dies with "not a valid object" (exit 128).
+          # Measured on the first real run: local testing cannot catch this, because
+          # a developer clone has the object. Fetch just that one commit.
+          if ! git fetch --no-tags --depth=1 origin \
+                 +refs/heads/gh-pages:refs/remotes/origin/gh-pages 2>/dev/null; then
+            echo "::error::gh-pages branch missing — cannot publish Brand Book"; exit 1
+          fi
+          PARENT=$(git rev-parse refs/remotes/origin/gh-pages)
           BLOB=$(git hash-object -w docs/index.html)
           NOJ=$(printf '' | git hash-object -w --stdin)
           TREE=$(printf '100644 blob %s\t.nojekyll\n100644 blob %s\tindex.html\n' "$NOJ" "$BLOB" | git mktree)
-          PARENT=$(git ls-remote origin refs/heads/gh-pages | cut -f1)
-          if [ -z "$PARENT" ]; then echo "::error::gh-pages branch missing"; exit 1; fi
           if [ "$(git rev-parse "$PARENT^{tree}")" = "$TREE" ]; then
             echo "Brand Book unchanged on gh-pages, nothing to publish"
             echo "published=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Refs #2590

## 這是 #2598 merge 後第一次真跑就炸的 bug

```
fatal: 22cf843cfeec95fe843f34b4e4626de80b5a8016 is not a valid object
Process completed with exit code 128
```

`actions/checkout` 是 **shallow clone**（`fetch-depth: 1`）→ `git ls-remote` 拿得到 `gh-pages` 的 SHA，但那個 commit object **不在 runner 本地** → `git rev-parse <sha>^{tree}` 直接死。

## 為什麼前面都沒抓到

- **codex review 沒抓到** —— 它審了 plumbing 語法、權限、洩漏路徑、失敗模式、遞迴風險五個維度，都對，但 shallow clone 不在其中
- **我自己的 pre-merge 驗證也沒抓到** —— 我在本地模擬跑 plumbing，本地 clone 有完整 object，永遠測不出來

抓到它的是 merge 後那次 `workflow_dispatch`。這正是當初在 #2598 裡加驗證步驟的理由：**本地綠不等於 runner 綠**。

## 修法

只 fetch 需要的那一個 commit（不 deepen 整個 clone）：

```bash
git fetch --no-tags --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
PARENT=$(git rev-parse refs/remotes/origin/gh-pages)
```

順帶把「`gh-pages` 不存在」從「`PARENT` 是空字串然後後面才爆」改成 fetch 失敗時直接明確報錯。

## merge 後

再跑一次 `workflow_dispatch` 確認。預期走 `published=false` 路徑（Brand Book 目前未變），也就是**能正確判斷「無變化、不需發布」**而不是崩在讀 tree。