### PR TITLE
fix(#2622): 停止要真的讓聲音停，不能只把按鈕變回去

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -71,7 +71,12 @@ function deferred<T>() {
 }
 
 /** Sets the mocked useTtsPlayback() return value for the next render. */
-function mockTts(overrides: { isTtsLoading?: boolean; isTtsSpeaking?: boolean; ttsError?: string | null } = {}) {
+function mockTts(overrides: {
+  isTtsLoading?: boolean;
+  isTtsSpeaking?: boolean;
+  ttsError?: string | null;
+  utteranceRef?: { current: unknown };
+} = {}) {
   vi.mocked(useTtsPlayback).mockReturnValue({
     isTtsSpeaking: overrides.isTtsSpeaking ?? false,
     isTtsPaused: false,
@@ -80,7 +85,7 @@ function mockTts(overrides: { isTtsLoading?: boolean; isTtsSpeaking?: boolean; t
     isTtsDegraded: false,
     setIsTtsSpeaking: vi.fn(),
     setIsTtsPaused: vi.fn(),
-    utteranceRef: { current: null },
+    utteranceRef: overrides.utteranceRef ?? { current: null },
     ttsRafRef: { current: null },
     speakText: mockSpeakText,
     pauseTts: vi.fn(),
@@ -343,5 +348,46 @@ describe('derivePlaybackState', () => {
     // key (nothing told the component to clear it), but both hook flags have
     // dropped back to false — the row must not get stuck showing "working".
     expect(derivePlaybackState(KEY, KEY, false, false, false)).toBe('idle');
+  });
+});
+
+describe('#2622 stop must actually silence the audio, not just the UI', () => {
+  /**
+   * Measured on staging 2026-08-08, after the first attempt at this fix:
+   * clicking a playing row's own stop control flipped the button back to
+   * 「播放全文」while the clip kept going — currentTime advanced 13s → 18s → 41s
+   * across two clicks. Worse than the bug it replaced, because the screen then
+   * asserts something false.
+   *
+   * stopTts() reaches the clip through utteranceRef / the ttsApi module's
+   * _currentAudio, and on the single-shot path there is a window where neither
+   * points at the element that is actually sounding. The component therefore
+   * pauses utteranceRef.current itself. Removing that direct pause turns this
+   * red no matter how correct the surrounding state handling looks.
+   */
+  it('pauses the audio element the hook is holding', async () => {
+    const audio = document.createElement('audio');
+    const pauseSpy = vi.spyOn(audio, 'pause');
+
+    vi.clearAllMocks();
+    mockFetchDispatcher();
+    mockTts({ utteranceRef: { current: audio } });
+
+    const { rerender } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+
+    // The browser has now fired `onplay`, so the hook reports audio flowing.
+    mockTts({ isTtsSpeaking: true, utteranceRef: { current: audio } });
+    rerender(<LessonAudioTable />);
+
+    pauseSpy.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /停止播放/ }));
+
+    expect(pauseSpy).toHaveBeenCalled();
+    expect(audio.currentTime).toBe(0);
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -196,7 +196,7 @@ const LessonAudioTable: React.FC = () => {
   // start the *stale* lesson's audio after the new one, re-creating the
   // overlap bug through a different path than "click while already playing".
   const activeRequestRef = useRef(0);
-  const { speakText, stopTts, isTtsLoading, isTtsSpeaking, ttsError } = useTtsPlayback(() => {}, () => {});
+  const { speakText, stopTts, isTtsLoading, isTtsSpeaking, ttsError, utteranceRef } = useTtsPlayback(() => {}, () => {});
 
   const sortedStories = useMemo(
     () => [...stories].sort((a, b) => a.lesson_number - b.lesson_number),
@@ -227,9 +227,29 @@ const LessonAudioTable: React.FC = () => {
   const stopCurrentPlayback = useCallback(() => {
     activeRequestRef.current += 1;
     stopTts();
+    // Belt and braces: pause the element directly as well.
+    //
+    // Measured on staging 2026-08-08 — clicking this row's own stop control
+    // flipped the UI back to idle while the audio kept going, currentTime
+    // advancing 13s → 18s → 41s across two clicks. Which is worse than the
+    // original bug: the screen now claims it stopped.
+    //
+    // stopTts() reaches the clip through utteranceRef / the ttsApi module's
+    // _currentAudio, and on this single-shot path there is a window where
+    // neither points at the element that is actually sounding. The hook hands
+    // utteranceRef back to us, so pausing it here closes that window without
+    // touching the shared hook (which every student reading step also uses).
+    // Duck-typed rather than `instanceof HTMLAudioElement`: the ref also holds
+    // SpeechSynthesisUtterance on the fallback path, and an instanceof check
+    // depends on which realm the element came from.
+    const el = utteranceRef.current as { pause?: () => void; currentTime?: number } | null;
+    if (el && typeof el.pause === 'function') {
+      el.pause();
+      el.currentTime = 0;
+    }
     setActiveKey(null);
     setIsFetchingDetail(false);
-  }, [stopTts]);
+  }, [stopTts, utteranceRef]);
 
   const playLesson = useCallback(async (story: StoryListItem, mode: AudioMode) => {
     const key = `${story.id}:${mode}`;


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

接續 PR #2628。上一版把疊音修好了，停止只修了一半 —— 在 staging 實測抓到。

## 實測到的

```
列內停止鈕   按兩次都無效   currentTime 13s → 18s → 41s 持續前進，按鈕卻變回「播放全文」
頂端停止播放  有效          paused=true, currentTime=0
```

比原本的 bug 更糟：畫面說停了，聲音沒停。上一版之所以看起來像修好，是因為我先按到頂端那顆。

## 根因

`stopTts()` 透過 `utteranceRef` 或 ttsApi 模組內的 `_currentAudio` 去碰音檔。
這個元件走的是單次整段播放路徑，存在一個空窗期 —— 兩個 ref 都沒指向真正在發聲的元素。

hook 本來就有把 `utteranceRef` 回傳出來，所以元件自己再 pause 一次即可，
**不必動共用的 `useTtsPlayback`**（學生端每一個朗讀步驟都靠它）。

判斷式用鴨子型別而非 `instanceof HTMLAudioElement` —— 那個 ref 在 fallback 路徑上
會是 `SpeechSynthesisUtterance`，而 instanceof 還取決於元素來自哪個 realm。

## 驗證

```
vitest（本檔）  14 passed
mutation        把守衛換成 if (false) → 1 紅；還原 → 14 綠
lint            0 errors
CI 那條命令     30 passed
```

## 寫這條測試本身的教訓（已寫進 commit message）

第一版測試沒有先按播放就直接按停止，而頂端控制項在沒有 active 項目時是 disabled，
所以 handler 根本沒執行 —— 測試失敗的原因跟被測的程式碼完全無關。
是靠一行印出呼叫次數的 debug 才分辨出「修正無效」與「我的測試沒打到」。

## 尚未做

merge 後要在 staging 重跑一次實測（播 A → 播 B 斷言只有一個在播；按列內停止斷言 paused=true）。