### PR TITLE
fix(#2626): 8-9 年級不再提供全文 QR 與交付欄位

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
-import LessonAudioTable, { buildLessonQrValue, buildQrManifestCsv, buildQrManifestRows, derivePlaybackState } from './LessonAudioTable';
+import LessonAudioTable, { buildLessonQrValue, buildQrManifestCsv, buildQrManifestRows, deliversFullText, derivePlaybackState } from './LessonAudioTable';
 import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 
 vi.mock('../../../contexts/AuthContext', () => ({
@@ -425,7 +425,10 @@ describe('#2622 QR 交付表', () => {
     expect(rows[0].lesson_no).toBe('L01');
     expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
     expect(rows[0].passage_url).toBe('https://x.test/learn/1/full-reading');
-    expect(rows[1].full_url).toBe('https://x.test/learn/2/intro');
+    // Lesson 2 is grade 8, which per #2626 delivers 段落 only — its 全文
+    // column is deliberately blank rather than a code pointing at silence.
+    expect(rows[1].full_url).toBe('');
+    expect(rows[1].passage_url).toBe('https://x.test/learn/2/full-reading');
   });
 
   it('quotes fields and leads with a BOM so Excel reads the Chinese correctly', () => {
@@ -472,5 +475,36 @@ describe('#2622 QR 預覽必須蓋在整頁之上', () => {
     // A direct child of body, so no ancestor can hijack its containing block.
     expect(dialog.parentElement).toBe(document.body);
     expect(dialog.closest('[role="row"]')).toBeNull();
+  });
+});
+
+describe('#2626 只有 4-7 年級交付全文', () => {
+  /**
+   * The batch generator already honours the grade rule — a dry run against
+   * staging planned 222 items across 165 lessons with zero whole-text rows in
+   * grades 8-9. The panel did not, so an admin could play, and hand out a QR
+   * for, audio that will never exist.
+   *
+   * Every shipped grade gets its own assertion rather than one per branch: the
+   * rule is defined *by* which grade you are in, and the boundary between 7 and
+   * 8 is the whole point.
+   */
+  it.each([[4, true], [5, true], [6, true], [7, true], [8, false], [9, false]])(
+    'grade %i delivers full text: %s',
+    (grade, expected) => {
+      expect(deliversFullText(grade as number)).toBe(expected);
+    },
+  );
+
+  it('leaves the 全文 URL blank for 8-9 so no code points at silence', () => {
+    const rows = buildQrManifestRows([
+      { id: 1, lesson_number: 1, title: 'G7 課', grade: 7, grade_code: 'G7-L01', char_count: 10, has_key_reading: true },
+      { id: 2, lesson_number: 2, title: 'G8 課', grade: 8, grade_code: 'G8-L02', char_count: 10, has_key_reading: true },
+    ] as never, 'https://x.test');
+
+    expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
+    expect(rows[1].full_url).toBe('');
+    // 段落 is delivered for every grade, so it must survive.
+    expect(rows[1].passage_url).toBe('https://x.test/learn/2/full-reading');
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -106,6 +106,19 @@ function detailToFullText(detail: StoryDetailResponse): string {
   return paragraphs.join('\n\n');
 }
 
+/**
+ * Whether the batch will produce a whole-text clip for this grade.
+ *
+ * The requirement (docs/requirements/reading-demo-audio-qr.md) gives grades 4-7
+ * both 全文 and 段落, and grades 8-9 段落 only. The batch generator already
+ * honours that — a dry run plans zero whole-text items for 8-9 — but this panel
+ * was offering play and QR for all of them, so an admin could hear and hand out
+ * a code for audio that will never be generated.
+ */
+export function deliversFullText(grade: number): boolean {
+  return grade <= 7;
+}
+
 export function buildLessonQrValue(origin: string, lessonId: number, step: LessonQrStep): string {
   return `${origin}/learn/${lessonId}/${step}`;
 }
@@ -166,7 +179,9 @@ export function buildQrManifestRows(stories: StoryListItem[], origin: string): Q
     lesson_no: lessonTitle(s),
     title: s.title,
     grade: s.grade,
-    full_url: buildLessonQrValue(origin, s.id, 'intro'),
+    // Blank rather than a URL: the batch produces no whole-text clip for
+    // grades 8-9, so handing the 教材端 a code for it would point at silence.
+    full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'intro') : '',
     passage_url: buildLessonQrValue(origin, s.id, 'full-reading'),
   }));
 }
@@ -424,6 +439,7 @@ const LessonAudioTable: React.FC = () => {
         row.alignment = { vertical: 'middle' };
 
         for (const [col, url] of [[3, r.full_url], [5, r.passage_url]] as const) {
+          if (!url) continue; // grades 8-9 have no whole-text clip to point at
           const dataUrl = await qrCodeToDataUrl(url);
           const imgId = wb.addImage({ base64: dataUrl.split(',')[1], extension: 'png' });
           ws.addImage(imgId, {
@@ -672,6 +688,9 @@ const LessonAudioTable: React.FC = () => {
                 {fullContent.icon}
                 {fullContent.label}
               </button>
+              {!deliversFullText(story.grade) && (
+                <span className="mt-1 block text-xs text-gray-400">僅試聽，不列入交付</span>
+              )}
 
               <div className="flex flex-wrap items-center gap-2">
                 <button
@@ -697,7 +716,9 @@ const LessonAudioTable: React.FC = () => {
                 )}
               </div>
 
-              <QrDownloadButton lessonId={story.id} step="intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
+              {deliversFullText(story.grade)
+                ? <QrDownloadButton lessonId={story.id} step="intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
+                : <span className="text-xs text-gray-400" title="8-9 年級依規格只交付段落朗讀">—</span>}
               <QrDownloadButton lessonId={story.id} step="full-reading" label="QR" filePrefix="full-reading-qr" lessonTitle={story.title} />
             </div>
           );


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2626。

規格：4-7 年級交付全文＋段落，**8-9 年級只交付段落**。
批次腳本一直是對的（staging dry-run：165 課 222 個項目，8-9 年級的全文列 = 0），
但後台表格對每個年級都給播放與 QR，管理員因此聽得到、也發得出一組永遠不會有音檔的 QR。

## 改動

```
8-9 年級的「QR（全文）」   → 顯示 —（tooltip 說明規格）
8-9 年級的「播放全文」     → 底下標「僅試聽，不列入交付」
Excel/CSV 的全文網址欄      → 8-9 年級留空
```

播放保留，管理員確實可能想聽整篇；只是不再暗示那是交付物。

## 測試

每個實際出貨的年級各一條斷言，不是每個分支抽一個 —— 這條規則的定義就是「你在哪個年級」，
而 7 與 8 的界線是全部重點。

```
vitest    26 passed
mutation  把界線從 <=7 改成 <=8 → 3 紅；還原 → 26 綠
lint      0 errors
CI 命令   30 passed
```

既有的一條測試原本斷言 G8 有全文網址（正是這次改掉的行為），已更新成斷言留空，
並繼續檢查每個年級的段落網址都還在。