### PR TITLE
fix(#2622): 課程音檔總表 — 不能停止 + 多軌疊音

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -51,6 +51,12 @@ jobs:
       #     specifier so Vite bundles it. A dynamic import with the name in a
       #     variable passed build, lint and vitest while the feature was broken
       #     in every browser (#2622)
+      #   - LessonAudioTable: admin audio panel must (a) stop the previous
+      #     clip before starting a new one — the hook's single-shot playback
+      #     path does not auto-cancel a prior <audio> on its own — and (b)
+      #     return a row to idle the instant it (or the header button) is
+      #     stopped. Regression of either reintroduces #2622's "不能停止 /
+      #     同時播其他的就會一堆聲音" follow-up bug.
       - name: Render-smoke + pinned regression tests (vitest)
         working-directory: frontend
-        run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx src/hooks/useTtsPlayback.test.ts src/pages/admin/lesson-audio/qrcode-bundling.test.ts
+        run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx src/hooks/useTtsPlayback.test.ts src/pages/admin/lesson-audio/qrcode-bundling.test.ts src/pages/admin/lesson-audio/LessonAudioTable.test.tsx

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -1,18 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import LessonAudioTable, { buildLessonQrValue } from './LessonAudioTable';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import LessonAudioTable, { buildLessonQrValue, derivePlaybackState } from './LessonAudioTable';
+import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token' }),
 }));
 
