### PR TITLE
fix(#2622): 停止 — 改成追蹤音檔元素本身（第三次）

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -15,6 +15,12 @@ vi.mock('../../../hooks/useTtsPlayback', () => ({
   useTtsPlayback: vi.fn(),
 }));
 
+// jsdom has no media playback; give the prototype a resolvable no-op so the
+// component's play() patch has something real to delegate to.
+if (!HTMLMediaElement.prototype.play.toString().includes('patchedPlay')) {
+  HTMLMediaElement.prototype.play = function () { return Promise.resolve(); };
+}
+
 vi.mock('qrcode', () => ({
   default: {
     toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,test'),
@@ -353,25 +359,27 @@ describe('derivePlaybackState', () => {
 
 describe('#2622 stop must actually silence the audio, not just the UI', () => {
   /**
-   * Measured on staging 2026-08-08, after the first attempt at this fix:
-   * clicking a playing row's own stop control flipped the button back to
-   * 「播放全文」while the clip kept going — currentTime advanced 13s → 18s → 41s
-   * across two clicks. Worse than the bug it replaced, because the screen then
-   * asserts something false.
+   * Measured on staging 2026-08-08: clicking stop flipped the button back to
+   * 「播放全文」while the clip kept going, currentTime advancing 13s → 18s → 41s.
+   * Worse than the bug it replaced, because the screen then asserts something
+   * false.
    *
-   * stopTts() reaches the clip through utteranceRef / the ttsApi module's
-   * _currentAudio, and on the single-shot path there is a window where neither
-   * points at the element that is actually sounding. The component therefore
-   * pauses utteranceRef.current itself. Removing that direct pause turns this
-   * red no matter how correct the surrounding state handling looks.
+   * Two earlier fixes aimed at handles the TTS layer exposes — utteranceRef and
+   * ttsApi's _currentAudio — and both still missed the element that was
+   * sounding. So the component now records the elements themselves, by patching
+   * HTMLMediaElement.prototype.play while it is mounted. That the technique
+   * reaches and stops the real element was verified in a browser on staging:
+   * an element at p:false t:13 went to p:true t:0 and stayed there.
+   *
+   * This test drives that patch directly with a stub element rather than trying
+   * to make jsdom play audio — jsdom has no playback, and three attempts to
+   * simulate it failed for reasons that had nothing to do with the code under
+   * test.
    */
-  it('pauses the audio element the hook is holding', async () => {
-    const audio = document.createElement('audio');
-    const pauseSpy = vi.spyOn(audio, 'pause');
-
+  it('pauses every element that started playing while the panel was open', async () => {
     vi.clearAllMocks();
     mockFetchDispatcher();
-    mockTts({ utteranceRef: { current: audio } });
+    mockTts();
 
     const { rerender } = render(<LessonAudioTable />);
     await waitFor(() => screen.getByText('贏得喝采的輸家'));
@@ -380,14 +388,23 @@ describe('#2622 stop must actually silence the audio, not just the UI', () => {
     fireEvent.click(within(row).getByRole('button', { name: /播放全文/ }));
     await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
 
-    // The browser has now fired `onplay`, so the hook reports audio flowing.
-    mockTts({ isTtsSpeaking: true, utteranceRef: { current: audio } });
+    // Stand in for the <audio> the TTS layer creates: never in the document,
+    // reachable only because the component patched the prototype's play().
+    let paused = false;
+    const pause = vi.fn(() => { paused = true; });
+    const clip = {
+      get paused() { return paused; },
+      currentTime: 42,
+      pause,
+    } as unknown as HTMLMediaElement;
+    HTMLMediaElement.prototype.play.call(clip);
+
+    mockTts({ isTtsSpeaking: true });
     rerender(<LessonAudioTable />);
 
-    pauseSpy.mockClear();
     fireEvent.click(screen.getByRole('button', { name: /停止播放/ }));
 
-    expect(pauseSpy).toHaveBeenCalled();
-    expect(audio.currentTime).toBe(0);
+    expect(pause).toHaveBeenCalled();
+    expect(clip.currentTime).toBe(0);
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -189,6 +189,12 @@ const LessonAudioTable: React.FC = () => {
   // those two only turn on *after* speakText() is called — activeKey also
   // covers the `/api/stories/{id}` round trip that happens before that.
   const [activeKey, setActiveKey] = useState<string | null>(null);
+  // Every <audio> that has actually started playing while this panel is open.
+  // Filled by the play() patch in the effect below; drained by
+  // stopCurrentPlayback. The elements are created inside the TTS layer and are
+  // never attached to the document, so querySelectorAll cannot find them —
+  // patching play() is the only way to get a handle on them.
+  const startedAudioRef = useRef<Set<HTMLMediaElement>>(new Set());
   const [isFetchingDetail, setIsFetchingDetail] = useState(false);
   // Guards against an old click's detail-fetch response landing after a
   // newer click has already moved on to a different lesson (out-of-order
@@ -196,7 +202,7 @@ const LessonAudioTable: React.FC = () => {
   // start the *stale* lesson's audio after the new one, re-creating the
   // overlap bug through a different path than "click while already playing".
   const activeRequestRef = useRef(0);
-  const { speakText, stopTts, isTtsLoading, isTtsSpeaking, ttsError, utteranceRef } = useTtsPlayback(() => {}, () => {});
+  const { speakText, stopTts, isTtsLoading, isTtsSpeaking, ttsError } = useTtsPlayback(() => {}, () => {});
 
   const sortedStories = useMemo(
     () => [...stories].sort((a, b) => a.lesson_number - b.lesson_number),
@@ -239,17 +245,29 @@ const LessonAudioTable: React.FC = () => {
     // neither points at the element that is actually sounding. The hook hands
     // utteranceRef back to us, so pausing it here closes that window without
     // touching the shared hook (which every student reading step also uses).
-    // Duck-typed rather than `instanceof HTMLAudioElement`: the ref also holds
-    // SpeechSynthesisUtterance on the fallback path, and an instanceof check
-    // depends on which realm the element came from.
-    const el = utteranceRef.current as { pause?: () => void; currentTime?: number } | null;
-    if (el && typeof el.pause === 'function') {
-      el.pause();
-      el.currentTime = 0;
-    }
+    // Pause every element that has actually played while this panel was open.
+    //
+    // Three attempts reached staging before this one, and each failed the same
+    // way: currentTime kept advancing while the button showed idle. stopTts()
+    // reaches the clip through utteranceRef, and cancelTts() through ttsApi's
+    // module-level _currentAudio — measured on staging, neither of them is
+    // holding the element that is actually sounding by the time the user
+    // clicks stop, so both pause something else and report success.
+    //
+    // Rather than keep guessing which handle is the live one, track the
+    // elements themselves. startedAudioRef is filled by the play() patch
+    // installed in the effect below, which is the same technique that proved
+    // in the browser that these elements are reachable and pausable.
+    startedAudioRef.current.forEach((el) => {
+      if (!el.paused) {
+        el.pause();
+        el.currentTime = 0;
+      }
+    });
+    startedAudioRef.current.clear();
     setActiveKey(null);
     setIsFetchingDetail(false);
-  }, [stopTts, utteranceRef]);
+  }, [stopTts]);
 
   const playLesson = useCallback(async (story: StoryListItem, mode: AudioMode) => {
     const key = `${story.id}:${mode}`;
@@ -278,6 +296,20 @@ const LessonAudioTable: React.FC = () => {
       setPlaybackError(err instanceof Error ? err.message : String(err));
     }
   }, [speakText, stopTts, token]);
+
+  useEffect(() => {
+    const started = startedAudioRef.current;
+    const originalPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function patchedPlay(this: HTMLMediaElement, ...args) {
+      started.add(this);
+      return originalPlay.apply(this, args);
+    };
+    return () => {
+      HTMLMediaElement.prototype.play = originalPlay;
+      started.forEach((el) => { if (!el.paused) el.pause(); });
+      started.clear();
+    };
+  }, []);
 
   useEffect(() => {
     loadStories();


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

接 #2628 #2629。停止這條前兩次都沒修好，staging 實測 `currentTime` 13s → 18s → 41s 持續前進。

## 為什麼前兩次會失敗

元素在 `ttsApi` 的 `playAudioUrl` 用 `new Audio()` 生成、存進模組層的 `_currentAudio`，
而它在 `onended` 與 `cancelTts` 時被清成 null。**在這些交接之間存在空窗**，
元件拿得到的那個變數不是正在發聲的元素 —— 換哪一個 ref 都補不完。

## 這次的做法

元件掛載期間 patch `HTMLMediaElement.prototype.play`，把每個真的播出去的元素登記起來，
停止時全部 pause。卸載時還原 patch，並停掉還在響的。

**寫 code 之前先在瀏覽器對 staging 驗過這個手法能停得掉**：
元素 `p:false t:13` → pause → `p:true t:0`，5 秒後仍不動。

## 驗證

```
vitest    14 passed
mutation  把集合換成空陣列 → 1 紅；還原 → 14 綠
lint      0 errors
```

## 測試為什麼用假元素

jsdom 沒有媒體播放。前三版測試各自因為與被測程式無關的原因失敗：
helper 名字錯、控制項在沒有 active 項目時是 disabled、以及**實例層的 `play()` spy
蓋掉了元件要 patch 的那個 prototype**。所以改用 stub 直接驅動 patch。

## 尚未做

merge 後在 staging 重測一次列內停止鈕。