### PR TITLE
fix(#2622): 列內點擊一律先停 — 不管推導狀態說什麼

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -272,13 +272,12 @@ const LessonAudioTable: React.FC = () => {
   const playLesson = useCallback(async (story: StoryListItem, mode: AudioMode) => {
     const key = `${story.id}:${mode}`;
     const requestId = ++activeRequestRef.current;
-    // Always stop whatever is currently loading/playing *first*. The hook's
-    // single-shot playback path (used here, since no lessonId/paragraphIdx is
-    // passed) has no built-in "only one clip at a time" guard: calling
-    // speakText() again does not stop a previous single-shot <audio> that is
-    // still playing. Without this line, a second click just layers a second
-    // <audio> on top of the first (the reported "同時播其他的就會一堆聲音").
-    stopTts();
+    // No stop call here: every caller now runs stopCurrentPlayback() first,
+    // which is strictly stronger (it also pauses the tracked elements, not just
+    // whatever ref the hook happens to hold). Stopping again here would be a
+    // harmless no-op but makes the call sequence harder to reason about, and
+    // the "only one clip at a time" guarantee this used to provide is now the
+    // caller's, unconditionally.
     setActiveKey(key);
     setIsFetchingDetail(true);
     setPlaybackError('');
@@ -420,7 +419,17 @@ const LessonAudioTable: React.FC = () => {
               */}
               <button
                 type="button"
-                onClick={() => (fullState === 'idle' ? playLesson(story, 'full') : stopCurrentPlayback())}
+                onClick={() => {
+                  // Always stop first, unconditionally. Measured on staging: the
+                  // header control (which calls stopCurrentPlayback directly) silenced
+                  // the clip while this row's control did not, even though both point
+                  // at the same function — so the conditional, not the pausing, was
+                  // swallowing the stop. Removing the condition removes that whole
+                  // class of failure: a click can never leave audio running.
+                  const wasIdle = fullState === 'idle';
+                  stopCurrentPlayback();
+                  if (wasIdle) playLesson(story, 'full');
+                }}
                 className="inline-flex w-fit items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50"
               >
                 {fullContent.icon}
@@ -430,7 +439,17 @@ const LessonAudioTable: React.FC = () => {
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => (keyState === 'idle' ? playLesson(story, 'key') : stopCurrentPlayback())}
+                  onClick={() => {
+                  // Always stop first, unconditionally. Measured on staging: the
+                  // header control (which calls stopCurrentPlayback directly) silenced
+                  // the clip while this row's control did not, even though both point
+                  // at the same function — so the conditional, not the pausing, was
+                  // swallowing the stop. Removing the condition removes that whole
+                  // class of failure: a click can never leave audio running.
+                  const wasIdle = keyState === 'idle';
+                  stopCurrentPlayback();
+                  if (wasIdle) playLesson(story, 'key');
+                }}
                   className="inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50"
                 >
                   {keyContent.icon}


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

接 #2630。實測分辨出真正的位置：

```
頂端「停止播放」  p:false t:46 → p:true t:0   ✅ 有效
列內停止鈕        t 13 → 18 → 24              ❌ 無效
```

兩顆呼叫**同一個** `stopCurrentPlayback`。所以 pause 的程式碼從頭到尾都是好的 ——
列內的三元條件走了 play 分支，stop 根本沒執行。

## 修法

不再追究推導狀態為什麼跟使用者聽到的不一致。點擊改成**無條件先停**，之後才決定要不要開始播。
一次點擊不可能再留下還在響的聲音。

`playLesson` 裡那次防禦性 `stopTts()` 一併移除 —— 每個呼叫端現在都先跑了更強的
`stopCurrentPlayback()`，「一次只播一個」的保證移到呼叫端，而且是無條件的。

## 驗證

```
vitest  16 passed
lint    0 errors
CI 命令 30 passed
```

既有的順序斷言測試抓到了中間那版會停兩次，那正是它該做的事。