### PR TITLE
chore(tts): TTS_PROVIDER gemini31 → azure (Fixes #2616)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --max-instances=3 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio-prod"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=azure::ENVIRONMENT=production::ENABLE_TEST_SEED=false::JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio-prod"
 
       - name: Verify backend health
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -105,7 +105,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-preview-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://placeholder.run.app::DATABASE_URL=${{ secrets.PREVIEW_DATABASE_URL }}::RUN_MIGRATIONS=true::ENVIRONMENT=preview::JWT_SECRET_KEY=${{ secrets.PREVIEW_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-preview::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://placeholder.run.app::DATABASE_URL=${{ secrets.PREVIEW_DATABASE_URL }}::RUN_MIGRATIONS=true::ENVIRONMENT=preview::JWT_SECRET_KEY=${{ secrets.PREVIEW_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-preview::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=azure"
 
       - name: Get backend preview URL
         id: backend-url

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-staging-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::JWT_SECRET_KEY=${{ secrets.STAGING_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio-staging"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=azure::ENVIRONMENT=staging::JWT_SECRET_KEY=${{ secrets.STAGING_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging::READING_AUDIO_GCS_BUCKET=lingoleap-reading-audio-staging"
 
       - name: Promote backend traffic to latest revision (Fixes #1449)
         run: |


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2616

## 為什麼

Young 聽過同一課全文的兩個版本後選 Azure `zh-TW-HsiaoChenNeural`（原生台灣腔），取代 Gemini `Aoede`（原話：「聽起來就是機器人」）。

## 改了什麼

三個 workflow 各一個值，`TTS_PROVIDER=gemini31` → `azure`。**沒有其他改動。**

逐字驗證（不是肉眼看）：

```
變動行數        -3 / +3
逐字比對        三行都只差 TTS_PROVIDER，其餘 499 / 369 / 589 字元完全相同
env key 數量    10→10、8→8、9→9
```

最後一項是重點：三個 workflow 都用 replace-all 形式設 env，**沒列到的 key 會被清掉**，那是 2026-04-18 staging 事故的成因。

## 前置條件都已落地

| | |
|---|---|
| #2613 | 修好 Azure 路徑（`<phoneme>` → `<sub alias>`，解掉 HTTP 400） |
| #2611 | 句表 57 → 165 課 |
| — | 6,356 個 Azure 音檔已預生成於 `azure/sentences/`（壞檔 0） |

`gemini31-prompt-only-v2/` 的 1,418 個原封不動，隨時可切回。

## 關於 CI 的 pre-land bypass

commit 用了具名 bypass，理由已驗證：`actionlint` 對這三個 workflow 報 **42 個 shellcheck 警告，而未修改的 `origin/staging` 原檔也是 42 個** — 完全相同，這個 diff 沒引入任何新問題。gate 對整檔 lint 而非只 lint diff，所以任何人碰這三個檔都會被同一批舊警告擋下。

## ⚠️ merge 後必須驗，不能只看綠燈

1. **Cloud Run 流量真的移到新 revision 了嗎** — workflow 沒有顯式 pin traffic。服務若處於釘住模式，每次 deploy 只建 revision 不換流量，**而且沒有任何警告**。查 `status.traffic` 找 `percent: 100` 那筆的 revision，再確認它跑的 image 是這次建的
2. **Azure 失敗會 fallback 到 Google Chirp3-HD** — 那是中國腔，2026-04 A/B 盲聽被否決過。切換後只要 Azure 抖動就會無聲無息冒出來，使用者不會知道。這條需要另外決定（拿掉 fallback／改成明確報錯／接受）
3. staging 先驗四條路徑：cache hit（應 < 1s）／cache miss（現場合成成功，不是 400）／Azure 失敗 → fallback／兩者都失敗 → 503