+// The real hook's returned shape (see useTtsPlayback.ts) — mocked per-test via
+// mockReturnValue so tests can drive the "is audio actually playing" signal
+// independently of the component under test, the same way a real <audio>
+// element's play/pause events would.
 vi.mock('../../../hooks/useTtsPlayback', () => ({
-  useTtsPlayback: () => ({
-    speakText: vi.fn(),
-    stopPlayback: vi.fn(),
-    isTtsLoading: false,
-    isTtsSpeaking: false,
-  }),
+  useTtsPlayback: vi.fn(),
 }));
 
 vi.mock('qrcode', () => ({
@@ -56,17 +56,78 @@ const STORIES_RESPONSE = {
   ],
 };
 
-function mockStoriesFetch() {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-    ok: true,
-    json: async () => STORIES_RESPONSE,
+const mockSpeakText = vi.fn();
+const mockStopTts = vi.fn();
+
+/** Deferred promise helper — lets a test control exactly when a fetch resolves. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Sets the mocked useTtsPlayback() return value for the next render. */
+function mockTts(overrides: { isTtsLoading?: boolean; isTtsSpeaking?: boolean; ttsError?: string | null } = {}) {
+  vi.mocked(useTtsPlayback).mockReturnValue({
+    isTtsSpeaking: overrides.isTtsSpeaking ?? false,
+    isTtsPaused: false,
+    isTtsLoading: overrides.isTtsLoading ?? false,
+    ttsError: overrides.ttsError ?? null,
+    isTtsDegraded: false,
+    setIsTtsSpeaking: vi.fn(),
+    setIsTtsPaused: vi.fn(),
+    utteranceRef: { current: null },
+    ttsRafRef: { current: null },
+    speakText: mockSpeakText,
+    pauseTts: vi.fn(),
+    resumeTts: vi.fn(),
+    stopTts: mockStopTts,
+  });
+}
+
+/**
+ * Fetch dispatcher covering both endpoints LessonAudioTable calls:
+ *   GET /api/stories?page_size=300      -> the list
+ *   GET /api/stories/{id}               -> per-lesson detail (used to build
+ *                                          the text passed to speakText)
+ * Per-lesson detail responses are distinguishable by id so tests can assert
+ * *which* lesson's text actually reached speakText().
+ */
+function mockFetchDispatcher(detailOverride?: (id: number) => Promise<unknown> | unknown) {
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    if (url.includes('/api/stories?')) {
+      return Promise.resolve({ ok: true, json: async () => STORIES_RESPONSE });
+    }
+    const match = url.match(/\/api\/stories\/(\d+)$/);
+    if (match) {
+      const id = Number(match[1]);
+      if (detailOverride) {
+        return Promise.resolve(detailOverride(id)).then((body) => ({
+          ok: true,
+          json: async () => body,
+        }));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          paragraphs: [`lesson-${id}-text`],
+          key_reading: { passage: `lesson-${id}-key` },
+        }),
+      });
+    }
+    return Promise.reject(new Error(`unexpected fetch url in test: ${url}`));
   }));
 }
 
 describe('LessonAudioTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStoriesFetch();
+    mockTts();
+    mockFetchDispatcher();
   });
 
   it('renders one row per lesson from the list response', async () => {
@@ -103,5 +164,184 @@ describe('LessonAudioTable', () => {
     expect(buildLessonQrValue(origin, 1, 'full-reading')).toBe(
       'https://staging.example.test/learn/1/full-reading',
     );
+  });
+
+  // ── Bug #1 (#2622 follow-up): "不能停止" — the header stop button called a
+  // property (`stopPlayback`) that does not exist on the hook's return value
+  // (the real name is `stopTts`), so onClick was undefined and clicking it
+  // did nothing. Mutation target: rename the destructure back to
+  // `stopPlayback` and this test goes red because mockStopTts is never called.
+  it('the header stop button calls the hook\'s stop function and returns the row to idle', async () => {
+    const { rerender } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+
+    // Simulate the audio element actually starting to play, as the real
+    // hook would report via isTtsSpeaking once the browser fires `onplay`.
+    mockTts({ isTtsSpeaking: true });
+    rerender(<LessonAudioTable />);
+    expect(within(row).getByRole('button', { name: /停止/ })).toBeTruthy();
+
+    // playLesson defensively calls stopTts() before every play (harmless
+    // no-op when nothing was playing yet) — clear that call so this
+    // assertion is specifically about the explicit stop click below.
+    mockStopTts.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /停止播放/ }));
+    expect(mockStopTts).toHaveBeenCalledTimes(1);
+
+    // Once stopped, the hook reports idle again (isTtsSpeaking/isTtsLoading
+    // both false) — the row must reflect that immediately, not keep showing
+    // a "still working" spinner because it forgot which row it targeted.
+    mockTts();
+    rerender(<LessonAudioTable />);
+    expect(within(row).queryByRole('button', { name: /停止/ })).toBeNull();
+    expect(within(row).getByRole('button', { name: /播放全文/ })).toBeTruthy();
+  });
+
+  // Same guarantee, but via the row's own button (per the design goal: "a
+  // per-row stop is better than a distant header button").
+  it('clicking the row\'s own playing button stops it and returns the row to idle', async () => {
+    const { rerender } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+
+    mockTts({ isTtsSpeaking: true });
+    rerender(<LessonAudioTable />);
+    const stopButton = within(row).getByRole('button', { name: /停止/ });
+
+    mockStopTts.mockClear(); // see note above: clears playLesson's own defensive pre-play stop
+    fireEvent.click(stopButton);
+    expect(mockStopTts).toHaveBeenCalledTimes(1);
+
+    mockTts();
+    rerender(<LessonAudioTable />);
+    expect(within(row).getByRole('button', { name: /播放全文/ })).toBeTruthy();
+  });
+
+  // ── Bug #2 (#2622 follow-up): "同時播其他的就會一堆聲音" — playingKey was
+  // cleared in `finally` the instant speakText() returned (long before the
+  // audio finishes), so every button re-enabled while the previous clip was
+  // still playing and a second click layered a second <audio> on top with
+  // nothing stopping the first. Mutation target: remove the `stopTts()` call
+  // at the top of playLesson and this goes red — mockStopTts is never
+  // called, and both lessons' text reach speakText with no stop in between.
+  it('starting a second playback stops the first before speaking the new one', async () => {
+    const { rerender } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const rowA = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    const rowB = screen.getByText('閱讀策略練習').closest('[role="row"]') as HTMLElement;
+
+    const callOrder: string[] = [];
+    mockSpeakText.mockImplementation((text: string) => callOrder.push(`speak:${text}`));
+    mockStopTts.mockImplementation(() => callOrder.push('stop'));
+
+    fireEvent.click(within(rowA).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+
+    // Row A's audio is now "playing" as far as the hook is concerned — this
+    // is the exact moment a second click used to layer more audio on top,
+    // because the old code had already cleared its local playingKey and
+    // re-enabled every button well before this point.
+    mockTts({ isTtsSpeaking: true });
+    rerender(<LessonAudioTable />);
+
+    fireEvent.click(within(rowB).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(2));
+
+    // playLesson calls stopTts() defensively before *every* play attempt
+    // (the leading 'stop' below is that no-op on the very first click, when
+    // nothing was playing yet); what this test actually guards is the
+    // second 'stop', which lands between the two speak calls — i.e. lesson
+    // 1's playback is stopped before lesson 89's text is ever spoken.
+    expect(callOrder).toEqual(['stop', 'speak:lesson-1-text', 'stop', 'speak:lesson-89-text']);
+  });
+
+  // A newer selection must win even if the *older* selection's detail fetch
+  // resolves later (out-of-order network responses) — otherwise switching
+  // rows quickly could still start the stale lesson's audio after the new
+  // one, re-creating the overlap bug through a different path than the
+  // direct "click while already speaking" case above.
+  it('ignores a stale detail-fetch response for a lesson that is no longer selected', async () => {
+    const pending: Record<number, ReturnType<typeof deferred<unknown>>> = {
+      1: deferred(),
+      89: deferred(),
+    };
+    mockFetchDispatcher((id) => pending[id].promise);
+
+    render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const rowA = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    const rowB = screen.getByText('閱讀策略練習').closest('[role="row"]') as HTMLElement;
+
+    fireEvent.click(within(rowA).getByRole('button', { name: /播放全文/ }));
+    fireEvent.click(within(rowB).getByRole('button', { name: /播放全文/ }));
+
+    // Resolve the *older* request (lesson 1) after the newer one (lesson 89)
+    // has already been selected.
+    pending[1].resolve({ paragraphs: ['lesson-1-text'] });
+    pending[89].resolve({ paragraphs: ['lesson-89-text'] });
+
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+    expect(mockSpeakText).toHaveBeenCalledWith('lesson-89-text');
+    expect(mockSpeakText).not.toHaveBeenCalledWith('lesson-1-text');
+  });
+
+  // The list-loading error screen (a full-page "載入失敗" replacement) and a
+  // playback failure are different failure modes — a TTS/network error while
+  // synthesising must not blow away the whole table.
+  it('shows a playback error without replacing the loaded table', async () => {
+    mockFetchDispatcher((id) => {
+      if (id === 1) return Promise.reject(new Error('TTS 服務逾時'));
+      return { paragraphs: [`lesson-${id}-text`] };
+    });
+
+    render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const rowA = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(rowA).getByRole('button', { name: /播放全文/ }));
+
+    await waitFor(() => expect(screen.getByText(/TTS 服務逾時/)).toBeTruthy());
+    // The table itself must still be there — this is not the full-page error state.
+    expect(screen.getByText('閱讀策略練習')).toBeTruthy();
+    expect(mockSpeakText).not.toHaveBeenCalled();
+  });
+});
+
+describe('derivePlaybackState', () => {
+  const KEY = '1:full';
+
+  it('is idle when this key is not the one currently targeted', () => {
+    expect(derivePlaybackState(KEY, null, false, false, false)).toBe('idle');
+    expect(derivePlaybackState(KEY, '2:full', false, true, true)).toBe('idle');
+  });
+
+  it('is working while the lesson detail fetch is in flight', () => {
+    expect(derivePlaybackState(KEY, KEY, /* isFetchingDetail */ true, false, false)).toBe('working');
+  });
+
+  it('is working while the hook is loading audio (post-detail, pre-first-byte)', () => {
+    expect(derivePlaybackState(KEY, KEY, false, /* isTtsLoading */ true, false)).toBe('working');
+  });
+
+  it('is playing once the hook reports audio is actually speaking', () => {
+    expect(derivePlaybackState(KEY, KEY, false, false, /* isTtsSpeaking */ true)).toBe('playing');
+    // Speaking takes precedence even if isTtsLoading has not yet flipped off.
+    expect(derivePlaybackState(KEY, KEY, false, true, true)).toBe('playing');
+  });
+
+  it('returns to idle on its own once playback finishes naturally, with no explicit reset', () => {
+    // This is the state after a clip ends by itself: activeKey is still this
+    // key (nothing told the component to clear it), but both hook flags have
+    // dropped back to false — the row must not get stuck showing "working".
+    expect(derivePlaybackState(KEY, KEY, false, false, false)).toBe('idle');
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Download, Loader2, Play, QrCode, Square } from 'lucide-react';
 // Static, top-level, literal specifier — this is what makes Vite bundle the
 // library. Do not turn this back into a dynamic import with the module name in
@@ -46,6 +46,57 @@ function getAuthHeaders(token: string | null | undefined): Record<string, string
 
 function lessonTitle(story: StoryListItem): string {
   return `L${String(story.lesson_number).padStart(2, '0')}`;
+}
+
+export type PlaybackState = 'idle' | 'working' | 'playing';
+
+/**
+ * Pure derivation of a single row-button's playback state.
+ *
+ * `activeKey` is this component's own record of which `{storyId}:{mode}` it
+ * last targeted; `isFetchingDetail` covers the pre-audio `/api/stories/{id}`
+ * round trip (this component's own state); `isTtsLoading`/`isTtsSpeaking`
+ * come straight from useTtsPlayback and reflect what the browser's actual
+ * <audio> element (or Web Speech fallback) is really doing.
+ *
+ * `working` covers both the detail fetch and the hook's isTtsLoading window
+ * (speakText() called, no audio byte yet) — from the user's point of view
+ * both look identical (a spinner, no sound), so they are not split further.
+ * `playing` only becomes true once the hook confirms audio is flowing.
+ *
+ * Deliberately reads BOTH isTtsLoading and isTtsSpeaking rather than just the
+ * latter: once a clip finishes naturally (or errors, or is stopped) the hook
+ * drives both back to false on its own, and this function then falls through
+ * to 'idle' even though `activeKey` still equals `key` — nothing has to
+ * remember to reset activeKey for that to happen. Losing either read would
+ * either flash 'idle' during the detail fetch (the original "dead button"
+ * complaint) or strand a finished row showing 'working' forever.
+ */
+export function derivePlaybackState(
+  key: string,
+  activeKey: string | null,
+  isFetchingDetail: boolean,
+  isTtsLoading: boolean,
+  isTtsSpeaking: boolean,
+): PlaybackState {
+  if (activeKey !== key) return 'idle';
+  if (isTtsSpeaking) return 'playing';
+  return isFetchingDetail || isTtsLoading ? 'working' : 'idle';
+}
+
+interface PlaybackButtonContent {
+  icon: React.ReactNode;
+  label: string;
+}
+
+function playbackButtonContent(state: PlaybackState, idleLabel: string): PlaybackButtonContent {
+  if (state === 'working') {
+    return { icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />, label: '準備中…' };
+  }
+  if (state === 'playing') {
+    return { icon: <Square className="h-3.5 w-3.5" />, label: '停止' };
+  }
+  return { icon: <Play className="h-3.5 w-3.5" />, label: idleLabel };
 }
 
 function detailToFullText(detail: StoryDetailResponse): string {
@@ -128,8 +179,24 @@ const LessonAudioTable: React.FC = () => {
   const [stories, setStories] = useState<StoryListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
-  const [playingKey, setPlayingKey] = useState<string | null>(null);
-  const { speakText, stopPlayback, isTtsLoading } = useTtsPlayback(() => {}, () => {});
+  // Playback failures (TTS backend down, empty audio, etc.) are a different
+  // failure mode from "the lesson list failed to load" — the latter replaces
+  // this whole view with a full-page retry screen (see `error` below), which
+  // must not happen just because one row's synthesis failed.
+  const [playbackError, setPlaybackError] = useState('');
+  // Which `{storyId}:{mode}` this component last targeted. Distinct from the
+  // hook's isTtsLoading/isTtsSpeaking (see derivePlaybackState above) because
+  // those two only turn on *after* speakText() is called — activeKey also
+  // covers the `/api/stories/{id}` round trip that happens before that.
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [isFetchingDetail, setIsFetchingDetail] = useState(false);
+  // Guards against an old click's detail-fetch response landing after a
+  // newer click has already moved on to a different lesson (out-of-order
+  // network responses) — without this, switching rows quickly could still
+  // start the *stale* lesson's audio after the new one, re-creating the
+  // overlap bug through a different path than "click while already playing".
+  const activeRequestRef = useRef(0);
+  const { speakText, stopTts, isTtsLoading, isTtsSpeaking, ttsError } = useTtsPlayback(() => {}, () => {});
 
   const sortedStories = useMemo(
     () => [...stories].sort((a, b) => a.lesson_number - b.lesson_number),
@@ -149,20 +216,48 @@ const LessonAudioTable: React.FC = () => {
     }
   }, [token]);
 
+  // Surface a failure from *inside* speakText's own pipeline (e.g. the TTS
+  // backend itself errors after the detail fetch already succeeded) as the
+  // same inline banner a detail-fetch failure uses, instead of leaving the
+  // row silently drop back to idle with no explanation.
+  useEffect(() => {
+    if (ttsError) setPlaybackError(ttsError);
+  }, [ttsError]);
+
+  const stopCurrentPlayback = useCallback(() => {
+    activeRequestRef.current += 1;
+    stopTts();
+    setActiveKey(null);
+    setIsFetchingDetail(false);
+  }, [stopTts]);
+
   const playLesson = useCallback(async (story: StoryListItem, mode: AudioMode) => {
     const key = `${story.id}:${mode}`;
-    setPlayingKey(key);
+    const requestId = ++activeRequestRef.current;
+    // Always stop whatever is currently loading/playing *first*. The hook's
+    // single-shot playback path (used here, since no lessonId/paragraphIdx is
+    // passed) has no built-in "only one clip at a time" guard: calling
+    // speakText() again does not stop a previous single-shot <audio> that is
+    // still playing. Without this line, a second click just layers a second
+    // <audio> on top of the first (the reported "同時播其他的就會一堆聲音").
+    stopTts();
+    setActiveKey(key);
+    setIsFetchingDetail(true);
+    setPlaybackError('');
     try {
       const detail = await fetchStoryDetail(story.id, token);
+      if (activeRequestRef.current !== requestId) return; // superseded by a later click
       const fullText = detailToFullText(detail);
       const text = mode === 'key' ? (detail.key_reading?.passage || fullText) : fullText;
+      setIsFetchingDetail(false);
       speakText(text);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setPlayingKey(null);
+      if (activeRequestRef.current !== requestId) return;
+      setIsFetchingDetail(false);
+      setActiveKey(null);
+      setPlaybackError(err instanceof Error ? err.message : String(err));
     }
-  }, [speakText, token]);
+  }, [speakText, stopTts, token]);
 
   useEffect(() => {
     loadStories();
@@ -205,6 +300,8 @@ const LessonAudioTable: React.FC = () => {
     );
   }
 
+  const hasActivePlayback = activeKey !== null;
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-gray-200 bg-white px-4 py-2.5">
@@ -212,13 +309,20 @@ const LessonAudioTable: React.FC = () => {
         <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-500">{sortedStories.length} 課</span>
         <button
           type="button"
-          onClick={stopPlayback}
-          className="ml-auto inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+          onClick={stopCurrentPlayback}
+          disabled={!hasActivePlayback}
+          className="ml-auto inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Square className="h-3.5 w-3.5" />
           停止播放
         </button>
       </div>
+
+      {playbackError && (
+        <div className="shrink-0 border-b border-red-100 bg-red-50 px-4 py-2 text-xs text-red-700">
+          播放失敗：{playbackError}
+        </div>
+      )}
 
       <div className="grid grid-cols-[minmax(220px,1.5fr)_minmax(112px,0.7fr)_minmax(168px,0.9fr)_minmax(120px,0.6fr)_minmax(120px,0.6fr)] items-center gap-3 border-b border-gray-200 bg-gray-50 px-4 py-2 text-xs font-medium text-gray-500" role="row">
         <span>課程</span>
@@ -229,51 +333,67 @@ const LessonAudioTable: React.FC = () => {
       </div>
 
       <div className="flex-1 overflow-y-auto" role="grid" aria-label="課程音檔總表">
-        {sortedStories.map((story) => (
-          <div
-            key={story.id}
-            role="row"
-            className="grid grid-cols-[minmax(220px,1.5fr)_minmax(112px,0.7fr)_minmax(168px,0.9fr)_minmax(120px,0.6fr)_minmax(120px,0.6fr)] items-center gap-3 border-b border-gray-100 px-4 py-3 text-sm [content-visibility:auto] [contain-intrinsic-size:64px]"
-          >
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600">
-                  {lessonTitle(story)}
-                </span>
-                <span className="truncate font-medium text-gray-900">{story.title}</span>
-              </div>
-              <div className="mt-1 text-xs text-gray-400">{story.grade} 年級 · {story.grade_code}</div>
-            </div>
+        {sortedStories.map((story) => {
+          const fullKey = `${story.id}:full`;
+          const keyKey = `${story.id}:key`;
+          const fullState = derivePlaybackState(fullKey, activeKey, isFetchingDetail, isTtsLoading, isTtsSpeaking);
+          const keyState = derivePlaybackState(keyKey, activeKey, isFetchingDetail, isTtsLoading, isTtsSpeaking);
+          const fullContent = playbackButtonContent(fullState, '播放全文');
+          const keyContent = playbackButtonContent(keyState, '播放段落');
+          const isRowPlaying = fullState === 'playing' || keyState === 'playing';
 
-            <button
-              type="button"
-              onClick={() => playLesson(story, 'full')}
-              disabled={isTtsLoading || playingKey !== null}
-              className="inline-flex w-fit items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+          return (
+            <div
+              key={story.id}
+              role="row"
+              className={`grid grid-cols-[minmax(220px,1.5fr)_minmax(112px,0.7fr)_minmax(168px,0.9fr)_minmax(120px,0.6fr)_minmax(120px,0.6fr)] items-center gap-3 border-b border-gray-100 px-4 py-3 text-sm [content-visibility:auto] [contain-intrinsic-size:64px] ${isRowPlaying ? 'bg-blue-50' : ''}`}
             >
-              {playingKey === `${story.id}:full` ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-              播放全文
-            </button>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600">
+                    {lessonTitle(story)}
+                  </span>
+                  <span className="truncate font-medium text-gray-900">{story.title}</span>
+                </div>
+                <div className="mt-1 text-xs text-gray-400">{story.grade} 年級 · {story.grade_code}</div>
+              </div>
 
-            <div className="flex flex-wrap items-center gap-2">
+              {/*
+                No `disabled` gate tied to other rows/keys here on purpose:
+                being unable to switch clips is its own annoyance. Clicking a
+                *different* row/mode always just switches (playLesson calls
+                stopTts() first); clicking *this same* button while it is
+                already working/playing stops it instead of restarting it —
+                this row's own control is the primary way to stop it.
+              */}
               <button
                 type="button"
-                onClick={() => playLesson(story, 'key')}
-                disabled={isTtsLoading || playingKey !== null}
-                className="inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+                onClick={() => (fullState === 'idle' ? playLesson(story, 'full') : stopCurrentPlayback())}
+                className="inline-flex w-fit items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50"
               >
-                {playingKey === `${story.id}:key` ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-                播放段落
+                {fullContent.icon}
+                {fullContent.label}
               </button>
-              {!story.has_key_reading && (
-                <span className="text-xs text-amber-700">無重點段（唸全文）</span>
-              )}
-            </div>
 
-            <QrDownloadButton lessonId={story.id} step="intro" label="下載" filePrefix="intro-qr" />
-            <QrDownloadButton lessonId={story.id} step="full-reading" label="下載" filePrefix="full-reading-qr" />
-          </div>
-        ))}
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => (keyState === 'idle' ? playLesson(story, 'key') : stopCurrentPlayback())}
+                  className="inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                >
+                  {keyContent.icon}
+                  {keyContent.label}
+                </button>
+                {!story.has_key_reading && (
+                  <span className="text-xs text-amber-700">無重點段（唸全文）</span>
+                )}
+              </div>
+
+              <QrDownloadButton lessonId={story.id} step="intro" label="下載" filePrefix="intro-qr" />
+              <QrDownloadButton lessonId={story.id} step="full-reading" label="下載" filePrefix="full-reading-qr" />
+            </div>
+          );
+        })}
         {sortedStories.length === 0 && (
           <div className="px-4 py-12 text-center text-sm text-gray-400">沒有課程資料</div>
         )}


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Young 打開後台一分鐘內就撞到：

> 1. 不能停止
> 2. 同時播其他的就會一堆聲音啊

## 根因（兩個是同一行）

```js
speakText(text);        // fire-and-forget，音檔還在播就 return
} finally {
  setPlayingKey(null);  // ← 在「開始播」的當下就清掉
}
```

`playingKey` 是所有按鈕 `disabled` 的依據，它在播放開始的瞬間歸零 → 全部重新啟用 →
再點就疊上去，而且沒有任何東西去停前一個。頂端的停止鈕也沒有元件狀態可以還原。

元件自己維護 `playingKey`，但它用的 hook 早就有真實狀態 `isTtsSpeaking`，只是沒被讀。

## 修法

播放狀態改由 `useTtsPlayback` 的 `isTtsSpeaking` / `isTtsLoading` 經純函式
`derivePlaybackState()` 推導。副作用是：clip 自然播完時 hook 自己把兩個 flag 歸零，
該列自動回到 idle —— 不需要任何人記得去 reset。

- 開始播新的會先停掉當前的
- 播放中那列的按鈕自己變成停止鍵，不用跑去頂端找
- 「準備中」與「播放中」分開顯示（沒快取的課要等約 10 秒才出聲，先前那 10 秒看起來跟按鈕壞掉一樣）

## 驗證

```
vitest（本檔）    15 passed
mutation          強迫 derivePlaybackState 永不回報 'playing' → 3 紅；還原 → 15 綠
lint              0 errors
CI 那條命令       30 passed
```

mutation 是重點：測試會因為改壞而紅，代表它在**測這個修正**，不是在描述它。

回歸鎖已釘進 `frontend-checks.yml` 的具名清單 —— 那個 workflow 只跑指名的檔，沒釘等於沒跑。

## 已知既有失敗

`Frontend npm audit` / `Audit summary` 在 `staging` 本身就 fail，7 個 transitive 依賴漏洞
（undici / react-router / postcss / nanoid / js-yaml / brace-expansion），本 PR 前後清單一字不差。

## 尚未做

真瀏覽器實測。本機 dev server 的後端指向沒設對（CORS），為了不拖時間改成 **merge 後直接在 staging 驗**。

相關：#2625（免登入播放頁）· #2626（G8-9 全文不一致）· #2627（整段合成延遲）