### PR TITLE
fix(#2622): QR 預覽改用 portal — 原本被塞進表格列裡

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -439,3 +439,37 @@ describe('#2622 QR 交付表 CSV', () => {
     expect(lines).toHaveLength(5); // header + 4 rows
   });
 });
+
+describe('#2622 QR 預覽必須蓋在整頁之上', () => {
+  /**
+   * Reported with a screenshot: the QR appeared jammed between two table
+   * columns instead of centred over the page.
+   *
+   * `position: fixed` resolves against the nearest ancestor that establishes a
+   * containing block, and the admin shell has several (transform, contain,
+   * overflow). Rendered in place, the overlay laid itself out inside the row.
+   * No amount of z-index or overflow on the dialog escapes that — it has to be
+   * portalled out.
+   *
+   * Asserting on the DOM position rather than on styles, because the styles
+   * were already correct when it was broken.
+   */
+  it('portals the dialog out of the table and into document.body', async () => {
+    vi.clearAllMocks();
+    mockFetchDispatcher();
+    mockTts();
+
+    const { container } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getAllByRole('button', { name: 'QR' })[0]);
+
+    const dialog = await screen.findByRole('dialog');
+    // Not inside the component's own tree — that is exactly the bug.
+    expect(container.contains(dialog)).toBe(false);
+    // A direct child of body, so no ancestor can hijack its containing block.
+    expect(dialog.parentElement).toBe(document.body);
+    expect(dialog.closest('[role="row"]')).toBeNull();
+  });
+});

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Download, Loader2, Play, QrCode, Square } from 'lucide-react';
 // Static, top-level, literal specifier — this is what makes Vite bundle the
 // library. Do not turn this back into a dynamic import with the module name in
@@ -222,7 +223,16 @@ const QrPreviewDialog: React.FC<{
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  return (
+  // Rendered into document.body rather than in place.
+  //
+  // `position: fixed` resolves against the nearest ancestor that establishes a
+  // containing block — any transform, filter, or contain on the way up does it,
+  // and the admin shell has several. In place, the overlay was laying itself
+  // out inside the table row, so the QR appeared jammed between two columns
+  // instead of centred over the page. A portal is the only reliable fix; there
+  // is no combination of z-index or overflow on the dialog itself that escapes
+  // an ancestor's containing block.
+  return createPortal((
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
       role="dialog"
@@ -256,7 +266,7 @@ const QrPreviewDialog: React.FC<{
         </div>
       </div>
     </div>
-  );
+  ), document.body);
 };
 
 const QrDownloadButton: React.FC<QrButtonProps> = ({ lessonId, step, label, filePrefix, lessonTitle: title }) => {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Young 附截圖回報：QR 卡在兩個欄位中間、把那一列撐開，而不是覆蓋整頁置中。

## 根因

`position: fixed` 的定位基準是**最近一個建立 containing block 的祖先** ——
路徑上任何 `transform` / `filter` / `contain` 都會建立，而後台外殼有好幾個。
原地 render 時，overlay 就在它所屬的那一列裡排版。

dialog 自己怎麼調 z-index 或 overflow 都逃不出祖先的 containing block，
唯一的解是 portal 到 `document.body`。

## 回歸鎖斷言在 DOM 位置，不是樣式

樣式在壞掉的時候本來就是對的（`fixed inset-0 z-50` 一應俱全），所以既有測試抓不到。
新的鎖斷言三件事：dialog 不在元件自己的樹裡、它的 parent 就是 body、它不在任何 `[role=row]` 底下。

## 驗證

```
vitest    19 passed
mutation  拿掉 createPortal → 紅；還原 → 綠
lint      0 errors
CI 命令   30 passed
tsc       本檔 0 error
```