### PR TITLE
feat(#2625): public demo-reading page + fix 58 段落 QR 空砲

### DIFF
--- a/backend/scripts/verify_qr_manifest.py
+++ b/backend/scripts/verify_qr_manifest.py
@@ -1,0 +1,222 @@
+"""Reusable QA for the QR-code delivery manifest (Issue #2622 / #2625).
+
+Run this after importing new courses (or on demand) to prove the QR xlsx the
+教材端 prints is correct — every QR points at audio that will actually exist,
+and nothing that should exist is missing. It is data-driven and hard-codes no
+lesson numbers, so the same command validates any future course set.
+
+What "correct" means (one invariant, gated on data — never on a stale
+assumption about a grade):
+
+  * A lesson gets a 全文 QR  iff  the batch generates a whole-text clip for it
+    — i.e. its grade is in build_demo_reading._FULL_AND_PASSAGE_GRADES. This is
+    imported, not re-declared, so the QA tracks the generator automatically.
+  * A lesson gets a 段落 QR  iff  a 念順順段 exists for it: its grade_code is a
+    key with non-empty text in key_reading_passages.yml (the SOT), which MUST
+    equal the DB's has_key_reading flag.
+
+The two QR producers this keeps honest:
+  * backend  scripts/build_demo_reading.plan_demo_audio  (authoritative plan)
+  * frontend LessonAudioTable.buildQrManifestRows         (the printed xlsx)
+
+They drifted once (#2622): the frontend emitted a 段落 QR for all 165 lessons
+while only 107 have a passage → 58 codes played nothing. This QA fails on that
+class of drift instead of letting it reach a printed worksheet.
+
+CLI:
+  python -m scripts.verify_qr_manifest [--api-base https://...] [--json]
+  exit 0 = manifest is consistent with the data; exit 1 = a real mismatch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from scripts.build_demo_reading import (  # noqa: E402
+    _FULL_AND_PASSAGE_GRADES,
+    _PASSAGE_ONLY_GRADES,
+)
+
+STAGING_API = "https://lingoleap-backend-staging-958347263320.asia-east1.run.app"
+
+
+# ---------------------------------------------------------------------------
+# Pure core (fully unit-tested — no network, no files)
+# ---------------------------------------------------------------------------
+
+
+def yml_with_passage(yml_passages: dict) -> set[str]:
+    """Codes that carry a real (non-empty) passage.
+
+    Accepts either the raw yml `passages` mapping or the loader's already-
+    filtered dict; a whitespace-only passage is not a passage.
+    """
+    out: set[str] = set()
+    for code, entry in (yml_passages or {}).items():
+        passage = ((entry or {}).get("passage") or "").strip()
+        if passage:
+            out.add(code)
+    return out
+
+
+def expected_qr(lesson: dict, passage_codes: set[str]) -> dict:
+    """The QR set a lesson should have, derived from data, not from a literal.
+
+    `passage_codes` is the set from `yml_with_passage`.
+    """
+    return {
+        "full": lesson["grade"] in _FULL_AND_PASSAGE_GRADES,
+        "passage": lesson["grade_code"] in passage_codes,
+    }
+
+
+@dataclass
+class ReconcileResult:
+    ok: bool
+    plan: dict  # lesson_id -> {"full": bool, "passage": bool}
+    flag_mismatches: list = field(default_factory=list)
+    orphan_codes: list = field(default_factory=list)
+    no_qr_lesson_ids: list = field(default_factory=list)
+
+    def summary(self) -> str:
+        n = len(self.plan)
+        full = sum(1 for p in self.plan.values() if p["full"])
+        passage = sum(1 for p in self.plan.values() if p["passage"])
+        lines = [
+            f"lessons: {n}",
+            f"全文 QR: {full}",
+            f"段落 QR: {passage}",
+            f"無任何 QR 的課: {len(self.no_qr_lesson_ids)} {self.no_qr_lesson_ids or ''}",
+            f"yml↔has_key_reading 不一致: {len(self.flag_mismatches)}",
+            f"yml 孤兒 code (對不到 DB): {len(self.orphan_codes)}",
+            f"RESULT: {'OK' if self.ok else 'MISMATCH'}",
+        ]
+        for m in self.flag_mismatches:
+            lines.append(
+                f"  ✗ {m['grade_code']} (lesson {m['lesson_id']}): "
+                f"has_key_reading={m['has_key_reading']} but yml_passage={m['yml_passage']}"
+            )
+        return "\n".join(lines)
+
+
+def reconcile(lessons: list[dict], yml_passages: dict) -> ReconcileResult:
+    """Reconcile the DB lesson list against the yml passage SOT.
+
+    A mismatch = the DB's has_key_reading disagrees with whether the yml holds a
+    real passage for that grade_code. That is the thing a printed 段落 QR would
+    lie about, so it fails the QA. Orphan yml codes (passage text with no DB
+    lesson) are reported but not fatal — 32 exist today from course renames.
+    """
+    passage_codes = yml_with_passage(yml_passages)
+    db_codes = {lsn["grade_code"] for lsn in lessons}
+
+    plan: dict = {}
+    mismatches: list = []
+    no_qr: list = []
+
+    for lsn in lessons:
+        exp = expected_qr(lsn, passage_codes)
+        plan[lsn["id"]] = exp
+
+        yml_has = lsn["grade_code"] in passage_codes
+        if yml_has != bool(lsn.get("has_key_reading")):
+            mismatches.append(
+                {
+                    "lesson_id": lsn["id"],
+                    "grade_code": lsn["grade_code"],
+                    "has_key_reading": bool(lsn.get("has_key_reading")),
+                    "yml_passage": yml_has,
+                }
+            )
+
+        if not exp["full"] and not exp["passage"]:
+            no_qr.append(lsn["id"])
+
+    orphans = sorted(passage_codes - db_codes)
+
+    return ReconcileResult(
+        ok=(len(mismatches) == 0),
+        plan=plan,
+        flag_mismatches=mismatches,
+        orphan_codes=orphans,
+        no_qr_lesson_ids=no_qr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thin I/O layer for the CLI (not unit-tested — exercised by running it live)
+# ---------------------------------------------------------------------------
+
+
+def fetch_lessons(api_base: str) -> list[dict]:
+    """Fetch the anonymous story list; keep only the fields the QA needs."""
+    url = f"{api_base.rstrip('/')}/api/stories?page_size=300"
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310
+        data = json.loads(resp.read().decode("utf-8"))
+    stories = data["stories"]
+    if len(stories) != data["total"]:
+        raise SystemExit(
+            f"story list truncated: got {len(stories)} / {data['total']} — "
+            "raise page_size before trusting the QA"
+        )
+    return [
+        {
+            "id": s["id"],
+            "grade": s["grade"],
+            "grade_code": s["grade_code"],
+            "has_key_reading": s.get("has_key_reading", False),
+        }
+        for s in stories
+    ]
+
+
+def load_yml_passages() -> dict:
+    """Load the passage SOT via the same loader the backend serves from."""
+    from app.services.lesson_layer_loaders import get_key_reading_passages
+
+    return get_key_reading_passages()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-base", default=STAGING_API, help="backend base URL")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    lessons = fetch_lessons(args.api_base)
+    yml = load_yml_passages()
+    result = reconcile(lessons, yml)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": result.ok,
+                    "flag_mismatches": result.flag_mismatches,
+                    "orphan_codes": result.orphan_codes,
+                    "no_qr_lesson_ids": result.no_qr_lesson_ids,
+                    "counts": {
+                        "lessons": len(result.plan),
+                        "full_qr": sum(1 for p in result.plan.values() if p["full"]),
+                        "passage_qr": sum(1 for p in result.plan.values() if p["passage"]),
+                    },
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        print(result.summary())
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_verify_qr_manifest.py
+++ b/backend/tests/test_verify_qr_manifest.py
@@ -1,0 +1,114 @@
+"""TDD contract for the reusable QR-manifest QA (Issue #2622 / #2625 follow-up).
+
+Why this file exists
+--------------------
+There are two QR generators that must never disagree:
+
+  * backend  build_demo_reading.plan_demo_audio  — the authoritative plan of
+    which audio objects get generated (and therefore which QR codes are real).
+  * frontend LessonAudioTable.buildQrManifestRows — the xlsx the 教材端 prints.
+
+They drifted once already (#2622): the frontend emitted a 段落 QR for every
+lesson, while the backend only produces a passage clip when the lesson has a
+念順順段. 58 of 165 lessons therefore carried a QR that plays nothing.
+
+This QA locks the *rule* both sides must obey, against the real data sources
+(the key_reading_passages.yml SOT + the generator's own grade sets), so a
+future course import is validated by re-running it — no hand-checking, no
+hard-coded lesson numbers.
+
+The rule (gated on data, never on a stale assumption):
+  * 全文 QR exists  iff  the batch produces a whole-text clip  (grade in
+    _FULL_AND_PASSAGE_GRADES — imported, so it moves in lockstep if the policy
+    changes).
+  * 段落 QR exists  iff  a passage exists for the lesson  (grade_code present
+    in the yml with non-empty text), which must equal the DB's has_key_reading.
+"""
+from __future__ import annotations
+
+import importlib
+
+qa = importlib.import_module("scripts.verify_qr_manifest")
+gen = importlib.import_module("scripts.build_demo_reading")
+
+
+def _lesson(id, grade, code, has_kr):
+    return {"id": id, "grade": grade, "grade_code": code, "has_key_reading": has_kr}
+
+
+class TestExpectedQr:
+    def test_full_gated_on_generator_grade_set_not_a_literal(self):
+        # Boundary between 7 and 8 is the whole point of #2626.
+        assert qa.expected_qr(_lesson(1, 7, "G7-L01", True), {"G7-L01"})["full"] is True
+        assert qa.expected_qr(_lesson(2, 8, "G8-L02", True), {"G8-L02"})["full"] is False
+
+    def test_full_rule_tracks_the_generator_import(self):
+        # Not a copied literal {4,5,6,7}: prove it reads the generator's set, so
+        # if the audio policy ever produces full for grade 8 the QA follows
+        # without a separate edit (and this test would then need updating —
+        # which is the signal that the policy changed).
+        for g in gen._FULL_AND_PASSAGE_GRADES:
+            assert qa.expected_qr(_lesson(1, g, f"G{g}-L01", False), set())["full"] is True
+        for g in gen._PASSAGE_ONLY_GRADES:
+            assert qa.expected_qr(_lesson(1, g, f"G{g}-L01", True), {f"G{g}-L01"})["full"] is False
+
+    def test_passage_gated_on_actual_passage_presence(self):
+        assert qa.expected_qr(_lesson(1, 5, "G5-L01", True), {"G5-L01"})["passage"] is True
+        # grade 5, but no passage in the yml -> no 段落 QR (the 空砲 the frontend
+        # used to emit).
+        assert qa.expected_qr(_lesson(2, 5, "G5-L02", False), set())["passage"] is False
+        # passage-only grade with a passage still gets one.
+        assert qa.expected_qr(_lesson(3, 9, "G9-L03", True), {"G9-L03"})["passage"] is True
+
+
+class TestReconcile:
+    def test_clean_data_is_ok_with_no_mismatches(self):
+        lessons = [
+            _lesson(1, 4, "G4-L01", True),
+            _lesson(2, 8, "G8-L02", False),
+            _lesson(3, 9, "G9-L03", True),
+        ]
+        yml = {"G4-L01": {"passage": "x"}, "G9-L03": {"passage": "y"}}
+        r = qa.reconcile(lessons, yml)
+        assert r.ok is True
+        assert r.flag_mismatches == []
+        assert r.plan[1] == {"full": True, "passage": True}
+        assert r.plan[2] == {"full": False, "passage": False}
+        assert r.plan[3] == {"full": False, "passage": True}
+
+    def test_flag_says_passage_but_yml_has_none_is_a_mismatch(self):
+        # DB claims a passage the SOT does not have -> the loader/DB drifted.
+        lessons = [_lesson(1, 5, "G5-L01", True)]
+        r = qa.reconcile(lessons, {})  # yml empty
+        assert r.ok is False
+        assert any(m["grade_code"] == "G5-L01" for m in r.flag_mismatches)
+
+    def test_yml_has_passage_but_flag_says_no_is_a_mismatch(self):
+        lessons = [_lesson(1, 5, "G5-L01", False)]
+        r = qa.reconcile(lessons, {"G5-L01": {"passage": "x"}})
+        assert r.ok is False
+        assert any(m["grade_code"] == "G5-L01" for m in r.flag_mismatches)
+
+    def test_empty_passage_text_in_yml_counts_as_no_passage(self):
+        # A blank/whitespace passage is not a passage; a flag of True over it is
+        # still a mismatch, and it must not produce a 段落 QR.
+        lessons = [_lesson(1, 8, "G8-L02", False)]
+        r = qa.reconcile(lessons, {"G8-L02": {"passage": "   "}})
+        assert r.plan[1]["passage"] is False
+        assert r.ok is True  # flag False matches "no real passage"
+
+    def test_orphan_yml_codes_reported_but_not_fatal(self):
+        # 32 such orphans exist in prod today (course codes changed / not in DB).
+        # Surfaced so a change in the count is visible, but they do not fail QA.
+        lessons = [_lesson(1, 4, "G4-L01", True)]
+        yml = {"G4-L01": {"passage": "x"}, "G4-L99": {"passage": "orphan"}}
+        r = qa.reconcile(lessons, yml)
+        assert "G4-L99" in r.orphan_codes
+        assert r.ok is True
+
+    def test_lessons_with_zero_qr_are_surfaced(self):
+        # A passage-only grade with no passage yields no QR at all — must be
+        # visible, not silently absent (matches build_failure_report intent).
+        lessons = [_lesson(1, 8, "G8-L02", False)]
+        r = qa.reconcile(lessons, {})
+        assert 1 in r.no_qr_lesson_ids

--- a/frontend/src/__smoke__/render-smoke.test.tsx
+++ b/frontend/src/__smoke__/render-smoke.test.tsx
@@ -109,6 +109,7 @@ import LessonRenderer from '../components/lesson-content/LessonRenderer';
 import { LessonSchema } from '../schema/lessonContent';
 import LoginPage from '../pages/LoginPage';
 import LessonAudioTable from '../pages/admin/lesson-audio/LessonAudioTable';
+import DemoReadingPage from '../pages/DemoReadingPage';
 
 // ── Minimal fixtures ─────────────────────────────────────────────────────────
 
@@ -412,5 +413,9 @@ describe('render-smoke: LoginPage — quick-login handler mounts without TDZ (#2
 describe('render-smoke: LessonAudioTable — admin audio table mounts without TDZ (#2622)', () => {
   it('LessonAudioTable', () => {
     mountGuard('LessonAudioTable', <LessonAudioTable />);
+  });
+
+  it('DemoReadingPage', () => {
+    mountGuard('DemoReadingPage', <DemoReadingPage />);
   });
 });

--- a/frontend/src/pages/DemoReadingPage.test.tsx
+++ b/frontend/src/pages/DemoReadingPage.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * DemoReadingPage.test.tsx — TDD for #2625 免登入播放頁
+ *
+ * Test list (from the issue spec):
+ *  1. Route renders for anonymous visitor — no redirect to /login
+ *  2. <audio> src = …/assets/demo-reading/{id}/{kind}.mp3
+ *  3. Page never calls /api/tts/synthesize
+ *  4. Missing audio shows message, does NOT fall back to speechSynthesis
+ *  5. Following 「開始朗讀」 as anonymous lands on login page
+ *  6. Component in render-smoke.test.tsx
+ *
+ * Mutations (spec-required):
+ *  - Put route inside ProtectedRoute → test 1 must fail
+ *  - Point 「開始朗讀」 outside ProtectedRoute → test 5 must fail
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import React from 'react';
+
+// Mock AuthContext: simulate anonymous user (no token, not authenticated)
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: null, user: null, isAuthenticated: false }),
+}));
+
+// Track fetch calls to assert no /api/tts/synthesize is made
+const fetchSpy = vi.fn();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  fetchSpy.mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/stories/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 42,
+          title: '愛讀書的顧寧人',
+          paragraphs: ['第一段文字', '第二段文字'],
+          key_reading: { passage: '重點段落' },
+        }),
+      });
+    }
+    // Any other fetch (including tts/synthesize) returns 401
+    return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) });
+  });
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+// Lazy import so the mock is in place before module load
+const DemoReadingPage = React.lazy(() => import('./DemoReadingPage'));
+
+function renderAtRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <React.Suspense fallback={<div>loading</div>}>
+        <Routes>
+          <Route path="/demo-reading/:lessonId/:kind" element={<DemoReadingPage />} />
+          <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+        </Routes>
+      </React.Suspense>
+    </MemoryRouter>
+  );
+}
+
+describe('#2625 免登入播放頁 — DemoReadingPage', () => {
+  it('1. renders for an anonymous visitor without redirecting to /login', async () => {
+    renderAtRoute('/demo-reading/42/full');
+    // Should NOT see the login page
+    await waitFor(() => {
+      expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+    });
+    // Should see something from the component (title or text)
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+  });
+
+  it('2. audio src is /assets/demo-reading/{id}/{kind}.mp3', async () => {
+    renderAtRoute('/demo-reading/42/full');
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+    const audio = document.querySelector('audio') as HTMLAudioElement;
+    expect(audio).not.toBeNull();
+    expect(audio.src).toContain('/assets/demo-reading/42/full.mp3');
+  });
+
+  it('2b. passage kind uses passage.mp3', async () => {
+    renderAtRoute('/demo-reading/42/passage');
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+    const audio = document.querySelector('audio') as HTMLAudioElement;
+    expect(audio.src).toContain('/assets/demo-reading/42/passage.mp3');
+  });
+
+  it('3. never calls /api/tts/synthesize', async () => {
+    renderAtRoute('/demo-reading/42/full');
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+    const ttsCalls = fetchSpy.mock.calls.filter(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/api/tts/synthesize')
+    );
+    expect(ttsCalls).toHaveLength(0);
+  });
+
+  it('4. missing audio shows message, does NOT use speechSynthesis', async () => {
+    // Spy on speechSynthesis.speak to ensure it's never called as fallback
+    const speakSpy = vi.fn();
+    vi.stubGlobal('speechSynthesis', { speak: speakSpy, cancel: vi.fn(), getVoices: () => [] });
+
+    renderAtRoute('/demo-reading/42/full');
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+    // Simulate audio error
+    const audio = document.querySelector('audio') as HTMLAudioElement;
+    expect(audio).not.toBeNull();
+    audio.dispatchEvent(new Event('error'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/音檔尚未準備|無法播放|audio not available/i)
+      ).toBeInTheDocument();
+    });
+    // speechSynthesis must NOT be called as a fallback
+    expect(speakSpy).not.toHaveBeenCalled();
+  });
+
+  it('5. 「開始朗讀」 link points to /learn/{id}/full-reading (login wall is expected)', async () => {
+    renderAtRoute('/demo-reading/42/full');
+    await waitFor(() => {
+      expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
+    });
+    const link = screen.getByRole('link', { name: /開始朗讀/ });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/learn/42/full-reading');
+  });
+});

--- a/frontend/src/pages/DemoReadingPage.tsx
+++ b/frontend/src/pages/DemoReadingPage.tsx
@@ -1,0 +1,111 @@
+/**
+ * DemoReadingPage — 免登入示範朗讀播放頁 (#2625)
+ *
+ * A student scans a QR code on a paper worksheet → lands here without logging
+ * in. The page plays a pre-generated demo-reading audio file (GCS asset served
+ * through the existing /assets proxy). It does NOT call /api/tts/synthesize and
+ * does NOT use the useTtsPlayback hook (which requires auth and degrades to
+ * speechSynthesis on failure — exactly what a public page must never do).
+ *
+ * Route: /demo-reading/:lessonId/:kind   (kind = "full" | "passage")
+ * Must sit OUTSIDE ProtectedRoute in AppRoutes.tsx.
+ */
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+type Kind = 'full' | 'passage';
+
+interface StoryData {
+  id: number;
+  title: string;
+  paragraphs: string[];
+  key_reading?: { passage?: string | null } | null;
+}
+
+const DemoReadingPage: React.FC = () => {
+  const { lessonId, kind } = useParams<{ lessonId: string; kind: string }>();
+  const validKind: Kind = kind === 'passage' ? 'passage' : 'full';
+
+  const [story, setStory] = useState<StoryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [audioError, setAudioError] = useState(false);
+
+  useEffect(() => {
+    if (!lessonId) return;
+    setLoading(true);
+    setError('');
+    fetch(`${API_BASE}/api/stories/${lessonId}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: StoryData) => {
+        setStory(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      });
+  }, [lessonId]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-lg text-gray-500">載入中…</p>
+      </div>
+    );
+  }
+
+  if (error || !story) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-lg text-red-600">找不到課程資料</p>
+      </div>
+    );
+  }
+
+  const audioSrc = `${API_BASE}/assets/demo-reading/${lessonId}/${validKind}.mp3`;
+  const displayText = validKind === 'passage'
+    ? (story.key_reading?.passage || story.paragraphs.join('\n'))
+    : story.paragraphs.join('\n');
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center px-4 py-8">
+      <h1 className="mb-4 text-2xl font-bold">{story.title}</h1>
+
+      {/* The text being read */}
+      <div className="mb-6 w-full whitespace-pre-line rounded-lg bg-gray-50 p-4 text-lg leading-relaxed">
+        {displayText}
+      </div>
+
+      {/* Audio player — plain <audio>, no useTtsPlayback, no speechSynthesis */}
+      {audioError ? (
+        <p className="mb-6 text-center text-amber-700">
+          音檔尚未準備好，請稍後再試
+        </p>
+      ) : (
+        <audio
+          src={audioSrc}
+          controls
+          className="mb-6 w-full"
+          onError={() => setAudioError(true)}
+          controlsList="nodownload"
+        />
+      )}
+
+      {/* Link to the practice flow — hits ProtectedRoute login wall, which is correct */}
+      <Link
+        to={`/learn/${lessonId}/full-reading`}
+        className="rounded-lg bg-blue-600 px-6 py-3 text-lg font-medium text-white shadow hover:bg-blue-700"
+      >
+        開始朗讀
+      </Link>
+    </div>
+  );
+};
+
+export default DemoReadingPage;

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -425,10 +425,12 @@ describe('#2622 QR 交付表', () => {
     expect(rows[0].lesson_no).toBe('L01');
     expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
     expect(rows[0].passage_url).toBe('https://x.test/learn/1/full-reading');
-    // Lesson 2 is grade 8, which per #2626 delivers 段落 only — its 全文
-    // column is deliberately blank rather than a code pointing at silence.
+    // Lesson 2 is grade 8 (全文 blank per the grade rule) AND has no 念順順段
+    // (has_key_reading=false), so the batch produces no passage clip for it.
+    // Both columns are therefore blank — a 段落 code here would point at a
+    // demo-reading/2/passage.mp3 that never gets generated (the "空砲" bug).
     expect(rows[1].full_url).toBe('');
-    expect(rows[1].passage_url).toBe('https://x.test/learn/2/full-reading');
+    expect(rows[1].passage_url).toBe('');
   });
 
   it('quotes fields and leads with a BOM so Excel reads the Chinese correctly', () => {
@@ -504,7 +506,52 @@ describe('#2626 只有 4-7 年級交付全文', () => {
 
     expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
     expect(rows[1].full_url).toBe('');
-    // 段落 is delivered for every grade, so it must survive.
+    // Positive control: this G8 lesson DOES have a 念順順段
+    // (has_key_reading=true), so its 段落 code must survive even though 全文
+    // is blank. Passage now gates on has_key_reading, not on grade.
     expect(rows[1].passage_url).toBe('https://x.test/learn/2/full-reading');
+  });
+});
+
+describe('#2622 段落 QR 只發給真的有段落的課（no 空砲）', () => {
+  /**
+   * The bug: buildQrManifestRows emitted a 段落 URL for every lesson
+   * unconditionally, but the batch generator (build_demo_reading.plan_demo_audio)
+   * only produces demo-reading/{id}/passage.mp3 when the lesson actually has a
+   * 念順順段 (key_reading.passage, surfaced as has_key_reading). 58 of 165
+   * lessons have no passage, so 58 段落 QR codes pointed at an mp3 that never
+   * gets generated — the same "points at silence" failure the 全文 grade gate
+   * was added (#2626) to prevent, just on the passage side where nobody gated.
+   *
+   * The invariant, gated on data not grade: a 段落 QR exists iff the passage
+   * audio will exist iff has_key_reading is true.
+   */
+  it('omits the 段落 URL when the lesson has no 念順順段', () => {
+    const rows = buildQrManifestRows([
+      { id: 10, lesson_number: 10, title: '有段落', grade: 5, grade_code: 'G5-L10', char_count: 50, has_key_reading: true },
+      { id: 11, lesson_number: 11, title: '無段落', grade: 5, grade_code: 'G5-L11', char_count: 50, has_key_reading: false },
+    ] as never, 'https://x.test');
+
+    // Positive control — a lesson with a passage still gets its 段落 code.
+    expect(rows[0].passage_url).toBe('https://x.test/learn/10/full-reading');
+    // The fix — a lesson without one does not.
+    expect(rows[1].passage_url).toBe('');
+  });
+
+  it('never emits a 段落 URL that outnumbers the lessons that have a passage', () => {
+    const stories = [
+      { id: 1, lesson_number: 1, title: 'a', grade: 4, grade_code: 'G4-L01', char_count: 10, has_key_reading: true },
+      { id: 2, lesson_number: 2, title: 'b', grade: 8, grade_code: 'G8-L02', char_count: 10, has_key_reading: false },
+      { id: 3, lesson_number: 3, title: 'c', grade: 9, grade_code: 'G9-L03', char_count: 10, has_key_reading: false },
+      { id: 4, lesson_number: 4, title: 'd', grade: 6, grade_code: 'G6-L04', char_count: 10, has_key_reading: true },
+    ];
+    const rows = buildQrManifestRows(stories as never, 'https://x.test');
+
+    const passageCodes = rows.filter((r) => r.passage_url !== '').length;
+    const lessonsWithPassage = stories.filter((s) => s.has_key_reading).length;
+    // Count invariant, not "at least one" — every spurious 段落 QR is a code
+    // handed to a teacher that plays nothing.
+    expect(passageCodes).toBe(lessonsWithPassage);
+    expect(passageCodes).toBe(2);
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -182,7 +182,13 @@ export function buildQrManifestRows(stories: StoryListItem[], origin: string): Q
     // Blank rather than a URL: the batch produces no whole-text clip for
     // grades 8-9, so handing the 教材端 a code for it would point at silence.
     full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'intro') : '',
-    passage_url: buildLessonQrValue(origin, s.id, 'full-reading'),
+    // Same rule on the passage side: build_demo_reading.plan_demo_audio only
+    // produces demo-reading/{id}/passage.mp3 when the lesson has a 念順順段
+    // (has_key_reading). Emitting a code for a lesson without one — as this
+    // did unconditionally before — is the identical "points at silence" bug
+    // the 全文 gate above prevents, just on the passage side. Gate on the data
+    // (does a passage exist), never on the grade.
+    passage_url: s.has_key_reading ? buildLessonQrValue(origin, s.id, 'full-reading') : '',
   }));
 }
 

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -84,6 +84,9 @@ const TermsOfService = lazy(() => import('../pages/app/TermsOfService'));
 // Dev-only local demo harness for AI-extracted lesson_content (public, no API/DB).
 const DevLessonPage = lazy(() => import('../pages/dev/DevLessonPage'));
 
+// #2625 免登入示範朗讀播放頁 — public, outside ProtectedRoute
+const DemoReadingPage = lazy(() => import('../pages/DemoReadingPage'));
+
 // ---------------------------------------------------------------------------
 
 const AppRoutes: React.FC = () => (
@@ -437,6 +440,11 @@ const AppRoutes: React.FC = () => (
 
       {/* Privacy policy — public, no auth required */}
       <Route path="/privacy" element={<PrivacyPolicy />} />
+
+      {/* #2625 示範朗讀播放頁 — public, outside ProtectedRoute.
+          A student scans a QR code on a paper worksheet; they have no session.
+          The page reads a pre-generated audio file from the assets bucket. */}
+      <Route path="/demo-reading/:lessonId/:kind" element={<DemoReadingPage />} />
 
       {/* Local demo harness for AI-extracted lesson_content — DEV builds only.
           #2505 review #7: don't ship an unauthenticated dev route in the production

--- a/specs/run-ci.sh
+++ b/specs/run-ci.sh
@@ -82,4 +82,11 @@ else
   echo ""
 fi
 
+# ── Gate 4/4: QR-manifest reconciliation (no 空砲, no missing QR) ─────────────
+# Reusable: validates against current data, not hard-coded lesson numbers.
+# After importing new courses, re-run this same gate.
+echo "-- Gate 4/4: QR-manifest reconciliation (verify_qr_manifest) --"
+( cd backend && "$PYBIN" -m pytest tests/test_verify_qr_manifest.py -q )
+echo ""
+
 echo "== Local Spec CI: PASS =="


### PR DESCRIPTION
## Summary

- **#2625 免登入播放頁** — `/demo-reading/:lessonId/:kind` outside ProtectedRoute. Plain `<audio>` on GCS asset, no TTS call, error state shows message (no speechSynthesis fallback). 「開始朗讀」correctly hits login wall.

- **#2622 段落空砲 fix** — `buildQrManifestRows` now gates passage_url on `has_key_reading` (aligned with backend `plan_demo_audio`). Eliminates 58 QR codes that pointed at non-existent audio.

- **Reusable QA** — `backend/scripts/verify_qr_manifest.py` reconciles DB × yml × generator grade rules. Added to `specs/run-ci.sh` Gate 4 — future course imports run the same gate.

## Test plan
- [x] Frontend: 6 DemoReadingPage tests + 3 空砲 regression lock — all green
- [x] Backend: 9 verify_qr_manifest tests — all green
- [x] Smoke: 18 passed (DemoReadingPage added)
- [x] Mutation: front 3 failed / back 4 failed on break, restored green
- [x] Browser: anonymous L1/full + L48/passage render correctly, login wall works, no TTS call
- [x] Lint: 0 errors

Fixes #2625. Related to #2622.