### PR TITLE
feat(#2622): QR 改成 popup 預覽＋下載，加「下載全部 QR + CSV」

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "ai-reading-tutor-frontend",
       "version": "0.2.6",
       "dependencies": {
+        "@types/jszip": "^3.4.0",
         "date-fns": "^4.3.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^1.7.0",
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
@@ -2106,6 +2108,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -2998,6 +3009,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3932,6 +3949,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -3978,6 +4001,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -4064,6 +4093,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4211,6 +4246,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4233,6 +4280,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -4526,6 +4582,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4879,6 +4941,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5055,6 +5123,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -5271,6 +5354,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5310,6 +5399,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -5365,6 +5460,15 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5799,7 +5903,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "@types/jszip": "^3.4.0",
     "date-fns": "^4.3.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.7.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.4",

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
-import LessonAudioTable, { buildLessonQrValue, derivePlaybackState } from './LessonAudioTable';
+import LessonAudioTable, { buildLessonQrValue, buildQrManifestCsv, buildQrManifestRows, derivePlaybackState } from './LessonAudioTable';
 import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 
 vi.mock('../../../contexts/AuthContext', () => ({
@@ -81,7 +81,6 @@ function mockTts(overrides: {
   isTtsLoading?: boolean;
   isTtsSpeaking?: boolean;
   ttsError?: string | null;
-  utteranceRef?: { current: unknown };
 } = {}) {
   vi.mocked(useTtsPlayback).mockReturnValue({
     isTtsSpeaking: overrides.isTtsSpeaking ?? false,
@@ -91,7 +90,7 @@ function mockTts(overrides: {
     isTtsDegraded: false,
     setIsTtsSpeaking: vi.fn(),
     setIsTtsPaused: vi.fn(),
-    utteranceRef: overrides.utteranceRef ?? { current: null },
+    utteranceRef: { current: null },
     ttsRafRef: { current: null },
     speakText: mockSpeakText,
     pauseTts: vi.fn(),
@@ -406,5 +405,37 @@ describe('#2622 stop must actually silence the audio, not just the UI', () => {
 
     expect(pause).toHaveBeenCalled();
     expect(clip.currentTime).toBe(0);
+  });
+});
+
+describe('#2622 QR 交付表 CSV', () => {
+  const stories = [
+    { id: 1, lesson_number: 1, title: '贏得喝采的輸家', grade: 4, grade_code: 'G4-L01', char_count: 100, has_key_reading: true },
+    // A title containing both a comma and a quote — editorial content will
+    // eventually have them, and unquoted CSV silently shifts every later column.
+    { id: 2, lesson_number: 2, title: '他說「快,再快」', grade: 8, grade_code: 'G8-L02', char_count: 90, has_key_reading: false },
+  ];
+
+  it('emits two rows per lesson, 全文 and 段落', () => {
+    const rows = buildQrManifestRows(stories as never, 'https://x.test');
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.kind)).toEqual(['全文', '段落', '全文', '段落']);
+    expect(rows[0].url).toBe('https://x.test/learn/1/intro');
+    expect(rows[1].url).toBe('https://x.test/learn/1/full-reading');
+    expect(rows[0].qr_file).toBe('intro-qr-L01.png');
+    expect(rows[1].qr_file).toBe('full-reading-qr-L01.png');
+  });
+
+  it('quotes fields and leads with a BOM so Excel reads the Chinese correctly', () => {
+    const csv = buildQrManifestCsv(buildQrManifestRows(stories as never, 'https://x.test'));
+
+    expect(csv.startsWith('﻿')).toBe(true);
+    // The comma inside the title must not create a column.
+    expect(csv).toContain('"他說「快,再快」"');
+    // Every line has the same field count as the header.
+    const lines = csv.replace(/^﻿/, '').trimEnd().split('\r\n');
+    const fieldCount = (line: string) => (line.match(/","/g) ?? []).length + 1;
+    expect(new Set(lines.map(fieldCount)).size).toBe(1);
+    expect(lines).toHaveLength(5); // header + 4 rows
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -38,6 +38,7 @@ interface QrButtonProps {
   step: LessonQrStep;
   label: string;
   filePrefix: string;
+  lessonTitle: string;
 }
 
 function getAuthHeaders(token: string | null | undefined): Record<string, string> {
@@ -143,34 +144,157 @@ async function qrCodeToDataUrl(value: string): Promise<string> {
   });
 }
 
-const QrDownloadButton: React.FC<QrButtonProps> = ({ lessonId, step, label, filePrefix }) => {
-  const [isGenerating, setIsGenerating] = useState(false);
+export interface QrManifestRow {
+  lesson_id: number;
+  lesson_no: string;
+  title: string;
+  grade: number;
+  kind: '全文' | '段落';
+  url: string;
+  qr_file: string;
+}
 
-  const downloadQr = useCallback(async () => {
+/**
+ * The index the 教材端 pastes alongside the images.
+ *
+ * RFC-4180 quoting throughout, not just where it currently matters — lesson
+ * titles are editorial content and will eventually contain a comma or a quote.
+ * A BOM leads the file so Excel on Windows opens the Chinese as UTF-8 instead
+ * of mojibake, which is the single most common way a correct CSV still arrives
+ * broken.
+ */
+export function buildQrManifestCsv(rows: QrManifestRow[]): string {
+  const esc = (v: string | number) => `"${String(v).replace(/"/g, '""')}"`;
+  const header = ['lesson_id', 'lesson_no', 'title', 'grade', 'kind', 'url', 'qr_file'];
+  const lines = [header.map(esc).join(',')];
+  for (const r of rows) {
+    lines.push([r.lesson_id, r.lesson_no, r.title, r.grade, r.kind, r.url, r.qr_file].map(esc).join(','));
+  }
+  return `\uFEFF${lines.join('\r\n')}\r\n`;
+}
+
+export function buildQrManifestRows(stories: StoryListItem[], origin: string): QrManifestRow[] {
+  const rows: QrManifestRow[] = [];
+  for (const s of stories) {
+    rows.push({
+      lesson_id: s.id, lesson_no: lessonTitle(s), title: s.title, grade: s.grade,
+      kind: '全文', url: buildLessonQrValue(origin, s.id, 'intro'),
+      qr_file: qrFileName('intro-qr', s.id),
+    });
+    rows.push({
+      lesson_id: s.id, lesson_no: lessonTitle(s), title: s.title, grade: s.grade,
+      kind: '段落', url: buildLessonQrValue(origin, s.id, 'full-reading'),
+      qr_file: qrFileName('full-reading-qr', s.id),
+    });
+  }
+  return rows;
+}
+
+export function qrFileName(filePrefix: string, lessonId: number): string {
+  return `${filePrefix}-L${String(lessonId).padStart(2, '0')}.png`;
+}
+
+function triggerDownload(href: string, filename: string): void {
+  const link = document.createElement('a');
+  link.href = href;
+  link.download = filename;
+  link.click();
+}
+
+/**
+ * Preview dialog for one QR code.
+ *
+ * Downloading blind was the previous behaviour and it gives you no way to tell
+ * a correct code from a wrong one until you have already pasted it into a
+ * worksheet and scanned it with a phone. Showing the image and the URL it
+ * encodes turns that into a two-second check.
+ */
+const QrPreviewDialog: React.FC<{
+  title: string;
+  value: string;
+  dataUrl: string;
+  filename: string;
+  onClose: () => void;
+}> = ({ title, value, dataUrl, filename, onClose }) => {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-lg bg-white p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-3 text-sm font-semibold text-gray-800">{title}</h3>
+        <img src={dataUrl} alt={`${title} QR code`} className="mx-auto h-56 w-56" />
+        <p className="mt-3 break-all rounded bg-gray-50 px-2 py-1.5 text-xs text-gray-500">{value}</p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+          >
+            關閉
+          </button>
+          <button
+            type="button"
+            onClick={() => triggerDownload(dataUrl, filename)}
+            className="inline-flex items-center gap-1.5 rounded bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700"
+          >
+            <Download className="h-3.5 w-3.5" />
+            下載 PNG
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const QrDownloadButton: React.FC<QrButtonProps> = ({ lessonId, step, label, filePrefix, lessonTitle: title }) => {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [preview, setPreview] = useState<{ dataUrl: string; value: string } | null>(null);
+
+  const openPreview = useCallback(async () => {
     setIsGenerating(true);
     try {
       const value = buildLessonQrValue(window.location.origin, lessonId, step);
-      const dataUrl = await qrCodeToDataUrl(value);
-      const link = document.createElement('a');
-      link.href = dataUrl;
-      link.download = `${filePrefix}-L${String(lessonId).padStart(2, '0')}.png`;
-      link.click();
+      setPreview({ dataUrl: await qrCodeToDataUrl(value), value });
     } finally {
       setIsGenerating(false);
     }
-  }, [filePrefix, lessonId, step]);
+  }, [lessonId, step]);
 
   return (
-    <button
-      type="button"
-      onClick={downloadQr}
-      disabled={isGenerating}
-      className="inline-flex items-center justify-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
-      title={buildLessonQrValue(window.location.origin, lessonId, step)}
-    >
-      {isGenerating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
-      {label}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={openPreview}
+        disabled={isGenerating}
+        className="inline-flex items-center justify-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60"
+        title={buildLessonQrValue(window.location.origin, lessonId, step)}
+      >
+        {isGenerating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <QrCode className="h-3.5 w-3.5" />}
+        {label}
+      </button>
+      {preview && (
+        <QrPreviewDialog
+          title={`${title}／${step === 'intro' ? '全文' : '段落'}`}
+          value={preview.value}
+          dataUrl={preview.dataUrl}
+          filename={qrFileName(filePrefix, lessonId)}
+          onClose={() => setPreview(null)}
+        />
+      )}
+    </>
   );
 };
 
@@ -229,6 +353,54 @@ const LessonAudioTable: React.FC = () => {
   useEffect(() => {
     if (ttsError) setPlaybackError(ttsError);
   }, [ttsError]);
+
+  const [isZipping, setIsZipping] = useState(false);
+  const [zipProgress, setZipProgress] = useState('');
+
+  /**
+   * One archive with every QR image plus the index that names them.
+   *
+   * The 教材端 pastes these into Word by hand, so downloading 330 files one
+   * click at a time was never going to be the workflow. A CSV cannot carry the
+   * images themselves, hence a zip: index.csv points at qr/<file>.png by the
+   * exact filename that is in the archive.
+   *
+   * Generated in the browser rather than server-side because the QR content is
+   * just this deployment's own origin plus a lesson id — there is nothing to
+   * compute that the page does not already know, and no reason to spend a
+   * backend round trip per lesson.
+   */
+  const downloadAllQrZip = useCallback(async () => {
+    setIsZipping(true);
+    try {
+      const { default: JSZip } = await import('jszip');
+      const zip = new JSZip();
+      const folder = zip.folder('qr');
+      const rows = buildQrManifestRows(sortedStories, window.location.origin);
+
+      for (let i = 0; i < rows.length; i += 1) {
+        const row = rows[i];
+        setZipProgress(`產生 QR ${i + 1}/${rows.length}`);
+        const dataUrl = await qrCodeToDataUrl(row.url);
+        folder?.file(row.qr_file, dataUrl.split(',')[1], { base64: true });
+        // Yield to the event loop so the progress label actually repaints;
+        // 330 synchronous QR renders otherwise freeze the tab with no feedback.
+        if (i % 10 === 0) await new Promise((r) => setTimeout(r, 0));
+      }
+
+      zip.file('index.csv', buildQrManifestCsv(rows));
+      setZipProgress('打包中…');
+      const blob = await zip.generateAsync({ type: 'blob' });
+      const url = URL.createObjectURL(blob);
+      triggerDownload(url, `lesson-qr-${rows.length}.zip`);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setPlaybackError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsZipping(false);
+      setZipProgress('');
+    }
+  }, [sortedStories]);
 
   const stopCurrentPlayback = useCallback(() => {
     activeRequestRef.current += 1;
@@ -360,6 +532,16 @@ const LessonAudioTable: React.FC = () => {
         <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-500">{sortedStories.length} 課</span>
         <button
           type="button"
+          onClick={downloadAllQrZip}
+          disabled={isZipping || sortedStories.length === 0}
+          className="ml-auto inline-flex items-center gap-1.5 rounded border border-violet-200 bg-violet-50 px-2.5 py-1.5 text-xs font-medium text-violet-700 hover:bg-violet-100 disabled:cursor-wait disabled:opacity-60"
+        >
+          {isZipping
+            ? <><Loader2 className="h-3.5 w-3.5 animate-spin" />{zipProgress}</>
+            : <><Download className="h-3.5 w-3.5" />下載全部 QR + CSV</>}
+        </button>
+        <button
+          type="button"
           onClick={stopCurrentPlayback}
           disabled={!hasActivePlayback}
           className="ml-auto inline-flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
@@ -460,8 +642,8 @@ const LessonAudioTable: React.FC = () => {
                 )}
               </div>
 
-              <QrDownloadButton lessonId={story.id} step="intro" label="下載" filePrefix="intro-qr" />
-              <QrDownloadButton lessonId={story.id} step="full-reading" label="下載" filePrefix="full-reading-qr" />
+              <QrDownloadButton lessonId={story.id} step="intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
+              <QrDownloadButton lessonId={story.id} step="full-reading" label="QR" filePrefix="full-reading-qr" lessonTitle={story.title} />
             </div>
           );
         })}

--- a/frontend/src/pages/admin/lesson-audio/qrcode-bundling.test.ts
+++ b/frontend/src/pages/admin/lesson-audio/qrcode-bundling.test.ts
@@ -49,9 +49,15 @@ describe('#2622 qrcode bundling', () => {
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .replace(/^\s*\/\/.*$/gm, '');
 
-    // No dynamic import at all in this module — that is the construct whose
-    // specifier the bundler cannot follow.
-    expect(code).not.toMatch(/\bimport\s*\(/);
+    // The bug was a dynamic import whose specifier the bundler cannot follow —
+    // a variable, not a string literal. `await import('jszip')` is fine and is
+    // used deliberately to keep a 100KB library out of the initial chunk, so
+    // this asserts on the dangerous shape rather than banning dynamic import
+    // outright.
+    const dynamicImports = [...code.matchAll(/\bimport\s*\(\s*([^)]*)\)/g)];
+    for (const [, specifier] of dynamicImports) {
+      expect(specifier.trim()).toMatch(/^['"][^'"]+['"]$/);
+    }
     // A literal top-level specifier is what makes Vite include the library.
     expect(code).toMatch(/^import QRCode from 'qrcode';$/m);
   });


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 兩件

**每列的 QR 改成 popup** —— 點下去顯示圖 + 它編進去的網址 + 下載 PNG。
先前是點了直接下載，你在貼進學習單、拿手機掃之前無從得知那張對不對。

**頂端加「下載全部 QR + CSV」** —— 一次產出整包 ZIP：
每張 QR 的 PNG + 一份 `index.csv` 指名它們，就是需求文件要的交付表格式。
330 個檔案一個一個點不是可行的流程，而 CSV 塞不進圖片，所以打包成 ZIP。

QR 內容只是這個部署的 origin 加課程 id，前端全都知道，所以在瀏覽器產生，
不必為每一課多跑一趟後端。

## CSV 的兩個細節

**每個欄位都加引號** —— 課名是編輯內容，遲早會出現逗號或引號，沒跳脫會讓後面每一欄整個位移。
測試用的課名同時含逗號與引號，拿掉跳脫就紅。

**開頭放 BOM** —— 否則 Windows 的 Excel 會把中文顯示成亂碼。這是「CSV 正確但打開還是壞掉」最常見的原因。

## 回歸鎖的調整

`jszip` 用動態 import，讓 100KB 不進初始 chunk。這需要收斂先前那條打包回歸鎖 ——
它原本禁止任何動態 import，但當初要防的 bug 是**非字面量的 specifier**（bundler 追不到）。
現在改成斷言 specifier 必須是字串字面量。**把 jszip 改成變數 specifier 仍然會紅**。

## 驗證

```
vitest    18 passed
mutation  拿掉 CSV 跳脫 → 紅 ／ jszip 改變數 specifier → 紅 ／ 還原 → 綠
lint      0 errors
CI 命令   30 passed
tsc       本檔 0 error
```