### PR TITLE
fix(#2622): Excel 下載的 blob URL 不要在同一輪就撤銷

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -442,7 +442,13 @@ const LessonAudioTable: React.FC = () => {
         type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       }));
       triggerDownload(url, `課程QR-${rows.length}課.xlsx`);
-      URL.revokeObjectURL(url);
+      // Revoke on a later turn, not on this one. Chrome happens to start the
+      // download synchronously from click(), so an immediate revoke usually
+      // survives, but it is a race — the object URL can be dead before the
+      // browser has read it, and the download silently produces nothing. Found
+      // while trying to inspect the produced file: fetching the blob URL right
+      // after the click already failed.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
     } catch (err) {
       setPlaybackError(err instanceof Error ? err.message : String(err));
     } finally {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

想驗證瀏覽器實際產出的檔案時發現的：`triggerDownload` 的下一行就 `revokeObjectURL`，
所以 blob 在被讀取之前可能已經失效。

Chrome 剛好會從 `click()` 同步開始下載，所以多半沒事 —— 但那是**運氣不是保證**，
失敗時的樣子是「按了沒反應、什麼都沒下載」。

改成一分鐘後才撤銷，代價是一份 blob 的記憶體。

```
vitest  19 passed
lint    0 errors
```