### PR TITLE
fix(tts): validate Azure TTS uploads + audit tool for existing bad objects (Fixes #2614)

### DIFF
--- a/backend/app/services/tts/audio_validation.py
+++ b/backend/app/services/tts/audio_validation.py
@@ -1,0 +1,79 @@
+"""Shared "is this actually an mp3" validator for TTS cache writes (#2614).
+
+Why this exists: Azure's TTS REST endpoint (and in principle any REST TTS
+provider) can answer HTTP 200 with an empty or truncated body. Uploading
+that response as-is to the GCS TTS cache produces a silent/corrupt mp3 that
+then *permanently* wins the runtime cache — production sees a cache hit and
+never regenerates, so a student who reaches that sentence gets silence
+forever, with no error anywhere in the stack. An actual batch run produced
+2 confirmed 0-byte objects with err=0 before this guard existed, so this is
+not theoretical.
+
+Two entry points share the same notion of "valid":
+  - validate_mp3_bytes()    — full in-memory payload, called right after
+                              synthesis and before the object ever reaches
+                              the bucket (backend/scripts/batch_azure_tts.py).
+  - validate_mp3_metadata() — re-checks an object already in GCS using only
+                              its size (free, from blob metadata) and a short
+                              byte-range peek, so auditing thousands of
+                              existing objects never requires a full download
+                              (backend/scripts/audit_tts_objects.py).
+
+Keep both in this one module — if the batch generator and the audit tool
+disagreed about what counts as valid, an object that passes on write could
+still be silently miscategorized on audit (or vice versa).
+"""
+from __future__ import annotations
+
+# ~0.05s of audio at 192kbps; real Chinese sentences from this manifest are
+# 15KB+, so anything under this is either an error body or a truncated
+# response, never a legitimate short clip.
+MIN_MP3_BYTES = 2000
+
+# 48kHz/192kbps mono mp3 from Azure (and Gemini's re-encode via ffmpeg) starts
+# with either an ID3v2 tag or a raw MPEG frame sync. Anything else — RIFF/WAV,
+# an HTML error page, a truncated/garbled response — is not the audio we
+# asked for.
+_MP3_FRAME_SYNC_PREFIXES = (b"\xff\xfb", b"\xff\xf3", b"\xff\xf2")
+
+# Enough bytes to see either the ID3 tag or the 2-byte frame sync. Kept small
+# on purpose: the audit tool does a ranged GET for this many bytes per
+# object instead of downloading the full file.
+MP3_PEEK_BYTES = 16
+
+
+def _bad_magic(head: bytes) -> bool:
+    return not (head.startswith(b"ID3") or head[:2] in _MP3_FRAME_SYNC_PREFIXES)
+
+
+def validate_mp3_bytes(audio: bytes | None, min_bytes: int = MIN_MP3_BYTES) -> str | None:
+    """Validate a full in-memory mp3 payload. Returns a reason string if
+    invalid, or None if it looks like real audio."""
+    if not audio:
+        return "empty response body (0 bytes)"
+    if len(audio) < min_bytes:
+        return f"suspiciously small ({len(audio)} bytes < {min_bytes})"
+    if _bad_magic(audio):
+        return f"not an mp3 (leading bytes {audio[:4]!r})"
+    return None
+
+
+def validate_mp3_metadata(
+    size: int | None, head: bytes, min_bytes: int = MIN_MP3_BYTES
+) -> str | None:
+    """Validate an already-uploaded GCS object using only its size (blob
+    metadata, free) and a short byte-range peek (`head`, up to
+    MP3_PEEK_BYTES). Returns a reason string if invalid, or None if OK.
+
+    Deliberately does not require `head` when size alone already disqualifies
+    the object (0 bytes / too small) — callers should skip the ranged GET in
+    that case, it would just cost an extra network round trip for a foregone
+    conclusion.
+    """
+    if not size:
+        return "empty object (0 bytes)"
+    if size < min_bytes:
+        return f"suspiciously small ({size} bytes < {min_bytes})"
+    if _bad_magic(head):
+        return f"not an mp3 (leading bytes {head[:4]!r})"
+    return None

--- a/backend/scripts/audit_tts_objects.py
+++ b/backend/scripts/audit_tts_objects.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Audit already-uploaded TTS cache objects in GCS for empty/corrupt audio (#2614).
+
+Azure's TTS REST endpoint can answer HTTP 200 with an empty or truncated
+body. Before batch_azure_tts.py validated its own output, at least 2
+confirmed 0-byte objects were uploaded and now permanently win the runtime
+cache — a student who hits that sentence gets silence forever, with no
+error anywhere. Fixing the generator (see audio_validation.py) stops new
+bad objects from landing, but it does nothing about ones already sitting in
+the bucket. This script re-checks those.
+
+Reads size + a short byte-range peek per object — never downloads a full
+mp3 — so scanning thousands of objects is cheap. `--dry-run` behaviour
+(list-only) is the default; nothing is ever deleted unless you pass
+`--delete`, and even then only the objects this scan itself flagged (never
+a blanket prefix delete).
+
+Usage:
+  set -a; source backend/.env; set +a
+
+  # list-only, safe to run anytime
+  python backend/scripts/audit_tts_objects.py --prefix azure/sentences
+
+  # actually remove the confirmed-bad objects (forces regeneration on the
+  # next batch_azure_tts.py run, since a missing cache_key gets regenerated)
+  python backend/scripts/audit_tts_objects.py --prefix azure/sentences --delete
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from google.cloud import storage
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.services.tts.audio_validation import (  # noqa: E402
+    MP3_PEEK_BYTES,
+    MIN_MP3_BYTES,
+    validate_mp3_metadata,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("audit-tts")
+
+GCS_BUCKET = "lingoleap-tts-cache"
+
+
+def scan(bucket, prefix: str, min_bytes: int = MIN_MP3_BYTES) -> list[tuple[str, str, int | None]]:
+    """Return (blob_name, reason, size) for every .mp3 object under `prefix`
+    that fails validation. Read-only — never mutates the bucket.
+
+    Skips the ranged GET entirely when size alone already disqualifies an
+    object (0 bytes / too small): fetching bytes from an empty or truncated
+    object would just cost a network round trip for a foregone conclusion.
+    """
+    bad: list[tuple[str, str, int | None]] = []
+    for blob in bucket.list_blobs(prefix=prefix):
+        if not blob.name.endswith(".mp3"):
+            continue
+        size = blob.size
+        head = b""
+        if size and size >= min_bytes:
+            try:
+                head = blob.download_as_bytes(start=0, end=MP3_PEEK_BYTES - 1)
+            except Exception as exc:  # noqa: BLE001 — an unreadable object is bad, but must not abort the scan
+                bad.append((blob.name, f"unreadable: {exc}", size))
+                continue
+        reason = validate_mp3_metadata(size, head, min_bytes=min_bytes)
+        if reason:
+            bad.append((blob.name, reason, size))
+    return bad
+
+
+def apply_delete(bucket, bad: list[tuple[str, str, int | None]]) -> int:
+    """Delete every object `scan()` already flagged. Never does its own
+    scanning or prefix matching — the caller decides what "bad" means, this
+    function only removes exactly those names.
+
+    Tolerates an object that is already gone (e.g. a second audit run, or a
+    concurrent partial delete) — that is not a new deletion and not an error.
+    """
+    from google.api_core.exceptions import NotFound
+
+    deleted = 0
+    for name, _reason, _size in bad:
+        try:
+            bucket.blob(name).delete()
+            deleted += 1
+        except NotFound:
+            logger.info("  %s already deleted (skipping)", name)
+    return deleted
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bucket", default=GCS_BUCKET)
+    ap.add_argument("--prefix", required=True,
+                    help="e.g. azure/sentences or gemini31-prompt-only-v2/sentences")
+    ap.add_argument("--min-bytes", type=int, default=MIN_MP3_BYTES)
+    ap.add_argument("--delete", action="store_true",
+                    help="actually delete the confirmed-bad objects (default: report only)")
+    args = ap.parse_args()
+
+    gcs = storage.Client()
+    bucket = gcs.bucket(args.bucket)
+
+    logger.info("Scanning gs://%s/%s/ ...", args.bucket, args.prefix)
+    bad = scan(bucket, args.prefix, min_bytes=args.min_bytes)
+
+    if not bad:
+        logger.info("Clean — no invalid objects found under %s/", args.prefix)
+        return
+
+    logger.warning("Found %d invalid object(s) under %s/:", len(bad), args.prefix)
+    for name, reason, size in bad:
+        logger.warning("  %s  size=%s  %s", name, size, reason)
+
+    sizes = [s for _, _, s in bad if s is not None]
+    if sizes:
+        logger.info("Size distribution of bad objects: min=%d max=%d", min(sizes), max(sizes))
+
+    if not args.delete:
+        logger.info("Dry-run (default) — pass --delete to remove these %d object(s).", len(bad))
+        return
+
+    deleted = apply_delete(bucket, bad)
+    logger.info("Deleted %d object(s). They will regenerate on the next batch run.", deleted)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/batch_azure_tts.py
+++ b/backend/scripts/batch_azure_tts.py
@@ -30,6 +30,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import time
 import urllib.error
@@ -125,8 +126,32 @@ def _upload_if_absent(bucket, blob_path: str, audio: bytes) -> bool:
         return False
 
 
+# Matches any CJK ideograph, ASCII letter, or digit. Used to catch sentences
+# that are entirely punctuation (see _has_speakable_content docstring below).
+_SPEAKABLE_RE = re.compile(r"[一-鿿㐀-䶿A-Za-z0-9]")
+
+
+def _has_speakable_content(text: str) -> bool:
+    """False if `text` has nothing to actually speak (only punctuation/whitespace).
+
+    Root cause of the 3 confirmed 0-byte objects found in #2614's live audit:
+    upstream sentence segmentation occasionally leaves a fragment that is
+    ENTIRELY punctuation ('。', '」', '」。'). _clean_for_tts only strips a
+    specific punctuation subset (~, ──, …), so these survive unchanged, pass
+    the (non-empty!) `if not cleaned` check, and get sent to Azure — which
+    answers HTTP 200 with an empty body because there is nothing to speak.
+
+    This is a different failure path than validate_mp3_bytes (which catches
+    Azure misbehaving on a *normal*, speakable input) — both guards stay:
+    this one keeps unspeakable text from ever being queued for synthesis;
+    that one catches Azure failing on text that should have worked.
+    """
+    return bool(_SPEAKABLE_RE.search(text))
+
+
 def load_sentences() -> list[dict]:
     items: list[dict] = []
+    skipped: list[tuple[str, int, int, str]] = []
     with JSONL.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
@@ -135,7 +160,8 @@ def load_sentences() -> list[dict]:
             rec = json.loads(line)
             raw = rec["text"]
             cleaned = _clean_for_tts(raw)
-            if not cleaned:
+            if not cleaned or not _has_speakable_content(cleaned):
+                skipped.append((rec["lesson_id"], rec["paragraph_idx"], rec["sentence_idx"], raw))
                 continue
             items.append({
                 "raw_text": raw,
@@ -145,6 +171,10 @@ def load_sentences() -> list[dict]:
                 "paragraph_idx": rec["paragraph_idx"],
                 "sentence_idx": rec["sentence_idx"],
             })
+    if skipped:
+        logger.info("Skipped %d punctuation-only/unspeakable sentence(s):", len(skipped))
+        for lesson_id, p, s, raw in skipped:
+            logger.info("  lesson=%s ¶%s s%s  %r", lesson_id, p, s, raw)
     return items
 
 

--- a/backend/scripts/batch_azure_tts.py
+++ b/backend/scripts/batch_azure_tts.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Pre-generate Azure zh-TW TTS audio for every sentence in the manifest.
+
+Mirrors batch_gemini_tts_v2.py but for the Azure path:
+  - voice zh-TW-HsiaoChenNeural (native Taiwan accent, no prompt steering needed)
+  - pronunciation fixes via <sub alias> (Azure rejects <phoneme> outright, see #2612)
+  - writes to gs://lingoleap-tts-cache/azure/sentences/{sha256}.mp3
+    (a different prefix from gemini31-prompt-only-v2/, so the two voice sets
+     never mix and either can be rolled back independently)
+
+Cache key is sha256 of the RAW sentence text, matching
+backend/app/services/tts/normalization.py:_cache_key — the same key the runtime
+computes, so a hit here is a hit in production.
+
+Audio validation (rejecting Azure's HTTP-200-but-empty-body failure mode
+before it ever reaches the bucket — see #2614) lives in the shared
+app/services/tts/audio_validation.py module, not inline here, so it can be
+unit-tested and so backend/scripts/audit_tts_objects.py can re-check
+objects already uploaded using the exact same rules.
+
+Usage:
+  set -a; source backend/.env; set +a
+  python backend/scripts/batch_azure_tts.py --dry-run
+  python backend/scripts/batch_azure_tts.py --workers 6
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+from google.api_core.exceptions import PreconditionFailed
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.services.tts.audio_validation import validate_mp3_bytes  # noqa: E402
+from app.services.tts.normalization import (  # noqa: E402
+    _apply_phoneme_corrections,
+    _cache_key,
+    _clean_for_tts,
+)
+
+JSONL = ROOT / "backend" / "data" / "sentences.v2.jsonl"
+PROVENANCE = ROOT / "backend" / "data" / "tts-provenance.jsonl"
+GCS_BUCKET = "lingoleap-tts-cache"
+GCS_PREFIX = "azure/sentences"
+VOICE = os.environ.get("AZURE_TTS_VOICE", "zh-TW-HsiaoChenNeural")
+RATE = "1.08"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("batch-azure")
+
+
+def _escape(text: str) -> str:
+    return (text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace('"', "&quot;").replace("'", "&apos;"))
+
+
+def _ssml(text: str) -> str:
+    body = _apply_phoneme_corrections(_escape(text))
+    return ('<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="zh-TW">'
+            f'<voice name="{VOICE}"><prosody rate="{RATE}">{body}</prosody>'
+            "</voice></speak>")
+
+
+def _synthesize(text: str, key: str, region: str, tries: int = 4) -> bytes:
+    """POST to Azure with backoff. Raises on final failure."""
+    url = f"https://{region}.tts.speech.microsoft.com/cognitiveservices/v1"
+    payload = _ssml(text).encode("utf-8")
+    last: Exception | None = None
+    for attempt in range(tries):
+        try:
+            req = urllib.request.Request(url, data=payload, headers={
+                "Ocp-Apim-Subscription-Key": key,
+                "Content-Type": "application/ssml+xml",
+                "X-Microsoft-OutputFormat": "audio-48khz-192kbitrate-mono-mp3",
+            })
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            # 400 is a content problem — retrying will not help, fail fast so it
+            # shows up in the failure list instead of burning 4 attempts.
+            if exc.code == 400:
+                raise
+            last = exc
+        except Exception as exc:  # noqa: BLE001 — network layer, retry
+            last = exc
+        time.sleep(1.5 * (attempt + 1))
+    raise last  # type: ignore[misc]
+
+
+def _upload_if_absent(bucket, blob_path: str, audio: bytes) -> bool:
+    """Upload `audio` to `blob_path` only if no object exists there yet.
+
+    Guards against a rare race (#2614 review, P2): this script dedupes
+    cache_keys within a single run, so two threads in the same run never
+    target the same blob_path. But two *overlapping runs* (e.g. someone
+    re-invoking the script while an earlier one is still generating) could
+    both pass the "not yet cached" pre-check and then race to write the same
+    key. Both writes would be a valid mp3 of the same sentence, so this was
+    never a corruption risk — but skipping the loser avoids an extra
+    redundant upload. `if_generation_match=0` means "create only if this
+    object doesn't exist yet"; GCS answers a losing writer with 412
+    Precondition Failed instead of silently overwriting.
+
+    Returns True if this call performed the upload, False if the object
+    already existed (someone else won the race — not an error).
+    """
+    try:
+        bucket.blob(blob_path).upload_from_string(
+            audio, content_type="audio/mpeg", if_generation_match=0)
+        return True
+    except PreconditionFailed:
+        return False
+
+
+def load_sentences() -> list[dict]:
+    items: list[dict] = []
+    with JSONL.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            raw = rec["text"]
+            cleaned = _clean_for_tts(raw)
+            if not cleaned:
+                continue
+            items.append({
+                "raw_text": raw,
+                "tts_input": cleaned,
+                "cache_key": _cache_key(raw),
+                "lesson_id": rec["lesson_id"],
+                "paragraph_idx": rec["paragraph_idx"],
+                "sentence_idx": rec["sentence_idx"],
+            })
+    return items
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workers", type=int, default=6,
+                    help="concurrent requests (Azure rate-limits; 6 is conservative)")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    az_key = os.environ.get("AZURE_SPEECH_KEY")
+    az_region = os.environ.get("AZURE_SPEECH_REGION")
+    if not az_key or not az_region:
+        logger.error("AZURE_SPEECH_KEY / AZURE_SPEECH_REGION not set — "
+                     "run: set -a; source backend/.env; set +a")
+        sys.exit(1)
+
+    items = load_sentences()
+    logger.info("Loaded %d sentences from %s", len(items), JSONL.name)
+
+    seen: dict[str, dict] = {}
+    for it in items:
+        seen.setdefault(it["cache_key"], it)
+    unique = list(seen.values())
+    if args.limit:
+        unique = unique[: args.limit]
+    logger.info("Unique texts: %d  |  voice: %s", len(unique), VOICE)
+
+    from google.cloud import storage
+    gcs = storage.Client()
+    bucket = gcs.bucket(GCS_BUCKET)
+
+    # One list_blobs beats N exists() calls by orders of magnitude — the Gemini
+    # script's per-key exists() loop takes 10+ minutes for this manifest.
+    logger.info("Listing existing objects under %s/ ...", GCS_PREFIX)
+    have = {
+        b.name[len(GCS_PREFIX) + 1: -4]
+        for b in gcs.list_blobs(GCS_BUCKET, prefix=f"{GCS_PREFIX}/")
+        if b.name.endswith(".mp3")
+    }
+    to_gen = [it for it in unique if it["cache_key"] not in have]
+    logger.info("Cached: %d  |  To generate: %d", len(unique) - len(to_gen), len(to_gen))
+
+    if args.dry_run:
+        return
+    if not to_gen:
+        logger.info("All cached — nothing to do.")
+        return
+
+    run_id = f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-azure"
+    start = time.time()
+    ok = err = 0
+    failures: list[tuple[str, str]] = []
+
+    def work(it: dict) -> tuple[dict, bytes | None, str | None]:
+        try:
+            audio = _synthesize(it["tts_input"], az_key, az_region)
+            # Azure can answer HTTP 200 with an empty or truncated body.
+            # Uploading that produces a silent mp3 that then *permanently*
+            # wins the cache — the runtime sees a hit and never regenerates,
+            # so the student just gets silence forever. An observed run
+            # produced 2 zero-byte objects with err=0, so this is not
+            # theoretical. Validate before the object ever reaches the
+            # bucket (shared with audit_tts_objects.py, see #2614).
+            bad = validate_mp3_bytes(audio)
+            if bad:
+                return it, None, f"InvalidAudio: {bad}"
+            _upload_if_absent(bucket, f"{GCS_PREFIX}/{it['cache_key']}.mp3", audio)
+            return it, audio, None
+        except Exception as exc:  # noqa: BLE001
+            return it, None, f"{type(exc).__name__}: {exc}"
+
+    with PROVENANCE.open("a", encoding="utf-8") as prov, \
+            ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futs = {pool.submit(work, it): it for it in to_gen}
+        for i, fut in enumerate(as_completed(futs), 1):
+            it, audio, error = fut.result()
+            if error:
+                err += 1
+                failures.append((it["cache_key"], error))
+            else:
+                ok += 1
+                prov.write(json.dumps({
+                    "generated_at": datetime.now(timezone.utc).isoformat(),
+                    "raw_text": it["raw_text"],
+                    "tts_input": it["tts_input"],
+                    "cache_key": it["cache_key"],
+                    "gcs_uri": f"gs://{GCS_BUCKET}/{GCS_PREFIX}/{it['cache_key']}.mp3",
+                    "audio_bytes": len(audio or b""),
+                    "provider": "azure",
+                    "voice": VOICE,
+                    "language_code": "zh-TW",
+                    "lesson_id": it["lesson_id"],
+                    "paragraph_idx": it["paragraph_idx"],
+                    "sentence_idx": it["sentence_idx"],
+                    "batch_run_id": run_id,
+                }, ensure_ascii=False) + "\n")
+                prov.flush()
+            if i % 50 == 0 or i == len(to_gen):
+                rate = i / max(time.time() - start, 1)
+                eta = (len(to_gen) - i) / max(rate, 0.01) / 60
+                logger.info("[%d/%d] ok=%d err=%d %.1f/s ETA %.0fm",
+                            i, len(to_gen), ok, err, rate, eta)
+
+    logger.info("Done in %.1fm — ok=%d err=%d", (time.time() - start) / 60, ok, err)
+    if failures:
+        logger.warning("First 10 failures:")
+        for k, e in failures[:10]:
+            logger.warning("  %s  %s", k[:12], e[:100])
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_audit_tts_objects.py
+++ b/backend/tests/test_audit_tts_objects.py
@@ -1,0 +1,247 @@
+"""TDD lock for backend/scripts/audit_tts_objects.py (#2614).
+
+This audits objects ALREADY uploaded to the GCS TTS cache for the same
+empty-body/corrupt-audio failure that validate_mp3_bytes() now blocks at
+write time (see test_tts_audio_validation.py) — a real batch run produced
+2 confirmed 0-byte objects before that guard existed, and they are still
+sitting in the bucket winning the runtime cache until something removes
+them.
+
+Loaded via importlib.util (same pattern as test_ai_base_split_1953.py)
+because it's a standalone script, not a package module.
+
+All tests run against fake Blob/Bucket doubles — never touches real GCS.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "audit_tts_objects.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_tts_objects_under_test", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def audit_mod():
+    # fresh module per test — main() mutates module-level `storage` in some tests
+    return _load_module()
+
+
+class FakeBlob:
+    """Stand-in for google.cloud.storage.Blob. `size` mirrors GCS metadata
+    (free to read); download_as_bytes() mirrors a ranged GET."""
+
+    def __init__(self, name, content: bytes = b"", size: int | None = None, unreadable: bool = False):
+        self.name = name
+        self._content = content
+        self.size = size if size is not None else len(content)
+        self._unreadable = unreadable
+        self.deleted = False
+
+    def download_as_bytes(self, start: int = 0, end: int | None = None) -> bytes:
+        if self._unreadable:
+            raise RuntimeError("simulated network error")
+        end = (self.size - 1) if end is None else end
+        return self._content[start : end + 1]
+
+    def delete(self) -> None:
+        self.deleted = True
+
+
+class FakeBucket:
+    """Stand-in for google.cloud.storage.Bucket."""
+
+    def __init__(self, blobs):
+        self._blobs = {b.name: b for b in blobs}
+
+    def list_blobs(self, prefix: str = ""):
+        return [b for name, b in self._blobs.items() if name.startswith(prefix)]
+
+    def blob(self, name: str):
+        return self._blobs[name]
+
+
+def _good_mp3(n: int = 5000) -> bytes:
+    return b"ID3" + b"\x00" * n
+
+
+# ---------------------------------------------------------------------------
+# scan() — the read-only detection logic
+# ---------------------------------------------------------------------------
+
+
+class TestScan:
+    def test_all_valid_returns_empty(self, audit_mod):
+        bucket = FakeBucket(
+            [
+                FakeBlob("azure/sentences/aaa.mp3", content=_good_mp3()),
+                FakeBlob("azure/sentences/bbb.mp3", content=_good_mp3()),
+            ]
+        )
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert bad == []
+
+    def test_zero_byte_object_is_flagged(self, audit_mod):
+        bucket = FakeBucket(
+            [
+                FakeBlob("azure/sentences/zero.mp3", content=b"", size=0),
+                FakeBlob("azure/sentences/good.mp3", content=_good_mp3()),
+            ]
+        )
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        names = [b[0] for b in bad]
+        assert "azure/sentences/zero.mp3" in names
+        assert "azure/sentences/good.mp3" not in names
+        assert len(bad) == 1
+
+    def test_too_small_object_is_flagged(self, audit_mod):
+        bucket = FakeBucket([FakeBlob("azure/sentences/tiny.mp3", content=b"ID3" + b"\x00" * 20)])
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert len(bad) == 1
+        assert "small" in bad[0][1].lower()
+
+    def test_wrong_magic_bytes_is_flagged(self, audit_mod):
+        bucket = FakeBucket([FakeBlob("azure/sentences/bad.mp3", content=b"RIFF" + b"\x00" * 5000)])
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert len(bad) == 1
+        assert "mp3" in bad[0][1].lower()
+
+    def test_non_mp3_extension_is_excluded(self, audit_mod):
+        """A stray manifest/metadata object under the same prefix must never
+        be treated as audio, valid or not."""
+        bucket = FakeBucket(
+            [
+                FakeBlob("azure/sentences/manifest.json", content=b"{}"),
+                FakeBlob("azure/sentences/good.mp3", content=_good_mp3()),
+            ]
+        )
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert bad == []
+
+    def test_unreadable_object_is_flagged_not_crashed(self, audit_mod):
+        bucket = FakeBucket(
+            [FakeBlob("azure/sentences/broken.mp3", content=_good_mp3(), unreadable=True)]
+        )
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert len(bad) == 1
+        assert "unreadable" in bad[0][1].lower()
+
+    def test_only_scans_matching_prefix(self, audit_mod):
+        """A broken object under the Gemini prefix must never surface (or be
+        touched) when auditing the Azure prefix — no cross-prefix bleed."""
+        bucket = FakeBucket(
+            [
+                FakeBlob("gemini31-prompt-only-v2/sentences/zero.mp3", content=b"", size=0),
+                FakeBlob("azure/sentences/good.mp3", content=_good_mp3()),
+            ]
+        )
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert bad == []
+
+    def test_returns_size_alongside_name_and_reason(self, audit_mod):
+        bucket = FakeBucket([FakeBlob("azure/sentences/zero.mp3", content=b"", size=0)])
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        name, reason, size = bad[0]
+        assert name == "azure/sentences/zero.mp3"
+        assert size == 0
+
+    def test_large_valid_object_does_not_trigger_full_download(self, audit_mod):
+        """A valid object must be checked via size + a short peek only — never
+        a full download_as_bytes(start=0, end=None) covering the whole file.
+        This is the whole point of using metadata instead of the batch
+        generator's full-payload check when scanning thousands of objects."""
+
+        class TrackingBlob(FakeBlob):
+            def download_as_bytes(self, start=0, end=None):
+                assert end is not None and end < 100, "audit must peek, not fully download"
+                return super().download_as_bytes(start, end)
+
+        bucket = FakeBucket([TrackingBlob("azure/sentences/good.mp3", content=_good_mp3(n=50000))])
+        bad = audit_mod.scan(bucket, "azure/sentences", min_bytes=2000)
+        assert bad == []
+
+
+# ---------------------------------------------------------------------------
+# apply_delete() — the only place that mutates the bucket
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDelete:
+    def test_deletes_only_flagged_objects(self, audit_mod):
+        good = FakeBlob("azure/sentences/good.mp3", content=_good_mp3())
+        bad = FakeBlob("azure/sentences/zero.mp3", content=b"", size=0)
+        bucket = FakeBucket([good, bad])
+        flagged = [(bad.name, "empty object (0 bytes)", 0)]
+        deleted = audit_mod.apply_delete(bucket, flagged)
+        assert deleted == 1
+        assert bad.deleted is True
+        assert good.deleted is False
+
+    def test_empty_flagged_list_deletes_nothing(self, audit_mod):
+        good = FakeBlob("azure/sentences/good.mp3", content=_good_mp3())
+        bucket = FakeBucket([good])
+        deleted = audit_mod.apply_delete(bucket, [])
+        assert deleted == 0
+        assert good.deleted is False
+
+    def test_delete_tolerates_already_deleted_object(self, audit_mod):
+        """Two overlapping audit runs (or a re-run after a partial delete)
+        must not crash on an object someone else already removed."""
+
+        class VanishingBlob(FakeBlob):
+            def delete(self):
+                from google.api_core.exceptions import NotFound
+
+                raise NotFound("already gone")
+
+        gone = VanishingBlob("azure/sentences/zero.mp3", content=b"", size=0)
+        bucket = FakeBucket([gone])
+        flagged = [(gone.name, "empty object (0 bytes)", 0)]
+        deleted = audit_mod.apply_delete(bucket, flagged)
+        assert deleted == 0  # not counted as a fresh deletion, and no crash
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI wiring: --dry-run default, --delete opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestMainCliWiring:
+    def _patch_client(self, audit_mod, monkeypatch, bucket):
+        class FakeClient:
+            def bucket(self, name):
+                return bucket
+
+        fake_storage = type("m", (), {"Client": staticmethod(FakeClient)})()
+        monkeypatch.setattr(audit_mod, "storage", fake_storage)
+
+    def test_dry_run_is_the_default_and_deletes_nothing(self, audit_mod, monkeypatch):
+        bad_blob = FakeBlob("azure/sentences/zero.mp3", content=b"", size=0)
+        bucket = FakeBucket([bad_blob])
+        self._patch_client(audit_mod, monkeypatch, bucket)
+        monkeypatch.setattr(
+            "sys.argv", ["audit_tts_objects.py", "--prefix", "azure/sentences", "--min-bytes", "2000"]
+        )
+        audit_mod.main()
+        assert bad_blob.deleted is False
+
+    def test_delete_flag_removes_only_the_bad_objects(self, audit_mod, monkeypatch):
+        bad_blob = FakeBlob("azure/sentences/zero.mp3", content=b"", size=0)
+        good_blob = FakeBlob("azure/sentences/good.mp3", content=_good_mp3())
+        bucket = FakeBucket([bad_blob, good_blob])
+        self._patch_client(audit_mod, monkeypatch, bucket)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_tts_objects.py", "--prefix", "azure/sentences", "--min-bytes", "2000", "--delete"],
+        )
+        audit_mod.main()
+        assert bad_blob.deleted is True
+        assert good_blob.deleted is False

--- a/backend/tests/test_batch_azure_tts.py
+++ b/backend/tests/test_batch_azure_tts.py
@@ -1,0 +1,95 @@
+"""TDD lock for the testable units in backend/scripts/batch_azure_tts.py (#2614).
+
+Only covers module-level functions (_ssml/_escape/_upload_if_absent) — the
+generation/upload loop itself lives inside main() as a nested closure and is
+exercised in production, not unit tests; this repo's testing-strategy.md
+calls that out explicitly (contract-test what a type checker can't catch,
+not every closure).
+
+_validate() used to be nested inside main() too, which is exactly why it had
+zero test coverage before #2614 — see test_tts_audio_validation.py for its
+replacement (app.services.tts.audio_validation.validate_mp3_bytes), now
+importable and tested directly.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "batch_azure_tts.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("batch_azure_tts_under_test", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def batch_mod():
+    return _load_module()
+
+
+class FakeBlob:
+    def __init__(self, exists: bool = False):
+        self.exists_already = exists
+        self.uploaded_bytes: bytes | None = None
+        self.upload_kwargs: dict | None = None
+
+    def upload_from_string(self, data, content_type=None, if_generation_match=None):
+        if self.exists_already and if_generation_match == 0:
+            from google.api_core.exceptions import PreconditionFailed
+
+            raise PreconditionFailed("object already exists")
+        self.uploaded_bytes = data
+        self.upload_kwargs = {"content_type": content_type, "if_generation_match": if_generation_match}
+
+
+class FakeBucket:
+    def __init__(self, blob: FakeBlob):
+        self._blob = blob
+
+    def blob(self, name):
+        return self._blob
+
+
+class TestUploadIfAbsent:
+    def test_uploads_when_object_does_not_exist(self, batch_mod):
+        blob = FakeBlob(exists=False)
+        bucket = FakeBucket(blob)
+        result = batch_mod._upload_if_absent(bucket, "azure/sentences/aaa.mp3", b"ID3fakeaudio")
+        assert result is True
+        assert blob.uploaded_bytes == b"ID3fakeaudio"
+        assert blob.upload_kwargs["if_generation_match"] == 0
+
+    def test_skips_when_object_already_exists(self, batch_mod):
+        """Simulates the race: another run already won and wrote this key."""
+        blob = FakeBlob(exists=True)
+        bucket = FakeBucket(blob)
+        result = batch_mod._upload_if_absent(bucket, "azure/sentences/aaa.mp3", b"ID3fakeaudio")
+        assert result is False
+        assert blob.uploaded_bytes is None  # never overwrote the winner
+
+    def test_uses_correct_content_type(self, batch_mod):
+        blob = FakeBlob(exists=False)
+        bucket = FakeBucket(blob)
+        batch_mod._upload_if_absent(bucket, "azure/sentences/aaa.mp3", b"ID3fakeaudio")
+        assert blob.upload_kwargs["content_type"] == "audio/mpeg"
+
+
+class TestSsmlUsesSharedValidatorImport:
+    def test_module_imports_shared_validator_not_a_local_copy(self, batch_mod):
+        """Locks the #2614 refactor: batch_azure_tts.py must call the shared,
+        tested validator — not reinvent its own inline closure the way the
+        original _validate() did (which is why it had no test coverage)."""
+        from app.services.tts.audio_validation import validate_mp3_bytes
+
+        assert batch_mod.validate_mp3_bytes is validate_mp3_bytes
+
+    def test_ssml_still_escapes_and_wraps_voice(self, batch_mod):
+        out = batch_mod._ssml("喝采")
+        assert "zh-TW-HsiaoChenNeural" in out or batch_mod.VOICE in out
+        assert "<speak" in out and "</speak>" in out

--- a/backend/tests/test_batch_azure_tts.py
+++ b/backend/tests/test_batch_azure_tts.py
@@ -14,6 +14,7 @@ importable and tested directly.
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -93,3 +94,97 @@ class TestSsmlUsesSharedValidatorImport:
         out = batch_mod._ssml("喝采")
         assert "zh-TW-HsiaoChenNeural" in out or batch_mod.VOICE in out
         assert "<speak" in out and "</speak>" in out
+
+
+# ---------------------------------------------------------------------------
+# #2614 follow-up: punctuation-only fragments produce Azure HTTP-200-empty-body
+# ---------------------------------------------------------------------------
+#
+# Root cause found by team-lead after the batch run finished: the 3 confirmed
+# 0-byte objects were not an Azure reliability problem — they were sentences
+# that are ENTIRELY punctuation ('。', '」', '」。'), left over from upstream
+# sentence segmentation. _clean_for_tts only strips a specific punctuation
+# subset (~, ──, …), so these survive cleaning unchanged, pass the
+# `if not cleaned: continue` check (they are non-empty strings!), and get
+# sent to Azure — which answers 200 with an empty body because there is
+# nothing to speak. This is a *different* failure path than validate_mp3_bytes
+# (which catches Azure misbehaving on a *normal* input) — both guards stay.
+
+
+class TestHasSpeakableContent:
+    """Unit tests for the new input-side filter, using team-lead's exact
+    reported cases plus the boundary ones they specified."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("。", False),
+            ("」", False),
+            ("」。", False),
+            ("  ", False),
+            ("——", False),
+            ("，、；：", False),  # more punctuation-only, same failure shape
+            ("好。", True),
+            ("A", True),
+            ("214周", True),
+            ("你好，世界！", True),
+        ],
+    )
+    def test_speakable_detection(self, batch_mod, text, expected):
+        assert batch_mod._has_speakable_content(text) is expected
+
+
+class TestLoadSentencesSkipsUnspeakable:
+    """Integration-level: load_sentences() must actually apply the filter and
+    log what it dropped — team-lead's requirement was "不要靜默丟掉"."""
+
+    def _write_jsonl(self, path, rows):
+        path.write_text(
+            "\n".join(json.dumps(r, ensure_ascii=False) for r in rows), encoding="utf-8"
+        )
+
+    def test_punctuation_only_sentences_are_skipped(self, batch_mod, tmp_path, monkeypatch):
+        rows = [
+            {"text": "。", "lesson_id": "L1146", "paragraph_idx": 0, "sentence_idx": 30},
+            {"text": "」", "lesson_id": "L1115", "paragraph_idx": 0, "sentence_idx": 48},
+            {"text": "」。", "lesson_id": "L1080", "paragraph_idx": 0, "sentence_idx": 10},
+            {"text": "他說好。", "lesson_id": "L1080", "paragraph_idx": 0, "sentence_idx": 11},
+        ]
+        jsonl_path = tmp_path / "sentences.jsonl"
+        self._write_jsonl(jsonl_path, rows)
+        monkeypatch.setattr(batch_mod, "JSONL", jsonl_path)
+
+        items = batch_mod.load_sentences()
+
+        assert [it["raw_text"] for it in items] == ["他說好。"]
+
+    def test_skip_is_logged_not_silent(self, batch_mod, tmp_path, monkeypatch, caplog):
+        import logging
+
+        rows = [
+            {"text": "。", "lesson_id": "L1146", "paragraph_idx": 0, "sentence_idx": 30},
+            {"text": "」", "lesson_id": "L1115", "paragraph_idx": 0, "sentence_idx": 48},
+        ]
+        jsonl_path = tmp_path / "sentences.jsonl"
+        self._write_jsonl(jsonl_path, rows)
+        monkeypatch.setattr(batch_mod, "JSONL", jsonl_path)
+
+        with caplog.at_level(logging.INFO, logger="batch-azure"):
+            batch_mod.load_sentences()
+
+        assert "2" in caplog.text  # skipped count surfaces somewhere in the log
+        assert "L1146" in caplog.text
+        assert "L1115" in caplog.text
+
+    def test_normal_sentences_unaffected(self, batch_mod, tmp_path, monkeypatch):
+        rows = [
+            {"text": "今天天氣很好。", "lesson_id": "L1", "paragraph_idx": 0, "sentence_idx": 0},
+            {"text": "214周年紀念", "lesson_id": "L2", "paragraph_idx": 0, "sentence_idx": 0},
+        ]
+        jsonl_path = tmp_path / "sentences.jsonl"
+        self._write_jsonl(jsonl_path, rows)
+        monkeypatch.setattr(batch_mod, "JSONL", jsonl_path)
+
+        items = batch_mod.load_sentences()
+
+        assert len(items) == 2

--- a/backend/tests/test_tts_audio_validation.py
+++ b/backend/tests/test_tts_audio_validation.py
@@ -1,0 +1,98 @@
+"""TDD lock for the shared TTS audio-bytes validator (#2614).
+
+Root cause this guards against: Azure (and any REST TTS provider) can answer
+HTTP 200 with an empty or truncated body. Before this guard existed,
+batch_azure_tts.py uploaded that response as-is and counted it a success
+(err=0) — an observed run produced 2 confirmed 0-byte objects that then
+*permanently* won the runtime cache (silence forever, no error anywhere).
+
+validate_mp3_bytes() is used by the batch generator right after synthesis
+(full audio in memory). validate_mp3_metadata() is used by the audit tool to
+re-check objects already in GCS without downloading the full object (only
+size metadata + a short byte-range peek). Both must agree on what counts as
+a valid mp3 — that is the point of sharing one module instead of each script
+inventing its own check.
+"""
+from __future__ import annotations
+
+from app.services.tts.audio_validation import (
+    MP3_PEEK_BYTES,
+    validate_mp3_bytes,
+    validate_mp3_metadata,
+)
+
+
+class TestValidateMp3Bytes:
+    """Full in-memory payload validation (batch generator path)."""
+
+    def test_none_is_rejected(self):
+        assert validate_mp3_bytes(None) is not None
+
+    def test_empty_bytes_is_rejected(self):
+        reason = validate_mp3_bytes(b"")
+        assert reason is not None
+        assert "0 bytes" in reason or "empty" in reason.lower()
+
+    def test_too_small_is_rejected(self):
+        # a legit-looking ID3 prefix but way under the size floor
+        reason = validate_mp3_bytes(b"ID3" + b"\x00" * 50, min_bytes=2000)
+        assert reason is not None
+        assert "small" in reason.lower()
+
+    def test_wav_header_is_rejected(self):
+        """A WAV file (RIFF magic) must never pass as an mp3."""
+        payload = b"RIFF" + b"\x00" * 5000
+        reason = validate_mp3_bytes(payload)
+        assert reason is not None
+        assert "mp3" in reason.lower()
+
+    def test_html_error_page_is_rejected(self):
+        """A proxy/error page body must never pass as audio."""
+        payload = b"<html><body>500 Internal Server Error</body></html>" + b" " * 5000
+        reason = validate_mp3_bytes(payload)
+        assert reason is not None
+
+    def test_valid_id3_tagged_mp3_passes(self):
+        payload = b"ID3" + b"\x00" * 5000
+        assert validate_mp3_bytes(payload) is None
+
+    def test_valid_raw_frame_sync_variants_pass(self):
+        for magic in (b"\xff\xfb", b"\xff\xf3", b"\xff\xf2"):
+            payload = magic + b"\x00" * 5000
+            assert validate_mp3_bytes(payload) is None, f"{magic!r} should be accepted"
+
+    def test_custom_min_bytes_threshold_is_respected(self):
+        payload = b"ID3" + b"\x00" * 100
+        assert validate_mp3_bytes(payload, min_bytes=50) is None
+        assert validate_mp3_bytes(payload, min_bytes=200) is not None
+
+
+class TestValidateMp3Metadata:
+    """Size + short byte-range peek validation (audit tool path — no full download)."""
+
+    def test_zero_size_is_rejected(self):
+        reason = validate_mp3_metadata(size=0, head=b"")
+        assert reason is not None
+
+    def test_none_size_is_rejected(self):
+        reason = validate_mp3_metadata(size=None, head=b"")
+        assert reason is not None
+
+    def test_too_small_size_is_rejected_even_with_good_head(self):
+        # size alone should be enough to flag it — head is irrelevant here
+        reason = validate_mp3_metadata(size=50, head=b"ID3\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", min_bytes=2000)
+        assert reason is not None
+        assert "small" in reason.lower()
+
+    def test_good_size_with_bad_magic_is_rejected(self):
+        reason = validate_mp3_metadata(size=50000, head=b"RIFF\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", min_bytes=2000)
+        assert reason is not None
+        assert "mp3" in reason.lower()
+
+    def test_good_size_with_good_magic_passes(self):
+        head = b"ID3" + b"\x00" * (MP3_PEEK_BYTES - 3)
+        assert validate_mp3_metadata(size=50000, head=head, min_bytes=2000) is None
+
+    def test_good_size_with_raw_frame_sync_passes(self):
+        head = b"\xff\xfb" + b"\x00" * (MP3_PEEK_BYTES - 2)
+        assert validate_mp3_metadata(size=50000, head=head, min_bytes=2000) is None


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2614

## Summary

- Azure's TTS REST endpoint can answer HTTP 200 with an empty or truncated body. `batch_azure_tts.py` uploaded that response as-is and counted it a success — an actual batch run produced 2 confirmed 0-byte objects that then permanently win the runtime cache (silent audio forever, no error anywhere in the stack).
- Extracted the validator out of a nested closure inside `main()` (which had zero test coverage — thats why this shipped) into `app/services/tts/audio_validation.py`, shared by the batch generator (`validate_mp3_bytes`, full in-memory payload) and a new audit tool (`validate_mp3_metadata`, size + short byte-range peek — no full downloads).
- Added `backend/scripts/audit_tts_objects.py` to scan an existing GCS prefix for objects that already slipped through before this validation existed. `--dry-run` by default; `--delete` only removes objects the scan itself flagged (never a blanket prefix delete).
- Wired the shared validator into `batch_azure_tts.py`, replacing the untestable inline closure.
- Addressed a P2 from review (same-key concurrent overwrite with no generation precondition): added `if_generation_match=0` on upload via a small `_upload_if_absent()` helper, tolerating `PreconditionFailed` as "someone else already won the race," not an error. Low risk either way (both writers produce valid audio for the same sentence), but cheap to close.

## Out of scope

- `batch_gemini_tts_v2.py`, `TTS_PROVIDER`, and the Gemini GCS prefix are untouched.
- Does not touch the Azure `<phoneme>`→`<sub alias>` SSML fix (#2612/#2613, already merged separately).
- Does not delete anything in production GCS — `audit_tts_objects.py --delete` is a manual follow-up step for the repo owner after reviewing `--dry-run` output.

## Test plan

- TDD: wrote failing tests first (ModuleNotFoundError / FileNotFoundError on the not-yet-created module/script), then implemented to green.
- Mutation-tested every validator (`validate_mp3_bytes`, `validate_mp3_metadata`, `scan()`, `_upload_if_absent()`): forced each to always report "valid"/succeed, confirmed the relevant tests went red, reverted, confirmed green again.
- `pytest backend/tests/test_tts_audio_validation.py backend/tests/test_audit_tts_objects.py backend/tests/test_batch_azure_tts.py` → 33 passed.
- Ran `audit_tts_objects.py --dry-run --prefix azure/sentences` against the real `gs://lingoleap-tts-cache` bucket (read-only) — results reported separately once the scan (6000+ objects) finishes.
