### PR TITLE
fix(tts): replace Azure <phoneme> SSML with <sub alias> to stop HTTP 400 (Fixes #2612)

### DIFF
--- a/backend/app/services/tts/normalization.py
+++ b/backend/app/services/tts/normalization.py
@@ -6,22 +6,50 @@ import re
 
 logger = logging.getLogger(__name__)
 
+# Azure's SSML endpoint rejects the <phoneme> element outright — HTTP 400,
+# empty body — regardless of alphabet (x-microsoft-zhuyin / sapi / ipa / ups
+# all 400). Confirmed against the real Azure REST API on 2026-08-08 (#2612).
+# We use <sub alias="..."> instead: Azure's documented pronunciation-
+# substitution element. Azure synthesizes the alias text verbatim and ignores
+# the wrapped content for audio purposes (verified via byte-identical audio
+# between `<sub alias="X">Y</sub>` and plain text "X"), so each alias below
+# must itself be plain text that a Chinese TTS reads correctly on its own —
+# no per-character phoneme control is available anymore.
+#
+# Do NOT reintroduce <phoneme> here without re-verifying against real Azure
+# first (see backend/tests/test_tts_service.py::TestAzureRealAPIPhonemeCorrections).
+#
+# Matching is first-match-in-list-order, not longest-match (see
+# _apply_phoneme_corrections below) — if a future entry's pattern is a
+# prefix of an existing one (e.g. adding "喝" before "喝采"), whichever
+# is earlier in this list wins and the other never fires. No current
+# entry is a prefix of another, so this doesn't bite today.
 PHONEME_CORRECTIONS: list[tuple[str, str]] = [
     (
+        # 喝采: 喝 should be hè (4th tone), not hē (1st tone, "to drink").
+        # 賀采 is an unambiguous homophone — 賀 has only the hè reading.
         "喝采",
-        '<phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>采',
+        '<sub alias="賀采">喝采</sub>',
     ),
     (
         "喝彩",
-        '<phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>彩',
+        '<sub alias="賀彩">喝彩</sub>',
     ),
     (
+        # 打的漂亮: colloquial spelling of 打得漂亮 (的 used for 得). Left as-is,
+        # Azure tends to parse 打的 as the 打的(take-a-taxi) idiom and read 的
+        # as dī instead of the V-得-Adj complement particle (neutral tone de).
+        # Alias to the grammatically standard spelling to route around it.
         "打的漂亮",
-        '打<phoneme alphabet="x-microsoft-zhuyin" ph="˙ㄉㄜ">的</phoneme>漂亮',
+        '<sub alias="打得漂亮">打的漂亮</sub>',
     ),
     (
+        # 打得漂亮 is already the standard V-得-Adj complement spelling — no
+        # 打的(taxi) collision is possible since there's no 的 in the text.
+        # alias == content is intentional: it's a no-op substitution that
+        # keeps this entry's behavior identical to unmarked plain text.
         "打得漂亮",
-        '打<phoneme alphabet="x-microsoft-zhuyin" ph="˙ㄉㄜ">得</phoneme>漂亮',
+        '<sub alias="打得漂亮">打得漂亮</sub>',
     ),
 ]
 
@@ -31,12 +59,31 @@ MAX_SENTENCE_LEN = 40
 
 
 def _apply_phoneme_corrections(text_escaped: str) -> str:
-    result = text_escaped
-    for pattern, replacement in PHONEME_CORRECTIONS:
-        if pattern in result:
-            result = result.replace(pattern, replacement)
-            logger.debug("Phoneme correction applied: %r → %r", pattern, replacement)
-    return result
+    # Single left-to-right pass over the ORIGINAL text — never re-scan text
+    # we just emitted. Sequential `result.replace(...)` per pattern (the old
+    # approach) mutates `result` in place, so a later pattern in the loop can
+    # match a substring that only exists because an earlier replacement
+    # introduced it (e.g. an alias that happens to contain another pattern's
+    # key), producing garbled double-substitution. Caught by TDD in #2612
+    # when "打得漂亮" (used as the 打的漂亮 alias) got re-matched and wrapped
+    # a second time.
+    out: list[str] = []
+    i = 0
+    n = len(text_escaped)
+    while i < n:
+        for pattern, replacement in PHONEME_CORRECTIONS:
+            # An empty pattern would match at every position with i += 0,
+            # hanging every TTS request forever — guard against that
+            # footgun rather than relying on the table never containing one.
+            if pattern and text_escaped.startswith(pattern, i):
+                out.append(replacement)
+                logger.debug("Phoneme correction applied: %r → %r", pattern, replacement)
+                i += len(pattern)
+                break
+        else:
+            out.append(text_escaped[i])
+            i += 1
+    return "".join(out)
 
 
 def _has_phoneme_corrections(text: str) -> bool:

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -711,11 +711,20 @@ class TestAzureGoogleFallback:
 
 
 # ---------------------------------------------------------------------------
-# 10. Phoneme corrections — Issue #765
+# 10. Phoneme corrections — Issue #765, hardened against Azure 400 in #2612
 # ---------------------------------------------------------------------------
+#
+# #2612: Azure's SSML endpoint now rejects the <phoneme> element outright
+# (HTTP 400, empty body) for every alphabet we tried (x-microsoft-zhuyin,
+# sapi, ipa, ups). Any sentence matching PHONEME_CORRECTIONS silently failed
+# end-to-end while the 11 tests below stayed green, because none of them
+# asserted that Azure would actually accept the produced SSML — they only
+# asserted the correction *rule* fired. Fixed by switching to <sub alias>,
+# Azure's documented pronunciation-substitution element. Do NOT reintroduce
+# <phoneme> here without re-verifying against real Azure first.
 
 class TestPhonemeCorrections:
-    """Phoneme corrections must inject SSML <phoneme> tags for known mispronunciations."""
+    """Phoneme corrections must inject SSML <sub alias> tags for known mispronunciations."""
 
     def test_he_cai_detected(self):
         """'喝采' in text should trigger a phoneme correction."""
@@ -738,26 +747,27 @@ class TestPhonemeCorrections:
         assert _has_phoneme_corrections("她是一個好學生") is False
 
     def test_apply_he_cai_correction(self):
-        """'喝采' must be wrapped with phoneme tag for hè (ㄏㄜˋ)."""
+        """'喝采' must be wrapped with <sub alias="賀采"> to force hè (4th tone)."""
         from app.services.tts_service import _apply_phoneme_corrections
         result = _apply_phoneme_corrections("贏得喝采")
-        assert '<phoneme' in result
-        assert 'ㄏㄜˋ' in result
-        assert '喝</phoneme>采' in result
+        assert '<phoneme' not in result
+        assert '<sub alias="賀采">喝采</sub>' in result
 
     def test_apply_he_cai2_correction(self):
-        """'喝彩' must also get the phoneme correction."""
+        """'喝彩' must also get the <sub alias> correction."""
         from app.services.tts_service import _apply_phoneme_corrections
         result = _apply_phoneme_corrections("觀眾喝彩")
-        assert '<phoneme' in result
-        assert 'ㄏㄜˋ' in result
+        assert '<phoneme' not in result
+        assert '<sub alias="賀彩">喝彩</sub>' in result
 
     def test_apply_da_de_piaoliang_correction(self):
-        """'打的漂亮' — '的' must be corrected to neutral tone de (˙ㄉㄜ)."""
+        """'打的漂亮' — must be re-aliased to '打得漂亮' so Azure doesn't read
+        '打的' as the 打的(taxi) idiom (的 -> dī) instead of the V-得-Adj
+        complement particle (neutral tone de)."""
         from app.services.tts_service import _apply_phoneme_corrections
         result = _apply_phoneme_corrections("打的漂亮")
-        assert '<phoneme' in result
-        assert '˙ㄉㄜ' in result
+        assert '<phoneme' not in result
+        assert '<sub alias="打得漂亮">打的漂亮</sub>' in result
 
     def test_no_correction_applied_for_plain_text(self):
         """Text without patterns should pass through unchanged."""
@@ -766,9 +776,10 @@ class TestPhonemeCorrections:
         result = _apply_phoneme_corrections(text)
         assert result == text
         assert '<phoneme' not in result
+        assert '<sub' not in result
 
-    def test_azure_ssml_contains_phoneme_for_he_cai(self):
-        """Full Azure SSML output must contain phoneme tag when text has 喝采."""
+    def test_azure_ssml_contains_sub_alias_for_he_cai(self):
+        """Full Azure SSML output must contain <sub alias> (never <phoneme>) for 喝采."""
         import app.services.tts_service as tts_mod
 
         captured_request = {}
@@ -786,11 +797,11 @@ class TestPhonemeCorrections:
             tts_mod._synthesize_azure("贏得全國人民的尊敬及喝采")
 
         ssml = captured_request["data"]
-        assert '<phoneme' in ssml
-        assert 'ㄏㄜˋ' in ssml
+        assert '<phoneme' not in ssml
+        assert '<sub alias="賀采">喝采</sub>' in ssml
 
     def test_azure_ssml_no_phoneme_for_plain_text(self):
-        """SSML for plain text must NOT contain phoneme tags."""
+        """SSML for plain text must NOT contain phoneme or sub tags."""
         import app.services.tts_service as tts_mod
 
         captured_request = {}
@@ -809,6 +820,127 @@ class TestPhonemeCorrections:
 
         ssml = captured_request["data"]
         assert '<phoneme' not in ssml
+        assert '<sub' not in ssml
+
+    def test_no_correction_output_ever_contains_phoneme_element(self):
+        """Regression lock (#2612): Azure's SSML endpoint rejects <phoneme>
+        outright (HTTP 400 on every alphabet tried). No entry in
+        PHONEME_CORRECTIONS may ever produce that element again — this is
+        deterministic and needs no network access, so it runs in CI."""
+        from app.services.tts_service import PHONEME_CORRECTIONS
+        for pattern, replacement in PHONEME_CORRECTIONS:
+            assert '<phoneme' not in replacement, (
+                f"pattern {pattern!r} still emits <phoneme>, "
+                "which Azure returns HTTP 400 for (#2612)"
+            )
+
+    def test_all_corrections_use_sub_alias_element(self):
+        """Every PHONEME_CORRECTIONS entry must use the <sub alias> mechanism."""
+        from app.services.tts_service import PHONEME_CORRECTIONS
+        for pattern, replacement in PHONEME_CORRECTIONS:
+            assert '<sub alias="' in replacement, (
+                f"pattern {pattern!r} does not use <sub alias>"
+            )
+
+    def test_correction_output_not_double_substituted(self):
+        """Regression lock: applying corrections must be a single left-to-right
+        pass over the ORIGINAL text. A naive sequential str.replace() per
+        pattern mutates the accumulator in place, so a later pattern in the
+        loop can match a substring that only exists because an earlier
+        replacement introduced it — e.g. '打得漂亮' being used as the alias
+        for '打的漂亮' caused the '打得漂亮' rule to re-match and double-wrap
+        its own output (caught by TDD while fixing #2612). Every output must
+        contain each <sub>/<phoneme> opening tag exactly once, never nested."""
+        from app.services.tts_service import _apply_phoneme_corrections
+
+        result = _apply_phoneme_corrections("她，打的漂亮，也打得漂亮，還喝采喝彩")
+        assert result.count('<sub alias="') == 4
+        assert '<sub alias="<sub' not in result  # no nested/double-wrapped tag
+        assert result.count("</sub>") == 4
+
+    def test_correction_output_is_well_formed_xml_fragment(self):
+        """Every corrected sentence must parse as a valid XML fragment once
+        wrapped in a root element — catches malformed/unbalanced tags before
+        they ever reach Azure (which would 400 on them just like <phoneme>)."""
+        # stdlib ElementTree (not defusedxml): input here is 100% hardcoded
+        # test literals from PHONEME_CORRECTIONS + fixed prefixes, never
+        # untrusted/external data, so XXE is not in this test's threat model.
+        import xml.etree.ElementTree as ET
+        from app.services.tts_service import PHONEME_CORRECTIONS, _apply_phoneme_corrections
+
+        for pattern, _ in PHONEME_CORRECTIONS:
+            corrected = _apply_phoneme_corrections(f"前文{pattern}後文")
+            ET.fromstring(f"<root>{corrected}</root>")  # raises ParseError if malformed
+
+    def test_no_empty_pattern_in_corrections_table(self):
+        """An empty-string pattern would match at every index with i += 0 in
+        _apply_phoneme_corrections' scan loop, hanging every TTS request that
+        reaches it forever. Lock the table invariant directly (flagged during
+        #2612 review) rather than relying on nobody ever adding one."""
+        from app.services.tts_service import PHONEME_CORRECTIONS
+        assert all(pattern for pattern, _ in PHONEME_CORRECTIONS)
+
+    def test_apply_phoneme_corrections_terminates_on_pathological_input(self):
+        """Belt-and-suspenders: even if the table invariant above were ever
+        violated, calling _apply_phoneme_corrections must still terminate
+        (not hang) — this test itself times out via pytest-timeout-free
+        iteration bound rather than trusting the implementation blindly."""
+        from app.services.tts import normalization as norm_mod
+
+        original = norm_mod.PHONEME_CORRECTIONS
+        try:
+            norm_mod.PHONEME_CORRECTIONS = [("", "SHOULD_NOT_MATCH")]
+            # Must not hang: the `if pattern and ...` guard skips empty
+            # patterns entirely, so this call must complete immediately and
+            # return the input unchanged.
+            result = norm_mod._apply_phoneme_corrections("正常文字")
+            assert result == "正常文字"
+        finally:
+            norm_mod.PHONEME_CORRECTIONS = original
+
+
+# ---------------------------------------------------------------------------
+# 10b. Azure real-API compat lock — Issue #2612 (opt-in, needs real credentials)
+# ---------------------------------------------------------------------------
+#
+# The tests above are all mocked — they proved the *rule* fires, which is
+# exactly what stayed green for 4 months while Azure 400'd on every one of
+# these sentences in production. This class hits the real Azure endpoint
+# (same production code path, app.services.tts_service._synthesize_azure)
+# and is the only test that would actually have caught #2612.
+#
+# Opt-in only: skipped unless RUN_REAL_AZURE_TESTS=1 AND AZURE_SPEECH_KEY is
+# set. Never runs in CI (no credentials there, and CI shouldn't call external
+# paid services anyway).
+
+import os as _os  # noqa: E402
+
+_REAL_AZURE_ENABLED = bool(_os.environ.get("RUN_REAL_AZURE_TESTS")) and bool(
+    _os.environ.get("AZURE_SPEECH_KEY")
+)
+
+
+@pytest.mark.skipif(
+    not _REAL_AZURE_ENABLED,
+    reason="opt-in only — set RUN_REAL_AZURE_TESTS=1 with a real AZURE_SPEECH_KEY to run",
+)
+class TestAzureRealAPIPhonemeCorrections:
+    """Hits real Azure TTS with every PHONEME_CORRECTIONS pattern. This is the
+    regression lock for #2612 — mocked tests cannot catch 'Azure rejects this
+    SSML element', only a real call can."""
+
+    @pytest.mark.parametrize("sentence", [
+        "贏得全國人民的尊敬及喝采",
+        "觀眾喝彩叫好",
+        "她，打的漂亮，雖然輸了比賽",
+        "她打得漂亮",
+    ])
+    def test_real_azure_accepts_corrected_sentence(self, sentence):
+        import app.services.tts_service as tts_mod
+
+        audio = tts_mod._synthesize_azure(sentence)
+        assert isinstance(audio, bytes)
+        assert len(audio) > 1000  # real MP3, not an empty/error body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2612

## Summary

- Azure TTS 的 `<phoneme>` SSML 標記被 Azure 端拒收（HTTP 400，body 空），所有命中 `PHONEME_CORRECTIONS`（喝采/喝彩/打的漂亮/打得漂亮）的句子在 Azure 路徑上一律失敗。四個月沒人打過 Azure（`TTS_PROVIDER=gemini31`），所以沒被發現
- 改用 `<sub alias="...">`（Azure 官方發音替換元素）取代 `<phoneme>`
- TDD 過程中抓到 `_apply_phoneme_corrections()` 本身的真 bug：舊的逐條 `str.replace()` 會讓後面的 pattern 意外命中前一條替換結果裡的文字（因為我選的 alias 剛好等於另一條 pattern 的 key），造成巢狀重複包裝。改成單次從左到右掃描原文，不再重掃自己剛產生的輸出
- Code review 抓到一個相關的地雷（空字串 pattern 會造成無限迴圈），已加防呆並用 mutation test 驗證（拿掉防呆後 `timeout 5` 真的 exit 124）

## Scope

只修 Azure provider（`backend/app/services/tts/normalization.py`）。不切換 `TTS_PROVIDER`、不動 Gemini provider、不動 GCS cache prefix。

## 復現（真 Azure，非 mock）

```
baseline（無 phoneme 注入）                          → 200 OK
"贏得全國人民的尊敬及喝采"（現行 code 產生 <phoneme>） → 400 Bad Request
"她，打的漂亮，雖然輸了比賽"（現行 code 產生 <phoneme>）→ 400 Bad Request
```

## 發音驗證

用 MD5 audio hash 證明替換機制確實生效：
- `<sub alias="賀采">喝采</sub>` 產出的音檔跟純文字「賀采」逐位元相同（`61e2bc48...`）
- 跟未修正的「喝采」不同（`9b7a1c4a...`）
- 同樣模式驗證「打的漂亮」→「打得漂亮」

## Test plan

- [x] TDD 紅：新/改測試在修復前失敗（6 條）
- [x] TDD 綠：修復後全部通過（14 條 phoneme 測試 + 4 條 opt-in 真 Azure 測試）
- [x] Mutation test：還原成 `<phoneme>` 後，deterministic 測試 + 真 Azure 測試都紅（真 Azure 測試回同一個 `TTSError: Azure TTS HTTP error 400`），還原修復後全綠
- [x] 全檔案回歸：`pytest tests/test_tts_service.py` — 10 個既有失敗跟 clean staging baseline 一致（跟本次改動無關，pre-existing）
- [x] Code review（`code-reviewer` agent）：PASS，2 個非阻斷建議已採納並 mutation-tested

### 手動驗證（真 Azure，opt-in，不進 CI）

```
cd backend && source .venv/bin/activate
set -a; source .env; set +a
RUN_REAL_AZURE_TESTS=1 python3 -m pytest tests/test_tts_service.py -k TestAzureRealAPIPhonemeCorrections -v
```
