### PR TITLE
test(tts): add coverage + no-degrade-on-success regression locks (Fixes #2619)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,3 +66,19 @@ jobs:
           AZURE_SPEECH_KEY: ""
           AZURE_SPEECH_REGION: eastus
           JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
+
+      # TTS coverage lock (#2619): mocked logic only (existing_keys/missing_keys/
+      # expected_keys against FakeBucket doubles + the real manifest file) — no
+      # GCS credentials touched here. The real-bucket class
+      # (TestRealGCSCoverage) is opt-in via RUN_REAL_GCS_TESTS and self-skips
+      # without it, so it never runs in CI. An un-run lock is theatre — pin it.
+      - name: Run TTS coverage lock (mocked — real-GCS class self-skips)
+        run: |
+          cd backend
+          python -m pytest --tb=short -q tests/test_audit_tts_coverage.py
+        env:
+          DATABASE_URL: sqlite://
+          TTS_PROVIDER: google
+          AZURE_SPEECH_KEY: ""
+          AZURE_SPEECH_REGION: eastus
+          JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"

--- a/backend/scripts/audit_tts_coverage.py
+++ b/backend/scripts/audit_tts_coverage.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Audit GCS coverage of the sentence manifest for the active TTS provider (#2619).
+
+Two TTS bugs shipped 2026-08-08 with no lock behind them: audio regenerated
+live on every "AI 朗讀" click (cache miss) and the first playback fell back
+to the browser's machine voice. Both existing locks (frontend's
+tts-alignment.eval.ts + useTtsPlayback.test.ts) only check that the frontend
+computes the SAME cache key as the backend — neither checks that an object
+actually EXISTS at that key in GCS. If the bucket gets wiped again (an
+`age:90` lifecycle rule did exactly that in 2026-07, unnoticed for 4 months),
+both of those stay green while every real user hits cold-generation and a
+possible fallback. This script is the missing check.
+
+`expected_keys()` deliberately reuses batch_azure_tts.py's own
+`load_sentences()` (dynamically loaded, same pattern its own tests use)
+instead of re-deriving the punctuation-only filter here — the risk of two
+independent copies of `_has_speakable_content` drifting apart is exactly the
+kind of gap this audit exists to close, not reproduce.
+
+`missing_keys()` is a subset check (expected - existing), not exact
+equality: the real bucket can hold MORE objects than the manifest currently
+expects (e.g. 3 punctuation-only objects an azure batch run generated before
+#2615's skip-filter landed) — those extras must never fail this gate.
+
+Usage:
+  set -a; source backend/.env; set +a
+  python backend/scripts/audit_tts_coverage.py
+  python backend/scripts/audit_tts_coverage.py --provider azure
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import logging
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.services.tts import TTS_GCS_BUCKET, _blob_path  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("audit-tts-coverage")
+
+# Reuse the runtime's own bucket name (env TTS_GCS_BUCKET, default
+# "lingoleap-tts-cache") instead of a second hardcoded literal — code review
+# on #2619 flagged the drift risk: harmless today since the default matches,
+# but silently wrong the day someone overrides TTS_GCS_BUCKET per-environment
+# without updating this file too.
+GCS_BUCKET = TTS_GCS_BUCKET
+
+
+def _load_batch_azure_module():
+    """Dynamically load batch_azure_tts.py so expected_keys() can call its
+    load_sentences() directly — the single source of truth for "what should
+    have been generated", including the punctuation-only skip filter. Not a
+    normal package import: it's a standalone script, same reason
+    test_batch_azure_tts.py and test_audit_tts_objects.py load it this way."""
+    spec = importlib.util.spec_from_file_location(
+        "batch_azure_tts_ref", ROOT / "backend" / "scripts" / "batch_azure_tts.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def expected_keys() -> set[str]:
+    """Every cache_key that batch_azure_tts.py would queue for generation —
+    i.e. every unique, speakable sentence currently in the manifest."""
+    batch_mod = _load_batch_azure_module()
+    return {item["cache_key"] for item in batch_mod.load_sentences()}
+
+
+def existing_keys(bucket, provider: str) -> set[str]:
+    """Every cache_key that already has a real .mp3 object in GCS for
+    `provider`. One list_blobs call, never a per-key exists() loop — see
+    batch_azure_tts.py's own comment on why (10+ minutes for this manifest)."""
+    prefix = _blob_path("", provider).removesuffix(".mp3")
+    found: set[str] = set()
+    for blob in bucket.list_blobs(prefix=prefix):
+        if not blob.name.endswith(".mp3"):
+            continue
+        found.add(blob.name[len(prefix):-4])
+    return found
+
+
+def missing_keys(expected: set[str], existing: set[str]) -> set[str]:
+    """Subset check, not equality — extra objects beyond what's currently
+    expected (stale/legacy generations) are never a failure."""
+    return expected - existing
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--provider", default=None,
+                     help="defaults to TTS_PROVIDER env (or 'azure')")
+    ap.add_argument("--bucket", default=GCS_BUCKET)
+    args = ap.parse_args()
+
+    from google.cloud import storage
+
+    provider = args.provider or os.environ.get("TTS_PROVIDER", "azure")
+    gcs = storage.Client()
+    bucket = gcs.bucket(args.bucket)
+
+    expected = expected_keys()
+    existing = existing_keys(bucket, provider)
+    missing = missing_keys(expected, existing)
+
+    logger.info("provider=%s expected=%d existing=%d missing=%d",
+                provider, len(expected), len(existing), len(missing))
+
+    if missing:
+        logger.warning("Missing %d/%d speakable sentence(s) under provider=%s:",
+                        len(missing), len(expected), provider)
+        for key in sorted(missing)[:20]:
+            logger.warning("  %s", key)
+        if len(missing) > 20:
+            logger.warning("  ... and %d more", len(missing) - 20)
+        sys.exit(1)
+
+    logger.info("Coverage 100%% — every speakable sentence has a GCS object under provider=%s.",
+                provider)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_audit_tts_coverage.py
+++ b/backend/tests/test_audit_tts_coverage.py
@@ -1,0 +1,203 @@
+"""TDD lock for backend/scripts/audit_tts_coverage.py (#2619).
+
+Two TTS bugs shipped the night of 2026-08-08 with no regression lock behind
+them: (1) every "AI 朗讀" click regenerated audio from scratch instead of
+hitting the pre-generated GCS cache, and (2) the first playback attempt fell
+back to the browser's machine voice. The two locks that already existed —
+frontend/scripts/eval/tts-alignment.eval.ts (cache *key* alignment) and
+frontend/src/hooks/useTtsPlayback.test.ts (fallback *visibility*) — both
+stay green even if every object in the GCS cache is deleted, because neither
+one checks that an object actually EXISTS. That is exactly what happened in
+2026-07 (an `age:90` lifecycle rule wiped the bucket, unnoticed for 4 months).
+
+This is the missing check: every speakable sentence in the manifest
+(backend/data/sentences.v2.jsonl) must have a real object in GCS under the
+active TTS_PROVIDER's prefix.
+
+Two layers, same split as test_audit_tts_objects.py:
+  - Always-run unit tests against FakeBucket doubles (no GCS, no credentials).
+  - An opt-in class that hits the real bucket (RUN_REAL_GCS_TESTS=1), mirroring
+    TestAzureRealAPIPhonemeCorrections in test_tts_service.py.
+
+Loaded via importlib.util (same pattern as test_audit_tts_objects.py /
+test_batch_azure_tts.py) because it's a standalone script, not a package
+module.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "audit_tts_coverage.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_tts_coverage_under_test", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def coverage_mod():
+    return _load_module()
+
+
+class FakeBlob:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class FakeBucket:
+    """Stand-in for google.cloud.storage.Bucket — list_blobs only, this
+    module never reads or mutates object contents."""
+
+    def __init__(self, names: list[str]):
+        self._names = names
+
+    def list_blobs(self, prefix: str = ""):
+        return [FakeBlob(n) for n in self._names if n.startswith(prefix)]
+
+
+# ---------------------------------------------------------------------------
+# expected_keys() — must reuse batch_azure_tts.load_sentences() (zero drift
+# from what the real generator actually queues), not re-derive the punctuation
+# filter here.
+# ---------------------------------------------------------------------------
+
+
+class TestExpectedKeysMatchesManifest:
+    def test_excludes_punctuation_only_sentences(self, coverage_mod):
+        """。／」／」。 are unspeakable — batch_azure_tts.py's own
+        _has_speakable_content skips them before they ever reach Azure
+        (#2614/#2615). expected_keys() must inherit that exclusion, not
+        re-derive its own (weaker or drifted) copy of the filter."""
+        from app.services.tts.normalization import _cache_key
+
+        expected = coverage_mod.expected_keys()
+        for punctuation_only in ("。", "」", "」。"):
+            assert _cache_key(punctuation_only) not in expected
+
+    def test_count_matches_known_manifest_state(self, coverage_mod):
+        """Pins the current manifest: 6,359 unique raw sentences in
+        sentences.v2.jsonl, 3 of them punctuation-only → 6,356 speakable.
+        If the manifest legitimately grows (new lessons), update this number
+        — do not delete the assertion, that is exactly the kind of silent
+        threshold-loosening this lock exists to prevent."""
+        expected = coverage_mod.expected_keys()
+        assert len(expected) == 6356
+
+    def test_returns_a_set_of_hex_strings(self, coverage_mod):
+        expected = coverage_mod.expected_keys()
+        assert isinstance(expected, set)
+        sample = next(iter(expected))
+        assert isinstance(sample, str)
+        int(sample, 16)  # must be valid hex (sha256 cache key)
+
+
+# ---------------------------------------------------------------------------
+# existing_keys() — one list_blobs, prefix-scoped, no per-object exists()
+# ---------------------------------------------------------------------------
+
+
+class TestExistingKeys:
+    def test_extracts_cache_key_from_blob_name(self, coverage_mod):
+        bucket = FakeBucket(["azure/sentences/aaa111.mp3"])
+        found = coverage_mod.existing_keys(bucket, "azure")
+        assert found == {"aaa111"}
+
+    def test_ignores_non_mp3_objects_under_the_same_prefix(self, coverage_mod):
+        bucket = FakeBucket(["azure/sentences/aaa111.mp3", "azure/sentences/manifest.json"])
+        found = coverage_mod.existing_keys(bucket, "azure")
+        assert found == {"aaa111"}
+
+    def test_only_matches_the_active_providers_prefix(self, coverage_mod):
+        """A fully-populated gemini31 prefix must never count toward azure's
+        coverage — no cross-prefix bleed. This is the same guard as
+        audit_tts_objects.py's test_only_scans_matching_prefix."""
+        bucket = FakeBucket([
+            "gemini31-prompt-only-v2/sentences/bbb222.mp3",
+            "azure/sentences/aaa111.mp3",
+        ])
+        found = coverage_mod.existing_keys(bucket, "azure")
+        assert found == {"aaa111"}
+
+    def test_empty_bucket_returns_empty_set(self, coverage_mod):
+        bucket = FakeBucket([])
+        assert coverage_mod.existing_keys(bucket, "azure") == set()
+
+
+# ---------------------------------------------------------------------------
+# missing_keys() — the actual assertion logic every other test/CI check
+# depends on. Subset check (expected ⊆ existing), not exact equality: real
+# provenance data shows the bucket can hold MORE objects than currently
+# expected (e.g. 3 punctuation-only objects generated by an azure batch run
+# before #2615's skip-filter landed) — those extras must never fail the gate.
+# ---------------------------------------------------------------------------
+
+
+class TestMissingKeys:
+    def test_returns_empty_when_everything_present(self, coverage_mod):
+        assert coverage_mod.missing_keys({"a", "b"}, {"a", "b"}) == set()
+
+    def test_tolerates_extra_objects_beyond_the_expected_set(self, coverage_mod):
+        """Bucket has MORE than the manifest currently expects (stale/legacy
+        objects) — must not be reported as missing."""
+        assert coverage_mod.missing_keys({"a"}, {"a", "b", "c"}) == set()
+
+    def test_reports_every_absent_key(self, coverage_mod):
+        """This is the mutation-provable case: inject a hole (drop 'b' from
+        existing) and confirm it is detected, not silently ignored."""
+        missing = coverage_mod.missing_keys({"a", "b", "c"}, {"a", "c"})
+        assert missing == {"b"}
+
+    def test_all_missing_when_bucket_is_empty(self, coverage_mod):
+        """The exact 2026-07 failure mode this lock exists for: the whole
+        prefix got wiped. Every expected key must show up as missing, not
+        just some."""
+        expected = {"a", "b", "c"}
+        assert coverage_mod.missing_keys(expected, set()) == expected
+
+
+# ---------------------------------------------------------------------------
+# Opt-in real GCS test — the actual regression lock. Everything above proves
+# the logic is correct; only this class proves the *live bucket* has full
+# coverage today. Mirrors TestAzureRealAPIPhonemeCorrections in
+# test_tts_service.py (opt-in, skipped without credentials, never runs in CI).
+# ---------------------------------------------------------------------------
+
+_REAL_GCS_ENABLED = bool(os.environ.get("RUN_REAL_GCS_TESTS"))
+
+
+@pytest.mark.skipif(
+    not _REAL_GCS_ENABLED,
+    reason="opt-in only — set RUN_REAL_GCS_TESTS=1 with real GCS credentials "
+           "(ADC or GOOGLE_APPLICATION_CREDENTIALS) to run",
+)
+class TestRealGCSCoverage:
+    """Hits the real lingoleap-tts-cache bucket. This is the only test that
+    would actually have caught 'the bucket got wiped' or 'the batch run
+    never finished' — every test above is mocked and would stay green
+    through either failure."""
+
+    def test_active_provider_has_full_manifest_coverage(self, coverage_mod):
+        import os as _os
+
+        from google.cloud import storage
+
+        provider = _os.environ.get("TTS_PROVIDER", "azure")
+        gcs = storage.Client()
+        bucket = gcs.bucket(coverage_mod.GCS_BUCKET)
+
+        expected = coverage_mod.expected_keys()
+        existing = coverage_mod.existing_keys(bucket, provider)
+        missing = coverage_mod.missing_keys(expected, existing)
+
+        assert not missing, (
+            f"{len(missing)}/{len(expected)} speakable sentences have no GCS "
+            f"audio object under provider={provider}. Sample missing keys: "
+            f"{sorted(missing)[:5]}"
+        )

--- a/frontend/src/hooks/useTtsPlayback.test.ts
+++ b/frontend/src/hooks/useTtsPlayback.test.ts
@@ -163,6 +163,35 @@ describe('useTtsPlayback — isTtsDegraded (silent fallback fix, #2609)', () => 
     expect(result.current.isTtsDegraded).toBe(false);
   });
 
+  // #2619: the test above only checks the isTtsDegraded flag. That flag is
+  // set inside the .catch() fallback branch, so it stays false whenever the
+  // .catch() branch simply doesn't run — it says nothing about whether the
+  // Web Speech engine was ever actually told to speak the real narration.
+  // This is the reverse assertion 2609's fix needs but never got: on a
+  // working backend, the machine voice must never be invoked with real
+  // content, full stop — not "invoked but the flag happens to read false".
+  it('never calls speechSynthesis.speak with real narration text when Cloud TTS succeeds (must not degrade a working backend)', async () => {
+    const synth = stubSpeechSynthesisAvailable();
+    mockFetchSuccess();
+    const { result } = renderHook(() => useTtsPlayback(() => {}, () => {}));
+
+    act(() => {
+      result.current.speakText('你好，早安。');
+    });
+
+    await waitFor(() => expect(result.current.isTtsSpeaking).toBe(true));
+
+    // speak() IS called once per speakText() call for the gesture-preserving
+    // warmup utterance (empty string, line ~145 of useTtsPlayback.ts) — that
+    // is deliberate and not a degradation signal. Only a call carrying the
+    // real narration text would mean the machine voice actually spoke it.
+    const realTextCalls = synth.speak.mock.calls.filter(
+      ([utterance]) => (utterance as MockUtterance).text !== ''
+    );
+    expect(realTextCalls).toHaveLength(0);
+    expect(result.current.isTtsDegraded).toBe(false);
+  });
+
   it('resets isTtsDegraded to false as soon as the next call starts', async () => {
     stubSpeechSynthesisAvailable();
     mockFetchNetworkFailure();


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2619

## Summary

- Two TTS bugs shipped 2026-08-08 (regenerate-on-click / first-playback-machine-voice) had no regression lock. Both existing locks (`tts-alignment.eval.ts`, `useTtsPlayback.test.ts`) stay green even if the GCS bucket is wiped, because neither checks that an audio object actually exists.
- `backend/scripts/audit_tts_coverage.py` + `backend/tests/test_audit_tts_coverage.py`: coverage audit reusing `batch_azure_tts.py`'s own `load_sentences()` for the expected set (zero drift from the real generator's punctuation filter). Subset check (`expected - existing`), not equality — the bucket legitimately holds a few extra legacy objects.
- `frontend/src/hooks/useTtsPlayback.test.ts`: new reverse assertion — Cloud TTS success must never call `speechSynthesis.speak` with real narration text (excludes the deliberate empty-string warmup utterance).
- `.github/workflows/pytest.yml`: pinned the new backend test file into CI (mocked class only; the opt-in real-GCS class self-skips without `RUN_REAL_GCS_TESTS=1`).

## Evidence

- Backend: 11 passed / 1 skipped (opt-in). Mutation-tested `missing_keys()` — broke it to always report clean, 2 tests correctly went red, reverted.
- Frontend: 7 passed (6 pre-existing + 1 new). Checked the new test against the pre-#2609 commit (`aac989ff~0`'s parent) first — didn't go red there (that race isn't reproducible via the synchronous `Audio` mock), so used mutation instead: injected a `speechSynthesis.speak(realText)` call into the success path's `onplay` handler, confirmed only the new test went red, reverted.
- Real-GCS test attempted this session: **403 Forbidden** — picked up `claude-deployer@career-creator-card.iam.gserviceaccount.com` (wrong project's ADC), which also lacks `storage.objects.list` on `lingoleap-tts-cache` regardless. Live bucket coverage is **unverified** — needs a re-run with valid `lingoleap-dev` credentials.

## Test plan

- [ ] Re-run `RUN_REAL_GCS_TESTS=1 pytest backend/tests/test_audit_tts_coverage.py::TestRealGCSCoverage` with valid GCS credentials once available
- [x] `pytest backend/tests/test_audit_tts_coverage.py` — 11 passed, 1 skipped
- [x] `npx vitest run src/hooks/useTtsPlayback.test.ts` — 7 passed
- [x] `npx vitest run` (full suite) — no new failures beyond the documented ~33 pre-existing ones
- [x] `npm run lint` — 0 errors
- [x] `bash specs/run-ci.sh --quick` — registry up to date
