### PR TITLE
refactor(#2641): step id 改名 — 讓 id 說出它的中文意思

### DIFF
--- a/frontend/src/components/SessionResumePrompt.tsx
+++ b/frontend/src/components/SessionResumePrompt.tsx
@@ -12,11 +12,11 @@ import {
  * Step index to URL path segment mapping.
  */
 const STEP_NUMBER_TO_PATH: Record<number, string> = {
-  1: 'intro',
-  2: 'tutor',
+  1: 'lesson-intro',
+  2: 'paragraph-reading',
   3: 'comprehension',
-  4: 'vocab',
-  5: 'full-reading',
+  4: 'character-practice',
+  5: 'key-passage-reading',
   6: 'report',
 };
 
@@ -84,7 +84,7 @@ const SessionResumePrompt: React.FC<SessionResumePromptProps> = ({ onDismiss }) 
 
   const handleResume = () => {
     if (!record) return;
-    const stepPath = STEP_NUMBER_TO_PATH[record.currentStep] ?? 'intro';
+    const stepPath = STEP_NUMBER_TO_PATH[record.currentStep] ?? 'lesson-intro';
     setVisible(false);
     onDismiss?.();
     navigate(`/learn/${record.storyId}/${stepPath}`);
@@ -96,7 +96,7 @@ const SessionResumePrompt: React.FC<SessionResumePromptProps> = ({ onDismiss }) 
     setVisible(false);
     onDismiss?.();
     if (record) {
-      navigate(`/learn/${record.storyId}/intro`);
+      navigate(`/learn/${record.storyId}/lesson-intro`);
     }
   };
 

--- a/frontend/src/components/StepErrorBoundary.tsx
+++ b/frontend/src/components/StepErrorBoundary.tsx
@@ -17,7 +17,7 @@
  *   a "跳過此步驟" action without coupling the boundary to router logic
  *
  * Usage:
- *   <StepErrorBoundary stepLabel="逐段朗讀" onSkip={() => navigate('/learn/x/full-reading')}>
+ *   <StepErrorBoundary stepLabel="逐段朗讀" onSkip={() => navigate('/learn/x/key-passage-reading')}>
  *     <TutorPage />
  *   </StepErrorBoundary>
  */

--- a/frontend/src/components/reading-steps/DictationPractice.tsx
+++ b/frontend/src/components/reading-steps/DictationPractice.tsx
@@ -31,7 +31,7 @@ interface DictationPracticeProps {
   onProgressChange?: (stepData: DictationStepData, immediate?: boolean) => void;
 }
 
-type Phase = 'intro' | 'practice' | 'results';
+type Phase = 'lesson-intro' | 'practice' | 'results';
 
 /**
  * Extract vocabulary words from a story.
@@ -149,7 +149,7 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
     : [];
 
   const [phase, setPhase] = useState<Phase>(
-    canShowResults ? 'results' : canResume ? 'practice' : 'intro',
+    canShowResults ? 'results' : canResume ? 'practice' : 'lesson-intro',
   );
   const [currentIndex, setCurrentIndex] = useState(
     canResume ? Math.min(initialProgress!.current_index ?? 0, words.length - 1) : 0,
@@ -294,7 +294,7 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
   }, [submitAnswer]);
 
   // ---- Phase: intro ----
-  if (phase === 'intro') {
+  if (phase === 'lesson-intro') {
     return (
       <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
         {/* Content */}
@@ -465,7 +465,7 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
   const skippedCount = wordResults.filter((r) => r.skipped).length;
   const incorrectCount = wordResults.length - correctCount - skippedCount;
   const handleRedo = () => {
-    setPhase('intro');
+    setPhase('lesson-intro');
     setCurrentIndex(0);
     setAnswer('');
     setWordResults([]);

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -34,7 +34,7 @@ interface FullReadingProps {
   initialResult?: FullReadingResult | null;
   /** All reading attempts for this session from DB (Issue #1386 — 4-attempt progress chart). */
   fullReadingAttempts?: FullReadingAttempt[];
-  /** Full step_data['full-reading'] snapshot from DB (Issue #1549) — provides selfRating + transcript. */
+  /** Full step_data['key-passage-reading'] snapshot from DB (Issue #1549) — provides selfRating + transcript. */
   initialProgress?: FullReadingStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: FullReadingStepData, immediate?: boolean) => void;

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -591,7 +591,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
               #2082 A4 removed the non-clickable ol — do NOT restore a static ol.
               This uses chip badges so each step is directly accessible. */}
           {(() => {
-            const digitalSteps = resolveActiveSteps(story.stepSequence).filter(s => s.id !== 'intro');
+            const digitalSteps = resolveActiveSteps(story.stepSequence).filter(s => s.id !== 'lesson-intro');
             if (digitalSteps.length === 0) return null;
             return (
               <div className="space-y-2 pb-2">

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -28,7 +28,7 @@ interface VocabPracticeProps {
   attempt: ReadingAttempt | null;
   onFinish: (result: VocabResult) => void;
   onBack: () => void;
-  /** Rehydrate from previously saved step_progress.step_data['vocab']. */
+  /** Rehydrate from previously saved step_progress.step_data['character-practice']. */
   initialProgress?: VocabStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: VocabStepData, immediate?: boolean) => void;
@@ -249,7 +249,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({
 
   const handleFinish = () => {
     // Immediate flush with the result summary so teacher dashboard can read it
-    // directly from step_data['vocab'].result (Issue #1549).
+    // directly from step_data['character-practice'].result (Issue #1549).
     onProgressChange?.(
       buildStepData({ result: { practiced_words: vocabWords, total_words: vocabWords.length } }),
       true,

--- a/frontend/src/components/reading-steps/__tests__/Intro.aiTts.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/Intro.aiTts.test.tsx
@@ -60,8 +60,8 @@ vi.mock('../../../hooks/useFocusTrap', () => ({
 
 vi.mock('../../../config/stepConfig', () => ({
   resolveActiveSteps: () => [
-    { id: 'reading-annotation', label: '做記號' },
-    { id: 'tutor', label: '逐段朗讀' },
+    { id: 'full-text-annotate', label: '做記號' },
+    { id: 'paragraph-reading', label: '逐段朗讀' },
   ],
 }));
 

--- a/frontend/src/components/reading-steps/__tests__/Intro.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/Intro.test.tsx
@@ -37,8 +37,8 @@ vi.mock('../../../hooks/useFocusTrap', () => ({
 
 vi.mock('../../../config/stepConfig', () => ({
   resolveActiveSteps: () => [
-    { id: 'reading-annotation', label: '做記號' },
-    { id: 'tutor', label: '逐段朗讀' },
+    { id: 'full-text-annotate', label: '做記號' },
+    { id: 'paragraph-reading', label: '逐段朗讀' },
   ],
 }));
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.readAgain.test.tsx
@@ -4,7 +4,7 @@
  * Scenario: 單段課 +「再讀一次」.
  * Two things must happen when the student clicks「再讀一次」on a completed lesson:
  *  1. onResetTutor() is invoked — the cross-layer full reset (DB step_data.tutor,
- *     steps_completed 'tutor', session.readingAttempt, completedParagraphsSet, …) that
+ *     steps_completed 'paragraph-reading', session.readingAttempt, completedParagraphsSet, …) that
  *     stops the round-trip / reload from resurrecting old 成績. (資料清除本體在
  *     useStepProgressPersistence.resetTutorStep，另有專屬 hook 測試守著。)
  *  2. The stale 朗讀對照 diff is cleared. For a single-paragraph lesson currentLineIndex

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -72,12 +72,12 @@ interface LiveTutorProps {
   onParagraphComplete?: (completedParagraphIndex: number) => void;
   /** Initial set of completed paragraph indices (for session resume). */
   initialCompletedParagraphs?: Set<number>;
-  /** Rehydrate from previously saved step_progress.step_data['tutor'] (Issue #1549). */
+  /** Rehydrate from previously saved step_progress.step_data['paragraph-reading'] (Issue #1549). */
   initialProgress?: TutorStepData;
   /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
   onProgressChange?: (stepData: TutorStepData, immediate?: boolean) => void;
   /** Issue #2532: full tutor reset for「再讀一次」— clears DB step_data.tutor,
-   *  steps_completed 'tutor', session-level tutor state and completedParagraphsSet.
+   *  steps_completed 'paragraph-reading', session-level tutor state and completedParagraphsSet.
    *  Owned by useStepProgressPersistence (LearningLayout); undefined in toolbox mode. */
   onResetTutor?: () => void;
   /** DB LearningSession integer id — used to bind accepted audio to the attempt row
@@ -424,7 +424,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   //     - resetForRetry() —— 清 in-memory lineResults/summaries/completed + liveTutor_progress_，
   //       回到第 1 段。
   //  B. 跨層 (onResetTutor → useStepProgressPersistence.resetTutorStep)：
-  //     DB step_data.tutor（含 readingAttempt）、steps_completed 'tutor'、
+  //     DB step_data.tutor（含 readingAttempt）、steps_completed 'paragraph-reading'、
   //     session.readingAttempt/completedParagraphs/completedSteps、completedParagraphsSet、
   //     tutor_completed_ localStorage —— 這些狀態不在 LiveTutor，集中在該 hook 一次清乾淨。
   const handleReadAgain = useCallback(() => {
@@ -657,7 +657,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     } catch {}
   }, [lineResults, paragraphSummaries, completedParagraphs, currentLineIndex, storageKey]);
 
-  // ── Issue #2530: 同步把逐段結果寫進 DB step_data['tutor']，讓「朗讀對照／這次成績」
+  // ── Issue #2530: 同步把逐段結果寫進 DB step_data['paragraph-reading']，讓「朗讀對照／這次成績」
   //     在導航去總結報告再回來、以及跨 session（換裝置/重新登入）時都能回歸 ──────────
   useEffect(() => {
     if (isToolboxMode()) return;            // toolbox 為暫時模式，不寫 session DB

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useLiveTutorProgress.ts
@@ -79,7 +79,7 @@ export function useLiveTutorProgress(
   onFinish: (attempt: ReadingAttempt) => void,
   onParagraphComplete?: (completedParagraphIndex: number) => void,
   initialCompletedParagraphs?: Set<number>,
-  /** Issue #2530: DB step_data['tutor'] — restore fallback when localStorage is empty
+  /** Issue #2530: DB step_data['paragraph-reading'] — restore fallback when localStorage is empty
    *  (e.g. cross-session / cleared), so 逐段朗讀紀錄回歸. */
   initialProgress?: TutorStepData,
 ) {

--- a/frontend/src/components/student/RecommendedStories.tsx
+++ b/frontend/src/components/student/RecommendedStories.tsx
@@ -135,7 +135,7 @@ const RecommendedStories: React.FC = () => {
   }, [fetchRecs]);
 
   const handleStart = (storySlug: string) => {
-    navigate(`/learn/${storySlug}/intro`);
+    navigate(`/learn/${storySlug}/lesson-intro`);
   };
 
   // ── Loading ──────────────────────────────────────────────────────────────

--- a/frontend/src/components/student/home/__tests__/TodayLessonCard.test.tsx
+++ b/frontend/src/components/student/home/__tests__/TodayLessonCard.test.tsx
@@ -55,7 +55,7 @@ const mockAssignmentPending: StudentAssignmentResponse = {
 const mockAssignmentInProgress: StudentAssignmentResponse = {
   ...mockAssignmentPending,
   status: 'in_progress',
-  current_step: 'tutor',
+  current_step: 'paragraph-reading',
 };
 
 const mockClassroom: StudentEnrolledClassroom = {

--- a/frontend/src/components/tools/ToolPicker.tsx
+++ b/frontend/src/components/tools/ToolPicker.tsx
@@ -19,18 +19,18 @@ export interface ToolOption {
 // (Future: derive from STEP_CONFIG to avoid manual sync — see #1333)
 export const TOOL_OPTIONS: ToolOption[] = [
   {
-    id: 'tutor',
+    id: 'paragraph-reading',
     label: '朗讀練習',
     description: '逐段朗讀，AI 即時糾正',
     icon: '🎤',
-    stepPath: 'tutor',
+    stepPath: 'paragraph-reading',
   },
   {
-    id: 'full-reading',
+    id: 'key-passage-reading',
     label: '全文朗讀',
     description: '完整朗讀評估',
     icon: '📖',
-    stepPath: 'full-reading',
+    stepPath: 'key-passage-reading',
   },
   {
     id: 'listening',
@@ -40,11 +40,11 @@ export const TOOL_OPTIONS: ToolOption[] = [
     stepPath: 'listening',
   },
   {
-    id: 'vocab',
+    id: 'character-practice',
     label: '生字書寫',
     description: '筆順練習 + 注音引導',
     icon: '🖊️',
-    stepPath: 'vocab',
+    stepPath: 'character-practice',
   },
   {
     id: 'sentence-practice',
@@ -76,11 +76,11 @@ export const TOOL_OPTIONS: ToolOption[] = [
     stepPath: 'comprehension',
   },
   {
-    id: 'vocab-word-search',
+    id: 'vocab-review',
     label: '詞語搜尋',
     description: '在文章中找出目標詞語',
     icon: '🔍',
-    stepPath: 'vocab-word-search',
+    stepPath: 'vocab-review',
   },
   {
     id: 'knowledge-station',

--- a/frontend/src/components/tools/ToolboxCompletionActions.tsx
+++ b/frontend/src/components/tools/ToolboxCompletionActions.tsx
@@ -28,15 +28,15 @@ import { recordToolboxCompletion, type ToolId } from '../../services/toolboxApi'
 
 // Order matches backend TOOL_MODEL_MAP and frontend TOOL_OPTIONS.
 const TOOLBOX_TOOL_IDS: readonly ToolId[] = [
-  'tutor',
-  'full-reading',
+  'paragraph-reading',
+  'key-passage-reading',
   'listening',
-  'vocab',
+  'character-practice',
   'sentence-practice',
   'vocab-definition',
   'vocab-application',
   'comprehension',
-  'vocab-word-search',
+  'vocab-review',
   'knowledge-station',
 ] as const;
 

--- a/frontend/src/config/stepConfig.test.ts
+++ b/frontend/src/config/stepConfig.test.ts
@@ -10,7 +10,7 @@ import {
 // lesson YAML (backend/data/lessons/L43.yml worksheet_section_order).
 const L43_WORKSHEET = [
   { number: '一', name: '讀全文-做記號', type: 'reading_annotation' },
-  { number: '二', name: '逐段朗讀', type: 'tutor' },
+  { number: '二', name: '逐段朗讀', type: 'paragraph-reading' },
   { number: '三', name: '全文朗讀', type: 'full_reading' },
   { number: '四', name: '詞語理解', type: 'vocab_definition' },
   { number: '五', name: '語詞應用', type: 'vocab_application' },
@@ -25,16 +25,16 @@ const L43_WORKSHEET = [
 describe('stepSequenceFromWorksheet — 學習步驟動態對應學習單', () => {
   it('maps section type (underscore) → step id (hyphen) and prepends intro', () => {
     expect(stepSequenceFromWorksheet(L43_WORKSHEET)).toEqual([
-      'intro',
-      'reading-annotation',
-      'tutor',
-      'full-reading',
+      'lesson-intro',
+      'full-text-annotate',
+      'paragraph-reading',
+      'key-passage-reading',
       'vocab-definition',
       'vocab-application',
-      'story-structure', // worksheet 六 — 文章重點表
-      'reading-strategy', // worksheet 七 — 閱讀聚光燈 (AFTER 重點表)
+      'keypoints-table', // worksheet 六 — 文章重點表
+      'spotlight', // worksheet 七 — 閱讀聚光燈 (AFTER 重點表)
       'comprehension',
-      'vocab-word-search',
+      'vocab-review',
       'knowledge-station',
       'report',
     ]);
@@ -44,9 +44,9 @@ describe('stepSequenceFromWorksheet — 學習步驟動態對應學習單', () =
     // DEFAULT_STEP_SEQUENCE orders reading-strategy BEFORE story-structure;
     // the paper worksheet is the opposite. The nav must follow the paper.
     const seq = stepSequenceFromWorksheet(L43_WORKSHEET)!;
-    expect(seq.indexOf('story-structure')).toBeLessThan(seq.indexOf('reading-strategy'));
+    expect(seq.indexOf('keypoints-table')).toBeLessThan(seq.indexOf('spotlight'));
     const ids = resolveActiveSteps(seq).map((s) => s.id);
-    expect(ids.indexOf('story-structure')).toBeLessThan(ids.indexOf('reading-strategy'));
+    expect(ids.indexOf('keypoints-table')).toBeLessThan(ids.indexOf('spotlight'));
   });
 
   it('returns null for empty/missing worksheet → caller falls back to DEFAULT', () => {
@@ -61,7 +61,7 @@ describe('stepSequenceFromWorksheet — 學習步驟動態對應學習單', () =
         { number: '一', name: 'X', type: 'bogus_type' },
         { number: '二', name: '閱讀理解', type: 'comprehension' },
       ]),
-    ).toEqual(['intro', 'comprehension']);
+    ).toEqual(['lesson-intro', 'comprehension']);
   });
 });
 
@@ -95,10 +95,10 @@ describe('stepSequenceFromWorksheet — REAL parser vocabulary alias map (#2526)
   // transform MUST resolve to a real STEP_REGISTRY id (no silent drop).
   it.each([
     ['vocab_definitions', 'vocab-definition'], //  ALIAS (plural → singular)
-    ['structure_table', 'story-structure'], //     ALIAS
-    ['spotlight', 'reading-strategy'], //          ALIAS
+    ['structure_table', 'keypoints-table'], //     ALIAS
+    ['spotlight', 'spotlight'], //          ALIAS
     ['mcq', 'comprehension'], //                   ALIAS
-    ['word_search', 'vocab-word-search'], //       ALIAS
+    ['word_search', 'vocab-review'], //       ALIAS
     ['vocab_application', 'vocab-application'], //  already worked (dash transform)
     ['knowledge_station', 'knowledge-station'], //  already worked (dash transform)
   ])('parser type "%s" resolves to registry id "%s"', (type, expectedId) => {
@@ -111,15 +111,15 @@ describe('stepSequenceFromWorksheet — REAL parser vocabulary alias map (#2526)
   it('resolves a full real worksheet in order (reading_timer → full-reading, all 8 kept)', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(stepSequenceFromWorksheet(G8_L16_WORKSHEET)).toEqual([
-      'intro',
-      'full-reading', //  念順順 → 重點朗讀 (full-reading 改造, 2026-07-20 教授審查定調)
+      'lesson-intro',
+      'key-passage-reading', //  念順順 → 重點朗讀 (full-reading 改造, 2026-07-20 教授審查定調)
       'vocab-definition',
       'vocab-application',
-      'story-structure',
+      'keypoints-table',
       'knowledge-station',
-      'reading-strategy',
+      'spotlight',
       'comprehension',
-      'vocab-word-search',
+      'vocab-review',
     ]);
   });
 
@@ -136,16 +136,16 @@ describe('stepSequenceFromWorksheet — REAL parser vocabulary alias map (#2526)
     // 2026-07-20 教授審查會議解決了唯一歧義：念順順 (reading_timer) = 1 分鐘計時流暢朗讀。
     // 做法＝把 full-reading step 改造成「重點朗讀」(保留 id 避免完成-識別 bug)，reading_timer 對應過去。
     expect([...KNOWN_UNMAPPED_WORKSHEET_TYPES]).toEqual([]);
-    expect(STEP_REGISTRY['full-reading']).toBeDefined();
-    expect(STEP_REGISTRY['full-reading'].label).toBe('重點朗讀');
+    expect(STEP_REGISTRY['key-passage-reading']).toBeDefined();
+    expect(STEP_REGISTRY['key-passage-reading'].label).toBe('重點朗讀');
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const seq = stepSequenceFromWorksheet([
       { number: '二', name: '念順順', type: 'reading_timer' },
       { number: '八', name: '閱讀理解', type: 'mcq' },
     ]);
-    expect(seq).toContain('full-reading'); //     念順順 now resolves (重點朗讀)
-    expect(seq).not.toContain('tutor'); //        逐段 hidden from nav
+    expect(seq).toContain('key-passage-reading'); //     念順順 now resolves (重點朗讀)
+    expect(seq).not.toContain('paragraph-reading'); //        逐段 hidden from nav
     expect(seq).toContain('comprehension'); //    mcq still resolves alongside
     expect(
       warnSpy.mock.calls.some((args) => args.some((a) => String(a).includes('reading_timer'))),

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -8,7 +8,7 @@
  *
  * DEFAULT_STEP_SEQUENCE: the canonical ordered list of step IDs for legacy lessons
  *   that do not carry their own step_sequence field.
- *   New lessons can include `step_sequence: ['reading-annotation', 'tutor', ...]`
+ *   New lessons can include `step_sequence: ['full-text-annotate', 'paragraph-reading', ...]`
  *   in their YAML to override this default.
  *
  * Consumers that need the active ordered list should use:
@@ -84,8 +84,8 @@ export interface StepConfig {
  *   New comprehension split steps use dbStepNumbers 15–16 (Issue #1335).
  */
 export const STEP_REGISTRY: Record<string, StepConfig> = {
-  'intro': {
-    id: 'intro',
+  'lesson-intro': {
+    id: 'lesson-intro',
     label: '課程簡介',
     displayChar: '簡',
     hint: '看看這堂課要學什麼策略，以及有哪些步驟',
@@ -95,8 +95,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     enabled: true,
     category: 'reading',
   },
-  'reading-annotation': {
-    id: 'reading-annotation',
+  'full-text-annotate': {
+    id: 'full-text-annotate',
     label: '讀全文-做記號',
     displayChar: '記',
     hint: '閱讀全文，選取不懂或重要的詞語做記號',
@@ -106,8 +106,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     enabled: true,
     category: 'reading',
   },
-  'tutor': {
-    id: 'tutor',
+  'paragraph-reading': {
+    id: 'paragraph-reading',
     label: '逐段朗讀',
     displayChar: '段',
     hint: '跟著 AI 一段一段大聲朗讀',
@@ -119,14 +119,14 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
   },
   // 2026-07-20 教授審查決策（曾世傑教授）：朗讀只練老師指定的「重點段落」(念順順，約 300-400 字，
   // 課文旁手指頭符號標起點、右欄累計字數標長度)，不練全文。做法＝把既有 full-reading step **改造**成
-  // 重點朗讀（保留 step id 'full-reading' → 完成/進度/作業 gate 全沿用現成佈線，不新增 step 避免完成-識別 bug）。
+  // 重點朗讀（保留 step id 'key-passage-reading' → 完成/進度/作業 gate 全沿用現成佈線，不新增 step 避免完成-識別 bug）。
   // 重點段資料就緒前，FullReadingPage 暫唸全文作 fallback；Phase 1 接 key_reading 欄位後只唸指定段
   // （見 docs/reading-key-passage-TODO.md、skill build-key-reading）。
   // ⚠️ 改這個 id 一定要同步更新後端 `backend/app/models/session.py` 的 `_FRONTEND_STEP_ALIAS`
   // （前端 step key → 後端 canonical key → step number）。後端查無此 key 會算成 0，
   // 完成度掉單、作業提交卡住且靜默無 error（#2588）。
-  'full-reading': {
-    id: 'full-reading',
+  'key-passage-reading': {
+    id: 'key-passage-reading',
     label: '重點朗讀',
     displayChar: '朗',
     hint: '朗讀老師指定的重點段落，練習流暢度',
@@ -147,8 +147,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     enabled: false, // hidden from StepperNav per product decision 2026-05-01 — accessible via ToolPicker
     category: 'comprehension',
   },
-  'vocab': {
-    id: 'vocab',
+  'character-practice': {
+    id: 'character-practice',
     label: '生字練習',
     displayChar: '字',
     hint: '練習課文中的生字筆順與讀音',
@@ -181,8 +181,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     category: 'practice',
   },
   // Issue #1335: split old "comprehension" tab-container into 3 independent steps
-  'story-structure': {
-    id: 'story-structure',
+  'keypoints-table': {
+    id: 'keypoints-table',
     label: '文章重點表',
     displayChar: '重',
     hint: '把課文重點填進去，讓 AI 幫你檢查',
@@ -192,8 +192,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     enabled: true,
     category: 'comprehension',
   },
-  'reading-strategy': {
-    id: 'reading-strategy',
+  'spotlight': {
+    id: 'spotlight',
     label: '閱讀聚光燈',
     displayChar: '光',
     hint: '練習這課的閱讀策略',
@@ -227,8 +227,8 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
     enabled: true,
     category: 'comprehension',
   },
-  'vocab-word-search': {
-    id: 'vocab-word-search',
+  'vocab-review': {
+    id: 'vocab-review',
     label: '語詞複習',
     displayChar: '複',
     hint: '在字母格中找出學過的詞語',
@@ -293,19 +293,19 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
  *   - 閱讀理解   (comprehension, dbStep 3)       — was tab 1 inside ComprehensionChat
  */
 export const DEFAULT_STEP_SEQUENCE: string[] = [
-  'intro',
-  'reading-annotation',
-  'tutor',
-  'full-reading',
+  'lesson-intro',
+  'full-text-annotate',
+  'paragraph-reading',
+  'key-passage-reading',
   'listening',
-  'vocab',
+  'character-practice',
   'vocab-definition',
   'vocab-application',
-  'reading-strategy',
-  'story-structure',
+  'spotlight',
+  'keypoints-table',
   'sentence-practice',
   'comprehension',
-  'vocab-word-search',
+  'vocab-review',
   'dictation',
   'knowledge-station',
   'report',
@@ -361,13 +361,13 @@ export function resolveActiveSteps(lessonStepSequence?: string[] | null): StepCo
  * When the parser vocabulary drifts, add the new alias here (a console.warn in
  * stepSequenceFromWorksheet flags any type that still resolves to nothing).
  */
-const WORKSHEET_TYPE_ALIASES: Record<string, string> = {
+export const WORKSHEET_TYPE_ALIASES: Record<string, string> = {
   vocab_definitions: 'vocab-definition', // 語詞我最棒 (plural type → singular id)
-  structure_table: 'story-structure', //   文章重點表
-  spotlight: 'reading-strategy', //         閱讀聚光燈
+  structure_table: 'keypoints-table', //   文章重點表
+  reading_strategy: 'spotlight', //   閱讀聚光燈（學習單的 section type 是 reading_strategy，不可改）
   mcq: 'comprehension', //                  閱讀理解
-  word_search: 'vocab-word-search', //      詞語複習
-  reading_timer: 'full-reading', //         念順順 → 重點朗讀（full-reading 已改造成重點朗讀，2026-07-20）
+  word_search: 'vocab-review', //      詞語複習
+  reading_timer: 'key-passage-reading', //         念順順 → 重點朗讀（full-reading 已改造成重點朗讀，2026-07-20）
 };
 
 /**
@@ -392,22 +392,42 @@ export const KNOWN_UNMAPPED_WORKSHEET_TYPES = [] as const;
  * — the 5/1 "學習步驟動態對應學習單" requirement — instead of the flat
  * DEFAULT_STEP_SEQUENCE (which e.g. orders 文章重點表/閱讀聚光燈 opposite to the paper).
  *
- * 'intro' is prepended (the online flow always opens with it; the paper starts
+ * 'lesson-intro' is prepended (the online flow always opens with it; the paper starts
  * at 讀全文). Unmapped types are dropped (with a console.warn — see below), and
  * disabled steps are dropped later by resolveActiveSteps. Returns null when
  * there is no worksheet order so callers fall back to DEFAULT_STEP_SEQUENCE.
  */
+export const LEGACY_STEP_ID_ALIASES: Record<string, string> = {
+  'full-reading': 'key-passage-reading',
+  tutor: 'paragraph-reading',
+  intro: 'lesson-intro',
+  'reading-annotation': 'full-text-annotate',
+  'reading-strategy': 'spotlight',
+  'story-structure': 'keypoints-table',
+  vocab: 'character-practice',
+  'vocab-word-search': 'vocab-review',
+};
+
+/** Resolve a possibly-legacy step id to the current one. Unknown ids pass through. */
+export function resolveStepId(id: string): string {
+  return LEGACY_STEP_ID_ALIASES[id] ?? id;
+}
+
 export function stepSequenceFromWorksheet(
   worksheet?: Array<{ number?: string; name?: string; type?: string }> | null,
 ): string[] | null {
   if (!worksheet || worksheet.length === 0) return null;
-  const ids: string[] = ['intro'];
+  const ids: string[] = ['lesson-intro'];
   for (const section of worksheet) {
     const type = section?.type;
     if (!type) continue;
     // Alias BEFORE the dash transform, then look up in the registry.
     const aliased = WORKSHEET_TYPE_ALIASES[type] ?? type;
-    const id = aliased.replace(/_/g, '-'); // reading_annotation → reading-annotation
+    // Underscore→dash yields the *historical* id (reading_annotation →
+    // reading-annotation). Run it through the legacy resolver so worksheet
+    // vocabulary — printed on paper and therefore unrenameable — keeps
+    // reaching the current step ids.
+    const id = resolveStepId(aliased.replace(/_/g, '-'));
     if (STEP_REGISTRY[id]) {
       if (!ids.includes(id)) ids.push(id);
     } else {
@@ -433,12 +453,34 @@ export function stepSequenceFromWorksheet(
 /** All enabled steps in default display order. Equivalent to resolveActiveSteps(). */
 export const ACTIVE_STEPS = resolveActiveSteps();
 
-/** Map from URL path id (e.g. "intro") to dbStepNumber (e.g. 1). */
+/** Map from URL path id (e.g. "lesson-intro") to dbStepNumber (e.g. 1). */
 export const STEP_PATH_TO_NUMBER: Record<string, number> = Object.fromEntries(
   Object.values(STEP_REGISTRY).map((s) => [s.id, s.dbStepNumber]),
 );
 
-/** Map from URL path id to AppView (e.g. "intro" → AppView.INTRO). */
+/** Map from URL path id to AppView (e.g. "lesson-intro" → AppView.INTRO). */
 export const PATH_TO_VIEW: Record<string, AppView> = Object.fromEntries(
   Object.values(STEP_REGISTRY).map((s) => [s.id, s.view]),
 );
+
+// ---------------------------------------------------------------------------
+// Legacy step ids
+// ---------------------------------------------------------------------------
+
+/**
+ * Old id → current id.
+ *
+ * The ids were renamed so each one says what its label says. Two were
+ * outright inverted before that: `full-reading` read a single key passage,
+ * while `reading-annotation` was the step that actually read the whole text —
+ * which is how a feature ended up wired to `tutor`, a step disabled since
+ * 2026-07-20, and how the 「全文」 QR codes came to point at the intro page.
+ *
+ * These aliases exist because URLs have already been handed out: QR codes
+ * generated from the admin panel, links in issues, links in docs. Resolving
+ * them costs one lookup and saves every one of those from 404ing.
+ *
+ * dbStepNumber is deliberately untouched by the rename — student progress is
+ * stored as that integer, never as the id string, so no row had to move.
+ */
+

--- a/frontend/src/config/stepNaming.test.ts
+++ b/frontend/src/config/stepNaming.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Locks the step ids to their Chinese labels.
+ *
+ * Five names existed for one thing and no two agreed: 念順順 on the paper
+ * worksheet, `reading_timer` in the data, `full-reading` in the URL, 重點朗讀 on
+ * screen, `LiveTutor` in code. That cost real time twice in one day — a feature
+ * was wired to `tutor`, disabled since 2026-07-20, and the 「全文」 QR codes point
+ * at the intro page because no whole-text reading step exists at all.
+ *
+ * Two ids were outright inverted: `full-reading` read a single key passage,
+ * while `reading-annotation` was the one that actually read the whole text.
+ */
+import { describe, it, expect } from 'vitest';
+import { STEP_REGISTRY, WORKSHEET_TYPE_ALIASES, LEGACY_STEP_ID_ALIASES, resolveStepId } from './stepConfig';
+
+/** id → label. The id must say what the label says. */
+const EXPECTED_NAMING: Record<string, string> = {
+  'lesson-intro': '課程簡介',
+  'full-text-annotate': '讀全文-做記號',
+  'paragraph-reading': '逐段朗讀',
+  'key-passage-reading': '重點朗讀',
+  listening: '聽力理解',
+  'character-practice': '生字練習',
+  'vocab-definition': '詞語理解',
+  'vocab-application': '語詞應用',
+  'keypoints-table': '文章重點表',
+  spotlight: '閱讀聚光燈',
+  'sentence-practice': '造句練習',
+  comprehension: '閱讀理解',
+  'vocab-review': '語詞複習',
+  dictation: '聽寫練習',
+  'knowledge-station': '知識補給站',
+  report: '報告',
+};
+
+/**
+ * Student progress is stored as an integer (`current_step: Mapped[int]` in
+ * backend/app/models/session.py), never as the id string. Freezing these numbers
+ * is what makes the rename a no-migration change — if one moves, existing
+ * progress rows start pointing at a different step.
+ */
+const FROZEN_DB_STEP_NUMBERS: Record<string, number> = {
+  'lesson-intro': 1,
+  'paragraph-reading': 2,
+  comprehension: 3,
+  'character-practice': 4,
+  dictation: 5,
+  'key-passage-reading': 6,
+  report: 7,
+  'full-text-annotate': 8,
+  'vocab-application': 9,
+  'vocab-review': 10,
+  'knowledge-station': 11,
+  'vocab-definition': 12,
+  listening: 13,
+  'sentence-practice': 14,
+  'keypoints-table': 15,
+  spotlight: 16,
+};
+
+describe('step id 必須說出它的中文意思', () => {
+  it('every registered step has the expected id→label pairing', () => {
+    const actual = Object.fromEntries(
+      Object.entries(STEP_REGISTRY).map(([id, cfg]) => [id, cfg.label]),
+    );
+    expect(actual).toEqual(EXPECTED_NAMING);
+  });
+
+  it('no id survives that contradicts its label', () => {
+    // The two that were inverted. Named explicitly so a partial rename cannot
+    // pass by leaving the worst offenders behind.
+    expect(STEP_REGISTRY).not.toHaveProperty('full-reading');
+    expect(STEP_REGISTRY).not.toHaveProperty('tutor');
+  });
+});
+
+describe('dbStepNumber 凍結 — 這是免 migration 的保證', () => {
+  it.each(Object.entries(FROZEN_DB_STEP_NUMBERS))(
+    '%s keeps dbStepNumber %i',
+    (id, num) => {
+      expect(STEP_REGISTRY[id]?.dbStepNumber).toBe(num);
+    },
+  );
+});
+
+describe('舊 id 仍然解析得到 — 已發出的連結與 QR 不能 404', () => {
+  it.each([
+    ['full-reading', 'key-passage-reading'],
+    ['tutor', 'paragraph-reading'],
+    ['intro', 'lesson-intro'],
+    ['reading-annotation', 'full-text-annotate'],
+    ['reading-strategy', 'spotlight'],
+    ['story-structure', 'keypoints-table'],
+    ['vocab', 'character-practice'],
+    ['vocab-word-search', 'vocab-review'],
+  ])('%s → %s', (oldId, newId) => {
+    expect(LEGACY_STEP_ID_ALIASES[oldId]).toBe(newId);
+    expect(resolveStepId(oldId)).toBe(newId);
+  });
+
+  it('a current id resolves to itself', () => {
+    expect(resolveStepId('key-passage-reading')).toBe('key-passage-reading');
+  });
+});
+
+describe('念順順 仍然接得回平台', () => {
+  it('reading_timer maps to the key-passage step', () => {
+    // The one thing the 2026-07-20 expert review settled: 朗讀 practises the
+    // teacher-marked passage, not the whole text. Break this and the paper
+    // worksheet stops connecting to the platform.
+    expect(WORKSHEET_TYPE_ALIASES.reading_timer).toBe('key-passage-reading');
+  });
+});

--- a/frontend/src/hooks/__tests__/useCurrentStepId.test.tsx
+++ b/frontend/src/hooks/__tests__/useCurrentStepId.test.tsx
@@ -1,7 +1,7 @@
 /**
  * useCurrentStepId (#2588) — route-derived step id with a fail-safe fallback.
  *
- * Pages used to hardcode their step id (FullReadingPage wrote 'full-reading' in
+ * Pages used to hardcode their step id (FullReadingPage wrote 'key-passage-reading' in
  * three places).  The hook derives it from the route so a renamed / re-mounted
  * step cannot split progress across two keys — but it must NEVER return an
  * unregistered id, because the backend maps step keys to step numbers and an
@@ -20,30 +20,30 @@ const wrapperFor = (initialPath: string) =>
     return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
   };
 
-const renderAt = (path: string, fallback = 'full-reading') =>
+const renderAt = (path: string, fallback = 'key-passage-reading') =>
   renderHook(() => useCurrentStepId(fallback), { wrapper: wrapperFor(path) }).result.current;
 
 describe('useCurrentStepId', () => {
   it('returns the route segment when it is a registered step', () => {
-    expect(renderAt('/learn/1/full-reading')).toBe('full-reading');
-    expect(renderAt('/learn/42/tutor', 'full-reading')).toBe('tutor');
+    expect(renderAt('/learn/1/key-passage-reading')).toBe('key-passage-reading');
+    expect(renderAt('/learn/42/paragraph-reading', 'key-passage-reading')).toBe('paragraph-reading');
   });
 
   it('follows the route when the step is mounted under a different registered id', () => {
     // Simulates a future rename: the page must report the id it is mounted at,
     // not the literal it was written with.
-    const anyOtherStepId = 'vocab';
+    const anyOtherStepId = 'character-practice';
     expect(STEP_REGISTRY[anyOtherStepId]).toBeTruthy();
-    expect(renderAt(`/learn/1/${anyOtherStepId}`, 'full-reading')).toBe(anyOtherStepId);
+    expect(renderAt(`/learn/1/${anyOtherStepId}`, 'key-passage-reading')).toBe(anyOtherStepId);
   });
 
   it('falls back to the canonical id for an UNREGISTERED segment (never persists unknown keys)', () => {
-    expect(renderAt('/learn/1/not-a-step')).toBe('full-reading');
+    expect(renderAt('/learn/1/not-a-step')).toBe('key-passage-reading');
   });
 
   it('falls back outside the learning flow / on trailing slashes', () => {
-    expect(renderAt('/library')).toBe('full-reading');
-    expect(renderAt('/learn/1/')).toBe('full-reading');
-    expect(renderAt('/')).toBe('full-reading');
+    expect(renderAt('/library')).toBe('key-passage-reading');
+    expect(renderAt('/learn/1/')).toBe('key-passage-reading');
+    expect(renderAt('/')).toBe('key-passage-reading');
   });
 });

--- a/frontend/src/hooks/__tests__/useLearningStepNavigation1954.test.ts
+++ b/frontend/src/hooks/__tests__/useLearningStepNavigation1954.test.ts
@@ -31,18 +31,18 @@ import {
 describe('STEP_FINISH_TRANSITIONS table', () => {
   it('covers all 13 expected step ids', () => {
     const expectedKeys = [
-      'tutor',
+      'paragraph-reading',
       'comprehension',
-      'vocab',
-      'full-reading',
+      'character-practice',
+      'key-passage-reading',
       'listening',
-      'reading-annotation',
+      'full-text-annotate',
       'vocab-definition',
       'vocab-application',
-      'story-structure',
-      'reading-strategy',
+      'keypoints-table',
+      'spotlight',
       'sentence-practice',
-      'vocab-word-search',
+      'vocab-review',
       'knowledge-station',
     ];
     for (const key of expectedKeys) {
@@ -61,11 +61,11 @@ describe('STEP_FINISH_TRANSITIONS table', () => {
   });
 
   it('reading-annotation → nextStep is tutor', () => {
-    expect(STEP_FINISH_TRANSITIONS['reading-annotation'].nextStep).toBe('tutor');
+    expect(STEP_FINISH_TRANSITIONS['full-text-annotate'].nextStep).toBe('paragraph-reading');
   });
 
   it('tutor → nextStep is full-reading', () => {
-    expect(STEP_FINISH_TRANSITIONS['tutor'].nextStep).toBe('full-reading');
+    expect(STEP_FINISH_TRANSITIONS['paragraph-reading'].nextStep).toBe('key-passage-reading');
   });
 
   it('knowledge-station → nextStep is report', () => {
@@ -73,11 +73,11 @@ describe('STEP_FINISH_TRANSITIONS table', () => {
   });
 
   it('comprehension → nextStep is vocab-word-search', () => {
-    expect(STEP_FINISH_TRANSITIONS['comprehension'].nextStep).toBe('vocab-word-search');
+    expect(STEP_FINISH_TRANSITIONS['comprehension'].nextStep).toBe('vocab-review');
   });
 
   it('vocab-word-search → nextStep is knowledge-station', () => {
-    expect(STEP_FINISH_TRANSITIONS['vocab-word-search'].nextStep).toBe('knowledge-station');
+    expect(STEP_FINISH_TRANSITIONS['vocab-review'].nextStep).toBe('knowledge-station');
   });
 });
 
@@ -85,8 +85,8 @@ describe('STEP_FINISH_TRANSITIONS table', () => {
 
 describe('getDefaultNextStep', () => {
   it('returns the mapped nextStep for a known step', () => {
-    expect(getDefaultNextStep('tutor')).toBe('full-reading');
-    expect(getDefaultNextStep('comprehension')).toBe('vocab-word-search');
+    expect(getDefaultNextStep('paragraph-reading')).toBe('key-passage-reading');
+    expect(getDefaultNextStep('comprehension')).toBe('vocab-review');
     expect(getDefaultNextStep('knowledge-station')).toBe('report');
   });
 
@@ -95,8 +95,8 @@ describe('getDefaultNextStep', () => {
   });
 
   it('is a pure function (no side effects)', () => {
-    const result1 = getDefaultNextStep('tutor');
-    const result2 = getDefaultNextStep('tutor');
+    const result1 = getDefaultNextStep('paragraph-reading');
+    const result2 = getDefaultNextStep('paragraph-reading');
     expect(result1).toBe(result2);
   });
 });
@@ -105,9 +105,9 @@ describe('getDefaultNextStep', () => {
 
 describe('buildStepFinishPayload', () => {
   it('returns completeStep and nextStep from the transition table', () => {
-    const payload = buildStepFinishPayload('reading-annotation', {});
-    expect(payload.completeStep).toBe('reading-annotation');
-    expect(payload.nextStep).toBe('tutor');
+    const payload = buildStepFinishPayload('full-text-annotate', {});
+    expect(payload.completeStep).toBe('full-text-annotate');
+    expect(payload.nextStep).toBe('paragraph-reading');
   });
 
   it('includes stepDataPatch with the stepDataKey set to provided data', () => {
@@ -117,14 +117,14 @@ describe('buildStepFinishPayload', () => {
   });
 
   it('uses empty object as default stepData when none provided', () => {
-    const payload = buildStepFinishPayload('story-structure', {});
-    expect(payload.stepDataPatch).toEqual({ 'story-structure': {} });
+    const payload = buildStepFinishPayload('keypoints-table', {});
+    expect(payload.stepDataPatch).toEqual({ 'keypoints-table': {} });
   });
 
   it('produces correct currentStep (nextStep) for persistStepProgressState', () => {
     // persistStepProgressState `currentStep` = the step we navigate TO
     const payload = buildStepFinishPayload('vocab-application', {});
-    expect(payload.currentStep).toBe('story-structure');
+    expect(payload.currentStep).toBe('keypoints-table');
     expect(payload.completeStep).toBe('vocab-application');
   });
 
@@ -135,9 +135,9 @@ describe('buildStepFinishPayload', () => {
   });
 
   it('full-reading uses nextStep listening', () => {
-    const payload = buildStepFinishPayload('full-reading', { result: { score: 80 } });
+    const payload = buildStepFinishPayload('key-passage-reading', { result: { score: 80 } });
     expect(payload.nextStep).toBe('listening');
-    expect(payload.stepDataPatch).toEqual({ 'full-reading': { result: { score: 80 } } });
+    expect(payload.stepDataPatch).toEqual({ 'key-passage-reading': { result: { score: 80 } } });
   });
 
   it('sentence-practice uses nextStep vocab-definition', () => {
@@ -146,7 +146,7 @@ describe('buildStepFinishPayload', () => {
   });
 
   it('vocab-word-search: nextStep is knowledge-station', () => {
-    const payload = buildStepFinishPayload('vocab-word-search', { completed: true });
+    const payload = buildStepFinishPayload('vocab-review', { completed: true });
     expect(payload.nextStep).toBe('knowledge-station');
   });
 });
@@ -162,17 +162,17 @@ describe('default step sequence contract', () => {
    * knowledge-station → report
    */
   const expectedChain: [string, string][] = [
-    ['reading-annotation', 'tutor'],
-    ['tutor', 'full-reading'],
-    ['full-reading', 'listening'],
-    ['listening', 'vocab'],
-    ['vocab', 'vocab-definition'],
+    ['full-text-annotate', 'paragraph-reading'],
+    ['paragraph-reading', 'key-passage-reading'],
+    ['key-passage-reading', 'listening'],
+    ['listening', 'character-practice'],
+    ['character-practice', 'vocab-definition'],
     ['vocab-definition', 'vocab-application'],
-    ['vocab-application', 'story-structure'],
-    ['story-structure', 'reading-strategy'],
-    ['reading-strategy', 'comprehension'],
-    ['comprehension', 'vocab-word-search'],
-    ['vocab-word-search', 'knowledge-station'],
+    ['vocab-application', 'keypoints-table'],
+    ['keypoints-table', 'spotlight'],
+    ['spotlight', 'comprehension'],
+    ['comprehension', 'vocab-review'],
+    ['vocab-review', 'knowledge-station'],
     ['knowledge-station', 'report'],
   ];
 

--- a/frontend/src/hooks/stepHandlerUtils.ts
+++ b/frontend/src/hooks/stepHandlerUtils.ts
@@ -34,7 +34,7 @@ export interface StepFinishPayload {
  *
  * Pure function — no React dependency, fully testable in isolation.
  *
- * @param stepId   The step that just finished (e.g. 'reading-annotation').
+ * @param stepId   The step that just finished (e.g. 'full-text-annotate').
  * @param stepData Arbitrary data to store in the step's progress record.
  */
 export function buildStepFinishPayload(

--- a/frontend/src/hooks/stepNavigationTransitions.ts
+++ b/frontend/src/hooks/stepNavigationTransitions.ts
@@ -27,35 +27,35 @@ export interface StepFinishTransition {
  * handleFinish* callbacks in useLearningStepNavigation.ts.
  */
 export const STEP_FINISH_TRANSITIONS: Record<string, StepFinishTransition> = {
-  'tutor': {
-    completeStep: 'tutor',
-    nextStep: 'full-reading',
-    stepDataKey: 'tutor',
+  'paragraph-reading': {
+    completeStep: 'paragraph-reading',
+    nextStep: 'key-passage-reading',
+    stepDataKey: 'paragraph-reading',
   },
   'comprehension': {
     completeStep: 'comprehension',
-    nextStep: 'vocab-word-search',
+    nextStep: 'vocab-review',
     stepDataKey: 'comprehension',
   },
-  'vocab': {
-    completeStep: 'vocab',
+  'character-practice': {
+    completeStep: 'character-practice',
     nextStep: 'vocab-definition',
-    stepDataKey: 'vocab',
+    stepDataKey: 'character-practice',
   },
-  'full-reading': {
-    completeStep: 'full-reading',
+  'key-passage-reading': {
+    completeStep: 'key-passage-reading',
     nextStep: 'listening',
-    stepDataKey: 'full-reading',
+    stepDataKey: 'key-passage-reading',
   },
   'listening': {
     completeStep: 'listening',
-    nextStep: 'vocab',
+    nextStep: 'character-practice',
     stepDataKey: 'listening',
   },
-  'reading-annotation': {
-    completeStep: 'reading-annotation',
-    nextStep: 'tutor',
-    stepDataKey: 'reading-annotation',
+  'full-text-annotate': {
+    completeStep: 'full-text-annotate',
+    nextStep: 'paragraph-reading',
+    stepDataKey: 'full-text-annotate',
   },
   'vocab-definition': {
     completeStep: 'vocab-definition',
@@ -64,28 +64,28 @@ export const STEP_FINISH_TRANSITIONS: Record<string, StepFinishTransition> = {
   },
   'vocab-application': {
     completeStep: 'vocab-application',
-    nextStep: 'story-structure',
+    nextStep: 'keypoints-table',
     stepDataKey: 'vocab-application',
   },
-  'story-structure': {
-    completeStep: 'story-structure',
-    nextStep: 'reading-strategy',
-    stepDataKey: 'story-structure',
+  'keypoints-table': {
+    completeStep: 'keypoints-table',
+    nextStep: 'spotlight',
+    stepDataKey: 'keypoints-table',
   },
-  'reading-strategy': {
-    completeStep: 'reading-strategy',
+  'spotlight': {
+    completeStep: 'spotlight',
     nextStep: 'comprehension',
-    stepDataKey: 'reading-strategy',
+    stepDataKey: 'spotlight',
   },
   'sentence-practice': {
     completeStep: 'sentence-practice',
     nextStep: 'vocab-definition',
     stepDataKey: 'sentence-practice',
   },
-  'vocab-word-search': {
-    completeStep: 'vocab-word-search',
+  'vocab-review': {
+    completeStep: 'vocab-review',
     nextStep: 'knowledge-station',
-    stepDataKey: 'vocab-word-search',
+    stepDataKey: 'vocab-review',
   },
   'knowledge-station': {
     completeStep: 'knowledge-station',

--- a/frontend/src/hooks/useLearningSessionBootstrap.ts
+++ b/frontend/src/hooks/useLearningSessionBootstrap.ts
@@ -190,7 +190,7 @@ export function useLearningSessionBootstrap({
           saveActiveSession(String(user.id), {
             sessionId: 0,
             storyId,
-            currentStep: STEP_PATH_TO_NUMBER['reading-annotation'],
+            currentStep: STEP_PATH_TO_NUMBER['full-text-annotate'],
             timestamp: Date.now(),
           });
         }

--- a/frontend/src/hooks/useLearningStepNavigation.ts
+++ b/frontend/src/hooks/useLearningStepNavigation.ts
@@ -126,9 +126,9 @@ export function useLearningStepNavigation({
       }
       return null;
     });
-    persistStep(STEP_PATH_TO_NUMBER['reading-annotation']);
+    persistStep(STEP_PATH_TO_NUMBER['full-text-annotate']);
     ensureDbSession();
-    navigate(isToolboxMode() ? '/tools' : `/learn/${storyId}/reading-annotation`);
+    navigate(isToolboxMode() ? '/tools' : `/learn/${storyId}/full-text-annotate`);
   }, [storyId, selectedStory, navigate, persistStep, ensureDbSession, setSession]);
 
   // ─── Navigation helpers ───────────────────────────────────────────────────
@@ -178,8 +178,8 @@ export function useLearningStepNavigation({
   const handleFinishReading = useCallback(
     (attempt: ReadingAttempt) => {
       setLastAttempt(attempt);
-      // handleFinishReading completes the 'tutor' step (live tutor readout)
-      dispatchStepFinish('tutor', { readingAttempt: attempt }, { readingAttempt: attempt });
+      // handleFinishReading completes the 'paragraph-reading' step (live tutor readout)
+      dispatchStepFinish('paragraph-reading', { readingAttempt: attempt }, { readingAttempt: attempt });
     },
     [dispatchStepFinish, setLastAttempt],
   );
@@ -193,7 +193,7 @@ export function useLearningStepNavigation({
 
   const handleFinishVocab = useCallback(
     (result: VocabResult) => {
-      dispatchStepFinish('vocab', { result }, { vocabResult: result });
+      dispatchStepFinish('character-practice', { result }, { vocabResult: result });
     },
     [dispatchStepFinish],
   );
@@ -202,15 +202,15 @@ export function useLearningStepNavigation({
     (result: DictationResult) => {
       // Dictation has no persistStepProgressState call in the original — just navigate
       setSession((prev) => (prev ? { ...prev, dictationResult: result } : null));
-      persistStep(STEP_PATH_TO_NUMBER['vocab-word-search']);
-      navigateAfterFinish('vocab-word-search');
+      persistStep(STEP_PATH_TO_NUMBER['vocab-review']);
+      navigateAfterFinish('vocab-review');
     },
     [navigateAfterFinish, persistStep, setSession],
   );
 
   const handleFinishFullReading = useCallback(
     (result: FullReadingResult) => {
-      dispatchStepFinish('full-reading', { result }, { fullReadingResult: result });
+      dispatchStepFinish('key-passage-reading', { result }, { fullReadingResult: result });
     },
     [dispatchStepFinish],
   );
@@ -224,7 +224,7 @@ export function useLearningStepNavigation({
 
   const handleFinishReadingAnnotation = useCallback(
     (_summary: AnnotationSummary) => {
-      dispatchStepFinish('reading-annotation', { completed: true }, { readingAnnotationCompleted: true });
+      dispatchStepFinish('full-text-annotate', { completed: true }, { readingAnnotationCompleted: true });
     },
     [dispatchStepFinish],
   );
@@ -245,14 +245,14 @@ export function useLearningStepNavigation({
 
   const handleFinishStoryStructure = useCallback(
     () => {
-      dispatchStepFinish('story-structure', { completed: true });
+      dispatchStepFinish('keypoints-table', { completed: true });
     },
     [dispatchStepFinish],
   );
 
   const handleFinishReadingStrategy = useCallback(
     () => {
-      dispatchStepFinish('reading-strategy', { completed: true });
+      dispatchStepFinish('spotlight', { completed: true });
     },
     [dispatchStepFinish],
   );
@@ -266,7 +266,7 @@ export function useLearningStepNavigation({
 
   const handleFinishVocabWordSearch = useCallback(
     (_elapsedSeconds: number) => {
-      dispatchStepFinish('vocab-word-search', { completed: true }, { vocabWordSearchCompleted: true });
+      dispatchStepFinish('vocab-review', { completed: true }, { vocabWordSearchCompleted: true });
     },
     [dispatchStepFinish],
   );

--- a/frontend/src/hooks/useStepProgressPersistence.resetTutorStep.test.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.resetTutorStep.test.ts
@@ -5,7 +5,7 @@
  * useStepProgressPersistence.resetTutorStep (invoked via LiveTutor's onResetTutor).
  *
  * RED before the fix: resetForRetry() only cleared React state + liveTutor_progress_
- * localStorage, leaving step_data.tutor (incl. readingAttempt), steps_completed 'tutor',
+ * localStorage, leaving step_data.tutor (incl. readingAttempt), steps_completed 'paragraph-reading',
  * session.readingAttempt, and completedParagraphsSet intact → old 成績 resurrected.
  */
 
@@ -50,7 +50,7 @@ describe('useStepProgressPersistence.resetTutorStep (#2532 必改 1)', () => {
     // Simulate a completed tutor reading (what would otherwise resurrect).
     act(() => {
       result.current.saveStepProgressPatch({
-        stepId: 'tutor',
+        stepId: 'paragraph-reading',
         stepData: {
           line_results: [{ lineIndex: 0, matchRate: 0.98 }],
           completed_paragraphs: [0],
@@ -62,7 +62,7 @@ describe('useStepProgressPersistence.resetTutorStep (#2532 必改 1)', () => {
       result.current.setCompletedParagraphsSet(new Set([0]));
     });
 
-    expect(result.current.stepProgressState.steps_completed).toContain('tutor');
+    expect(result.current.stepProgressState.steps_completed).toContain('paragraph-reading');
     expect(result.current.completedParagraphsSet.size).toBe(1);
 
     act(() => {
@@ -76,8 +76,8 @@ describe('useStepProgressPersistence.resetTutorStep (#2532 必改 1)', () => {
     expect(tutor.paragraph_summaries_data).toEqual({});
     expect(tutor.readingAttempt).toBeUndefined();
 
-    // 2. 'tutor' removed from steps_completed
-    expect(result.current.stepProgressState.steps_completed).not.toContain('tutor');
+    // 2. 'paragraph-reading' removed from steps_completed
+    expect(result.current.stepProgressState.steps_completed).not.toContain('paragraph-reading');
 
     // 3. in-memory completedParagraphsSet cleared
     expect(result.current.completedParagraphsSet.size).toBe(0);
@@ -87,10 +87,10 @@ describe('useStepProgressPersistence.resetTutorStep (#2532 必改 1)', () => {
     const cleared = updater({
       readingAttempt: { accuracy: 0.98 },
       completedParagraphs: [0],
-      completedSteps: ['tutor', 'vocab'],
+      completedSteps: ['paragraph-reading', 'character-practice'],
     } as unknown as LearningSession);
     expect(cleared.readingAttempt).toBeNull();
     expect(cleared.completedParagraphs).toEqual([]);
-    expect(cleared.completedSteps).toEqual(['vocab']);
+    expect(cleared.completedSteps).toEqual(['character-practice']);
   });
 });

--- a/frontend/src/hooks/useStepProgressPersistence.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.ts
@@ -161,7 +161,7 @@ export function useStepProgressPersistence({
     [requiredAssignmentSteps, completedStepsSet],
   );
   const isAssignmentReadyForSubmit = missingAssignmentSteps.length === 0;
-  const firstIncompleteStepPath = missingAssignmentSteps[0]?.id ?? 'reading-annotation';
+  const firstIncompleteStepPath = missingAssignmentSteps[0]?.id ?? 'full-text-annotate';
   const hasActiveAssignment = useMemo(() => {
     try {
       return isAssignmentFlow;
@@ -194,13 +194,13 @@ export function useStepProgressPersistence({
       setSession((prev) => {
         if (!prev) return prev;
         const tutorData = (loadedStepData.tutor ?? {}) as Record<string, unknown>;
-        const fullReadingData = (loadedStepData['full-reading'] ?? {}) as Record<string, unknown>;
+        const fullReadingData = (loadedStepData['key-passage-reading'] ?? {}) as Record<string, unknown>;
         const vocabData = (loadedStepData.vocab ?? {}) as Record<string, unknown>;
         const comprehensionData = (loadedStepData.comprehension ?? {}) as Record<string, unknown>;
-        const readingAnnotationData = (loadedStepData['reading-annotation'] ?? {}) as Record<string, unknown>;
+        const readingAnnotationData = (loadedStepData['full-text-annotate'] ?? {}) as Record<string, unknown>;
         const vocabDefinitionData = (loadedStepData['vocab-definition'] ?? {}) as Record<string, unknown>;
         const vocabApplicationData = (loadedStepData['vocab-application'] ?? {}) as Record<string, unknown>;
-        const vocabWordSearchData = (loadedStepData['vocab-word-search'] ?? {}) as Record<string, unknown>;
+        const vocabWordSearchData = (loadedStepData['vocab-review'] ?? {}) as Record<string, unknown>;
         const knowledgeStationData = (loadedStepData['knowledge-station'] ?? {}) as Record<string, unknown>;
 
         return {
@@ -211,13 +211,13 @@ export function useStepProgressPersistence({
           vocabResult: (vocabData.result as VocabResult | undefined) ?? prev.vocabResult,
           comprehensionResult: (comprehensionData.result as ComprehensionResult | undefined) ?? prev.comprehensionResult,
           readingAnnotationCompleted:
-            (readingAnnotationData.completed as boolean | undefined) ?? loadedCompleted.includes('reading-annotation') ?? prev.readingAnnotationCompleted,
+            (readingAnnotationData.completed as boolean | undefined) ?? loadedCompleted.includes('full-text-annotate') ?? prev.readingAnnotationCompleted,
           vocabDefinitionMatchCompleted:
             (vocabDefinitionData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-definition') ?? prev.vocabDefinitionMatchCompleted,
           vocabApplicationCompleted:
             (vocabApplicationData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-application') ?? prev.vocabApplicationCompleted,
           vocabWordSearchCompleted:
-            (vocabWordSearchData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-word-search') ?? prev.vocabWordSearchCompleted,
+            (vocabWordSearchData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-review') ?? prev.vocabWordSearchCompleted,
           knowledgeStationCompleted:
             (knowledgeStationData.completed as boolean | undefined) ?? loadedCompleted.includes('knowledge-station') ?? prev.knowledgeStationCompleted,
         };
@@ -364,8 +364,8 @@ export function useStepProgressPersistence({
    * that's a "half reset". Completion/成績 actually live in FOUR places; this clears
    * ALL of them so navigating away+back or a full reload can't resurrect old data:
    *   1. step_data.tutor — fully replaced with an empty entry (also drops readingAttempt)
-   *   2. steps_completed — 'tutor' removed (so the stepper doesn't stay ticked)
-   *   3. session.readingAttempt / completedParagraphs / completedSteps('tutor')
+   *   2. steps_completed — 'paragraph-reading' removed (so the stepper doesn't stay ticked)
+   *   3. session.readingAttempt / completedParagraphs / completedSteps('paragraph-reading')
    *      (ReportPage reads session.readingAttempt; reload rehydrates it from step_data)
    *   4. completedParagraphsSet (in-memory) + tutor_completed_ / liveTutor_progress_ localStorage
    */
@@ -380,7 +380,7 @@ export function useStepProgressPersistence({
 
     setStepProgressState((prev) => {
       const completed = new Set(prev.steps_completed);
-      completed.delete('tutor');
+      completed.delete('paragraph-reading');
       const next: StepProgressData = {
         current_step: prev.current_step,
         steps_completed: Array.from(completed),
@@ -406,7 +406,7 @@ export function useStepProgressPersistence({
         ...prev,
         readingAttempt: null,
         completedParagraphs: [],
-        completedSteps: (prev.completedSteps ?? []).filter((s) => s !== 'tutor'),
+        completedSteps: (prev.completedSteps ?? []).filter((s) => s !== 'paragraph-reading'),
       };
     });
   }, [

--- a/frontend/src/layouts/__tests__/learningLayout.test.ts
+++ b/frontend/src/layouts/__tests__/learningLayout.test.ts
@@ -63,10 +63,10 @@ describe('learning_step_transitions_follow_active_step_config', () => {
   it('every step in the default active sequence (except report and intro) has a STEP_TRANSITIONS entry', () => {
     const activeSteps = resolveActiveSteps(); // default sequence, enabled only
     // 'report' is the terminal step — no outgoing transition needed.
-    // 'intro' completion is handled by handleStartReading (not a handleFinish*),
+    // 'lesson-intro' completion is handled by handleStartReading (not a handleFinish*),
     // so it does not need a STEP_TRANSITIONS entry.
     const stepsNeedingTransition = activeSteps
-      .filter((s) => s.id !== 'report' && s.id !== 'intro')
+      .filter((s) => s.id !== 'report' && s.id !== 'lesson-intro')
       .map((s) => s.id);
 
     for (const stepId of stepsNeedingTransition) {
@@ -90,11 +90,11 @@ describe('learning_step_transitions_follow_active_step_config', () => {
   });
 
   it('getNextEnabledStep falls back to STEP_TRANSITIONS when step not in custom sequence', () => {
-    // 'tutor' is not in this custom list
-    const customSequence = ['reading-annotation', 'full-reading', 'report'];
-    const result = getNextEnabledStep('tutor', customSequence);
-    // Falls back to STEP_TRANSITIONS['tutor'].nextStep = 'full-reading'
-    expect(result).toBe(STEP_TRANSITIONS['tutor'].nextStep);
+    // 'paragraph-reading' is not in this custom list
+    const customSequence = ['full-text-annotate', 'key-passage-reading', 'report'];
+    const result = getNextEnabledStep('paragraph-reading', customSequence);
+    // Falls back to STEP_TRANSITIONS['paragraph-reading'].nextStep = 'key-passage-reading'
+    expect(result).toBe(STEP_TRANSITIONS['paragraph-reading'].nextStep);
   });
 
   it('each STEP_TRANSITIONS entry has consistent completeStep == key', () => {
@@ -115,10 +115,10 @@ describe('learning_step_transitions_follow_active_step_config', () => {
 
   it('a custom lesson step_sequence that disables some steps still gets correct next', () => {
     // Simulate a lesson that skips vocab steps — goes directly annotation → tutor → full-reading → report
-    const customIds = ['reading-annotation', 'tutor', 'full-reading', 'report'];
-    expect(getNextEnabledStep('reading-annotation', customIds)).toBe('tutor');
-    expect(getNextEnabledStep('tutor', customIds)).toBe('full-reading');
-    expect(getNextEnabledStep('full-reading', customIds)).toBe('report');
+    const customIds = ['full-text-annotate', 'paragraph-reading', 'key-passage-reading', 'report'];
+    expect(getNextEnabledStep('full-text-annotate', customIds)).toBe('paragraph-reading');
+    expect(getNextEnabledStep('paragraph-reading', customIds)).toBe('key-passage-reading');
+    expect(getNextEnabledStep('key-passage-reading', customIds)).toBe('report');
   });
 });
 
@@ -152,7 +152,7 @@ describe('assignment_completion_does_not_submit_until_required_steps_done', () =
 
   it('returns not-ready when only some steps are completed', () => {
     // Partially complete — only the first 3 steps done
-    const partial = ['reading-annotation', 'tutor', 'full-reading'];
+    const partial = ['full-text-annotate', 'paragraph-reading', 'key-passage-reading'];
     const { isReady } = computeIsReady(partial);
     expect(isReady).toBe(false);
   });

--- a/frontend/src/layouts/__tests__/learningLayout1906.test.ts
+++ b/frontend/src/layouts/__tests__/learningLayout1906.test.ts
@@ -213,9 +213,9 @@ describe('step_complete_handler_advances_through_active_step_config', () => {
   it('reading-annotation → tutor in default active sequence', () => {
     const activeSteps = resolveActiveSteps();
     const activeIds = activeSteps.map((s) => s.id);
-    const next = getNextEnabledStep('reading-annotation', activeIds);
+    const next = getNextEnabledStep('full-text-annotate', activeIds);
     // Tutor follows reading-annotation in the default 12-step sequence
-    expect(next).toBe('tutor');
+    expect(next).toBe('paragraph-reading');
   });
 
   it('knowledge-station → report (terminal step)', () => {
@@ -227,10 +227,10 @@ describe('step_complete_handler_advances_through_active_step_config', () => {
 
   it('custom sequence: skipped steps are bridged correctly', () => {
     // Simulates a lesson that goes: annotation → tutor → full-reading → report (skips vocab etc)
-    const custom = ['reading-annotation', 'tutor', 'full-reading', 'report'];
-    expect(getNextEnabledStep('reading-annotation', custom)).toBe('tutor');
-    expect(getNextEnabledStep('tutor', custom)).toBe('full-reading');
-    expect(getNextEnabledStep('full-reading', custom)).toBe('report');
+    const custom = ['full-text-annotate', 'paragraph-reading', 'key-passage-reading', 'report'];
+    expect(getNextEnabledStep('full-text-annotate', custom)).toBe('paragraph-reading');
+    expect(getNextEnabledStep('paragraph-reading', custom)).toBe('key-passage-reading');
+    expect(getNextEnabledStep('key-passage-reading', custom)).toBe('report');
   });
 
   it('every step in STEP_TRANSITIONS has a valid next step target', () => {
@@ -277,7 +277,7 @@ describe('assignment_completion_keeps_context_when_required_steps_missing', () =
   });
 
   it('partially completed → isReady false, missingSteps non-empty', () => {
-    const { isReady, missingSteps } = computeIsReady(['reading-annotation', 'tutor']);
+    const { isReady, missingSteps } = computeIsReady(['full-text-annotate', 'paragraph-reading']);
     expect(isReady).toBe(false);
     expect(missingSteps.length).toBeGreaterThan(0);
     // missingSteps will be used by report blocking UI to show what's left

--- a/frontend/src/layouts/learningStepTransitions.ts
+++ b/frontend/src/layouts/learningStepTransitions.ts
@@ -30,35 +30,35 @@ export interface StepTransition {
  * handleFinish* callbacks in LearningLayout.tsx.
  */
 export const STEP_TRANSITIONS: Record<string, StepTransition> = {
-  'tutor': {
-    completeStep: 'tutor',
-    nextStep: 'full-reading',
-    stepDataKey: 'tutor',
+  'paragraph-reading': {
+    completeStep: 'paragraph-reading',
+    nextStep: 'key-passage-reading',
+    stepDataKey: 'paragraph-reading',
   },
   'comprehension': {
     completeStep: 'comprehension',
-    nextStep: 'vocab-word-search',
+    nextStep: 'vocab-review',
     stepDataKey: 'comprehension',
   },
-  'vocab': {
-    completeStep: 'vocab',
+  'character-practice': {
+    completeStep: 'character-practice',
     nextStep: 'vocab-definition',
-    stepDataKey: 'vocab',
+    stepDataKey: 'character-practice',
   },
-  'full-reading': {
-    completeStep: 'full-reading',
+  'key-passage-reading': {
+    completeStep: 'key-passage-reading',
     nextStep: 'listening',
-    stepDataKey: 'full-reading',
+    stepDataKey: 'key-passage-reading',
   },
   'listening': {
     completeStep: 'listening',
-    nextStep: 'vocab',
+    nextStep: 'character-practice',
     stepDataKey: 'listening',
   },
-  'reading-annotation': {
-    completeStep: 'reading-annotation',
-    nextStep: 'tutor',
-    stepDataKey: 'reading-annotation',
+  'full-text-annotate': {
+    completeStep: 'full-text-annotate',
+    nextStep: 'paragraph-reading',
+    stepDataKey: 'full-text-annotate',
   },
   'vocab-definition': {
     completeStep: 'vocab-definition',
@@ -67,28 +67,28 @@ export const STEP_TRANSITIONS: Record<string, StepTransition> = {
   },
   'vocab-application': {
     completeStep: 'vocab-application',
-    nextStep: 'story-structure',
+    nextStep: 'keypoints-table',
     stepDataKey: 'vocab-application',
   },
-  'story-structure': {
-    completeStep: 'story-structure',
-    nextStep: 'reading-strategy',
-    stepDataKey: 'story-structure',
+  'keypoints-table': {
+    completeStep: 'keypoints-table',
+    nextStep: 'spotlight',
+    stepDataKey: 'keypoints-table',
   },
-  'reading-strategy': {
-    completeStep: 'reading-strategy',
+  'spotlight': {
+    completeStep: 'spotlight',
     nextStep: 'comprehension',
-    stepDataKey: 'reading-strategy',
+    stepDataKey: 'spotlight',
   },
   'sentence-practice': {
     completeStep: 'sentence-practice',
     nextStep: 'vocab-definition',
     stepDataKey: 'sentence-practice',
   },
-  'vocab-word-search': {
-    completeStep: 'vocab-word-search',
+  'vocab-review': {
+    completeStep: 'vocab-review',
     nextStep: 'knowledge-station',
-    stepDataKey: 'vocab-word-search',
+    stepDataKey: 'vocab-review',
   },
   'knowledge-station': {
     completeStep: 'knowledge-station',

--- a/frontend/src/pages/DemoReadingPage.test.tsx
+++ b/frontend/src/pages/DemoReadingPage.test.tsx
@@ -128,13 +128,13 @@ describe('#2625 免登入播放頁 — DemoReadingPage', () => {
     expect(speakSpy).not.toHaveBeenCalled();
   });
 
-  it('5. 「開始朗讀」 link points to /learn/{id}/full-reading (login wall is expected)', async () => {
+  it('5. 「開始朗讀」 link points to /learn/{id}/key-passage-reading (login wall is expected)', async () => {
     renderAtRoute('/demo-reading/42/full');
     await waitFor(() => {
       expect(screen.getByText('愛讀書的顧寧人')).toBeInTheDocument();
     });
     const link = screen.getByRole('link', { name: /開始朗讀/ });
     expect(link).toBeInTheDocument();
-    expect(link.getAttribute('href')).toBe('/learn/42/full-reading');
+    expect(link.getAttribute('href')).toBe('/learn/42/key-passage-reading');
   });
 });

--- a/frontend/src/pages/DemoReadingPage.tsx
+++ b/frontend/src/pages/DemoReadingPage.tsx
@@ -99,7 +99,7 @@ const DemoReadingPage: React.FC = () => {
 
       {/* Link to the practice flow — hits ProtectedRoute login wall, which is correct */}
       <Link
-        to={`/learn/${lessonId}/full-reading`}
+        to={`/learn/${lessonId}/key-passage-reading`}
         className="rounded-lg bg-blue-600 px-6 py-3 text-lg font-medium text-white shadow hover:bg-blue-700"
       >
         開始朗讀

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -170,9 +170,9 @@ describe('LessonAudioTable', () => {
   it('builds QR values for intro and full-reading lesson routes', () => {
     const origin = 'https://staging.example.test';
 
-    expect(buildLessonQrValue(origin, 1, 'intro')).toBe('https://staging.example.test/learn/1/intro');
-    expect(buildLessonQrValue(origin, 1, 'full-reading')).toBe(
-      'https://staging.example.test/learn/1/full-reading',
+    expect(buildLessonQrValue(origin, 1, 'lesson-intro')).toBe('https://staging.example.test/learn/1/lesson-intro');
+    expect(buildLessonQrValue(origin, 1, 'key-passage-reading')).toBe(
+      'https://staging.example.test/learn/1/key-passage-reading',
     );
   });
 
@@ -423,8 +423,8 @@ describe('#2622 QR 交付表', () => {
     // lesson, so both codes belong on the same line.
     expect(rows).toHaveLength(2);
     expect(rows[0].lesson_no).toBe('L01');
-    expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
-    expect(rows[0].passage_url).toBe('https://x.test/learn/1/full-reading');
+    expect(rows[0].full_url).toBe('https://x.test/learn/1/lesson-intro');
+    expect(rows[0].passage_url).toBe('https://x.test/learn/1/key-passage-reading');
     // Lesson 2 is grade 8 (全文 blank per the grade rule) AND has no 念順順段
     // (has_key_reading=false), so the batch produces no passage clip for it.
     // Both columns are therefore blank — a 段落 code here would point at a
@@ -504,12 +504,12 @@ describe('#2626 只有 4-7 年級交付全文', () => {
       { id: 2, lesson_number: 2, title: 'G8 課', grade: 8, grade_code: 'G8-L02', char_count: 10, has_key_reading: true },
     ] as never, 'https://x.test');
 
-    expect(rows[0].full_url).toBe('https://x.test/learn/1/intro');
+    expect(rows[0].full_url).toBe('https://x.test/learn/1/lesson-intro');
     expect(rows[1].full_url).toBe('');
     // Positive control: this G8 lesson DOES have a 念順順段
     // (has_key_reading=true), so its 段落 code must survive even though 全文
     // is blank. Passage now gates on has_key_reading, not on grade.
-    expect(rows[1].passage_url).toBe('https://x.test/learn/2/full-reading');
+    expect(rows[1].passage_url).toBe('https://x.test/learn/2/key-passage-reading');
   });
 });
 
@@ -533,7 +533,7 @@ describe('#2622 段落 QR 只發給真的有段落的課（no 空砲）', () => 
     ] as never, 'https://x.test');
 
     // Positive control — a lesson with a passage still gets its 段落 code.
-    expect(rows[0].passage_url).toBe('https://x.test/learn/10/full-reading');
+    expect(rows[0].passage_url).toBe('https://x.test/learn/10/key-passage-reading');
     // The fix — a lesson without one does not.
     expect(rows[1].passage_url).toBe('');
   });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -10,7 +10,7 @@ import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
-type LessonQrStep = 'intro' | 'full-reading';
+type LessonQrStep = 'lesson-intro' | 'key-passage-reading';
 type AudioMode = 'full' | 'key';
 
 interface StoryListItem {
@@ -181,14 +181,14 @@ export function buildQrManifestRows(stories: StoryListItem[], origin: string): Q
     grade: s.grade,
     // Blank rather than a URL: the batch produces no whole-text clip for
     // grades 8-9, so handing the 教材端 a code for it would point at silence.
-    full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'intro') : '',
+    full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'lesson-intro') : '',
     // Same rule on the passage side: build_demo_reading.plan_demo_audio only
     // produces demo-reading/{id}/passage.mp3 when the lesson has a 念順順段
     // (has_key_reading). Emitting a code for a lesson without one — as this
     // did unconditionally before — is the identical "points at silence" bug
     // the 全文 gate above prevents, just on the passage side. Gate on the data
     // (does a passage exist), never on the grade.
-    passage_url: s.has_key_reading ? buildLessonQrValue(origin, s.id, 'full-reading') : '',
+    passage_url: s.has_key_reading ? buildLessonQrValue(origin, s.id, 'key-passage-reading') : '',
   }));
 }
 
@@ -316,7 +316,7 @@ const QrDownloadButton: React.FC<QrButtonProps> = ({ lessonId, step, label, file
       </button>
       {preview && (
         <QrPreviewDialog
-          title={`${title}／${step === 'intro' ? '全文' : '段落'}`}
+          title={`${title}／${step === 'lesson-intro' ? '全文' : '段落'}`}
           value={preview.value}
           dataUrl={preview.dataUrl}
           filename={qrFileName(filePrefix, lessonId)}
@@ -726,9 +726,9 @@ const LessonAudioTable: React.FC = () => {
               </div>
 
               {deliversFullText(story.grade)
-                ? <QrDownloadButton lessonId={story.id} step="intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
+                ? <QrDownloadButton lessonId={story.id} step="lesson-intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
                 : <span className="text-xs text-gray-400" title="8-9 年級依規格只交付段落朗讀">—</span>}
-              <QrDownloadButton lessonId={story.id} step="full-reading" label="QR" filePrefix="full-reading-qr" lessonTitle={story.title} />
+              <QrDownloadButton lessonId={story.id} step="key-passage-reading" label="QR" filePrefix="full-reading-qr" lessonTitle={story.title} />
             </div>
           );
         })}

--- a/frontend/src/pages/admin/story-structure-lab/StoryStructureLabPage.tsx
+++ b/frontend/src/pages/admin/story-structure-lab/StoryStructureLabPage.tsx
@@ -251,7 +251,7 @@ const StoryStructureLabPage: React.FC = () => {
               </header>
               <iframe
                 title="story-structure-preview"
-                src={`/learn/${detail.story_id}/story-structure`}
+                src={`/learn/${detail.story_id}/keypoints-table`}
                 className="w-full h-[520px] border-0 bg-white"
               />
             </section>

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -145,7 +145,7 @@ export const LibraryPage: React.FC = () => {
   const handleSelectStory = (story: { id: string }) => {
     clearAssignmentContext(story.id);
     cleanupAssignmentScopedProgressKeys(story.id);
-    navigate(`/learn/${story.id}/intro`);
+    navigate(`/learn/${story.id}/lesson-intro`);
   };
 
   const handleClearProgress = (storyId: string) => {

--- a/frontend/src/pages/learning/ComprehensionPage.tsx
+++ b/frontend/src/pages/learning/ComprehensionPage.tsx
@@ -35,7 +35,7 @@ const ComprehensionPage: React.FC = () => {
       story={selectedStory}
       attempt={lastAttempt ?? emptyAttempt}
       onFinish={handleFinishComprehension}
-      onBack={() => navigate(`/learn/${storyId}/tutor`)}
+      onBack={() => navigate(`/learn/${storyId}/paragraph-reading`)}
       dbSessionId={dbSessionId ?? undefined}
       initialProgress={(stepProgressData.step_data?.comprehension as Record<string, unknown> | undefined) ?? undefined}
       onProgressChange={handleProgressChange}

--- a/frontend/src/pages/learning/DictationPage.tsx
+++ b/frontend/src/pages/learning/DictationPage.tsx
@@ -32,7 +32,7 @@ const DictationPage: React.FC = () => {
     <DictationPractice
       story={selectedStory}
       onFinish={handleFinishDictation}
-      onBack={() => navigate(`/learn/${storyId}/vocab`)}
+      onBack={() => navigate(`/learn/${storyId}/character-practice`)}
       initialProgress={stepProgressData.step_data?.dictation as DictationStepData | undefined}
       onProgressChange={handleProgressChange}
     />

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -6,7 +6,7 @@ import { useLearningContext } from '../../layouts/LearningLayout';
 import type { FullReadingStepData } from '../../types/stepProgress';
 
 /** Canonical step id this page is registered under in STEP_REGISTRY. */
-const CANONICAL_STEP_ID = 'full-reading';
+const CANONICAL_STEP_ID = 'key-passage-reading';
 
 const FullReadingPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
@@ -43,7 +43,7 @@ const FullReadingPage: React.FC = () => {
     <FullReading
       story={selectedStory}
       onFinish={handleFinishFullReading}
-      onBack={() => navigate(`/learn/${storyId}/tutor`)}
+      onBack={() => navigate(`/learn/${storyId}/paragraph-reading`)}
       initialResult={session?.fullReadingResult ?? null}
       initialProgress={stepProgressData.step_data?.[stepId] as FullReadingStepData | undefined}
       onProgressChange={handleProgressChange}

--- a/frontend/src/pages/learning/ListeningPage.tsx
+++ b/frontend/src/pages/learning/ListeningPage.tsx
@@ -25,7 +25,7 @@ const ListeningPage: React.FC = () => {
     <ListeningPractice
       story={selectedStory}
       onFinish={handleFinishListening}
-      onBack={() => navigate(`/learn/${storyId}/full-reading`)}
+      onBack={() => navigate(`/learn/${storyId}/key-passage-reading`)}
     />
   );
 };

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -198,7 +198,7 @@ const ReportPage: React.FC = () => {
         session={session}
         story={selectedStory}
         onRetry={handleRetry}
-        onGoToVocab={() => navigate(`/learn/${storyId}/vocab`)}
+        onGoToVocab={() => navigate(`/learn/${storyId}/character-practice`)}
         dbSessionId={dbSessionId}
         token={token}
         comprehensionScores={comprehensionScores}

--- a/frontend/src/pages/learning/SentencePracticePage.tsx
+++ b/frontend/src/pages/learning/SentencePracticePage.tsx
@@ -32,7 +32,7 @@ const SentencePracticePage: React.FC = () => {
       storyId={selectedStory.id}
       saveStepProgressPatch={saveStepProgressPatch}
       onFinish={handleFinishSentencePractice}
-      onBack={() => navigate(`/learn/${storyId}/vocab`)}
+      onBack={() => navigate(`/learn/${storyId}/character-practice`)}
     />
   );
 };

--- a/frontend/src/pages/learning/StoryStructurePage.tsx
+++ b/frontend/src/pages/learning/StoryStructurePage.tsx
@@ -24,9 +24,9 @@ const StoryStructurePage: React.FC = () => {
   const handleProgressChange = useCallback(
     (stepData: Record<string, unknown>, immediate = false) => {
       saveStepProgressPatch({
-        stepId: 'story-structure',
+        stepId: 'keypoints-table',
         stepData,
-        currentStep: 'story-structure',
+        currentStep: 'keypoints-table',
         immediate,
       });
     },

--- a/frontend/src/pages/learning/StrategyExercisePage.tsx
+++ b/frontend/src/pages/learning/StrategyExercisePage.tsx
@@ -27,16 +27,16 @@ const StrategyExercisePage: React.FC = () => {
     stepProgressData,
   } = useLearningContext();
 
-  const savedStrategyData = stepProgressData.step_data?.['reading-strategy'] as Record<string, unknown> | undefined;
+  const savedStrategyData = stepProgressData.step_data?.['spotlight'] as Record<string, unknown> | undefined;
 
   const [strategyDone, setStrategyDone] = useState(() => !!(savedStrategyData?.allDone));
 
   const handleProgressChange = useCallback(
     (stepData: Record<string, unknown>, immediate = false) => {
       saveStepProgressPatch({
-        stepId: 'reading-strategy',
+        stepId: 'spotlight',
         stepData,
-        currentStep: 'reading-strategy',
+        currentStep: 'spotlight',
         immediate,
       });
     },
@@ -116,7 +116,7 @@ const StrategyExercisePage: React.FC = () => {
     if (lesson && lessonHasSpotlight) {
       return (
         <div className="flex flex-col flex-1 min-h-0 overflow-hidden px-4 py-6">
-          <OmoPaperResultBanner stepId="reading-strategy" />
+          <OmoPaperResultBanner stepId="spotlight" />
           <LessonRenderer
             lesson={lesson}
             story={selectedStory}
@@ -134,7 +134,7 @@ const StrategyExercisePage: React.FC = () => {
   if (hasSpotlightV2 && spotlightV2) {
     return (
       <div className="flex flex-col flex-1 min-h-0 overflow-y-auto px-4 py-6">
-        <OmoPaperResultBanner stepId="reading-strategy" />
+        <OmoPaperResultBanner stepId="spotlight" />
         <BlockSequenceRenderer
           spotlight={spotlightV2}
           story={selectedStory}
@@ -142,7 +142,7 @@ const StrategyExercisePage: React.FC = () => {
           onComplete={handleStrategyComplete}
           onChange={handleAnswerChange}
           initialState={savedStrategyData}
-          onOpenKeypoints={() => navigate(`/learn/${selectedStory.id}/story-structure`)}
+          onOpenKeypoints={() => navigate(`/learn/${selectedStory.id}/keypoints-table`)}
         />
         {nextButton}
       </div>
@@ -156,7 +156,7 @@ const StrategyExercisePage: React.FC = () => {
       exerciseIcon="lightbulb"
       exerciseLabel="閱讀聚光燈"
     >
-      <OmoPaperResultBanner stepId="reading-strategy" />
+      <OmoPaperResultBanner stepId="spotlight" />
       {hasStrategy ? (
         <>
           {isGraphicTextList ? (

--- a/frontend/src/pages/learning/TutorPage.tsx
+++ b/frontend/src/pages/learning/TutorPage.tsx
@@ -22,9 +22,9 @@ const TutorPage: React.FC = () => {
   const handleProgressChange = useCallback(
     (stepData: TutorStepData, immediate = false) => {
       saveStepProgressPatch({
-        stepId: 'tutor',
+        stepId: 'paragraph-reading',
         stepData,
-        currentStep: 'tutor',
+        currentStep: 'paragraph-reading',
         immediate,
       });
     },

--- a/frontend/src/pages/learning/VocabPage.tsx
+++ b/frontend/src/pages/learning/VocabPage.tsx
@@ -19,9 +19,9 @@ const VocabPage: React.FC = () => {
   const handleProgressChange = useCallback(
     (stepData: VocabStepData, immediate = false) => {
       saveStepProgressPatch({
-        stepId: 'vocab',
+        stepId: 'character-practice',
         stepData,
-        currentStep: 'vocab',
+        currentStep: 'character-practice',
         immediate,
       });
     },

--- a/frontend/src/pages/learning/__tests__/FullReadingPage.test.tsx
+++ b/frontend/src/pages/learning/__tests__/FullReadingPage.test.tsx
@@ -1,12 +1,12 @@
 /**
  * FullReadingPage — step-aware step id (#2588)
  *
- * The page used to hardcode 'full-reading' in three places (patch stepId,
+ * The page used to hardcode 'key-passage-reading' in three places (patch stepId,
  * currentStep, and the step_data read key).  It now derives the id from the
  * route.  These tests pin the two properties that matter:
  *
- *   1. Assignment safety — at the real route `/learn/:storyId/full-reading`
- *      the persisted id is STILL exactly 'full-reading'.  A different value
+ *   1. Assignment safety — at the real route `/learn/:storyId/key-passage-reading`
+ *      the persisted id is STILL exactly 'key-passage-reading'.  A different value
  *      would land in an unknown key: the backend maps frontend step keys to
  *      step numbers (`_FRONTEND_STEP_ALIAS` in backend/app/models/session.py)
  *      and drops unknown ones, so completion stops counting and the assignment
@@ -50,7 +50,7 @@ import type { Story } from '../../../types';
  * `_FRONTEND_STEP_ALIAS` + `_STEP_NAMES` in backend/app/models/session.py.
  * Keep in sync when adding steps that persist progress.
  */
-const BACKEND_KNOWN_STEP_KEYS = ['full-reading', 'tutor', 'reading-annotation'];
+const BACKEND_KNOWN_STEP_KEYS = ['key-passage-reading', 'paragraph-reading', 'full-text-annotate'];
 
 const story: Story = {
   id: '1',
@@ -90,31 +90,31 @@ beforeEach(() => {
 });
 
 describe('FullReadingPage — assignment-safety (progress key must stay full-reading)', () => {
-  it("persists stepId 'full-reading' at the real route", () => {
-    renderAt('/learn/1/full-reading');
+  it("persists stepId 'key-passage-reading' at the real route", () => {
+    renderAt('/learn/1/key-passage-reading');
     fireEvent.click(screen.getByTestId('emit-progress'));
 
     expect(mockSaveStepProgressPatch).toHaveBeenCalledWith({
-      stepId: 'full-reading',
+      stepId: 'key-passage-reading',
       stepData: { cpm: 120 },
-      currentStep: 'full-reading',
+      currentStep: 'key-passage-reading',
       immediate: true,
     });
   });
 
   it('persists a step id the backend can resolve to a step number', () => {
-    renderAt('/learn/1/full-reading');
+    renderAt('/learn/1/key-passage-reading');
     fireEvent.click(screen.getByTestId('emit-progress'));
 
     const { stepId } = mockSaveStepProgressPatch.mock.calls[0][0];
     expect(BACKEND_KNOWN_STEP_KEYS).toContain(stepId);
   });
 
-  it("reads initialProgress back from step_data['full-reading']", () => {
+  it("reads initialProgress back from step_data['key-passage-reading']", () => {
     (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
-      makeContext({ 'full-reading': { cpm: 99 }, tutor: { cpm: 1 } }),
+      makeContext({ 'key-passage-reading': { cpm: 99 }, tutor: { cpm: 1 } }),
     );
-    renderAt('/learn/1/full-reading');
+    renderAt('/learn/1/key-passage-reading');
 
     expect(capturedProps.initialProgress).toEqual({ cpm: 99 });
   });
@@ -123,14 +123,14 @@ describe('FullReadingPage — assignment-safety (progress key must stay full-rea
 describe('FullReadingPage — step-aware (no hardcoded id drift)', () => {
   it('follows the route when mounted under another registered step id', () => {
     (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
-      makeContext({ 'full-reading': { cpm: 99 }, tutor: { cpm: 42 } }),
+      makeContext({ 'key-passage-reading': { cpm: 99 }, tutor: { cpm: 42 } }),
     );
-    renderAt('/learn/1/tutor');
+    renderAt('/learn/1/paragraph-reading');
     fireEvent.click(screen.getByTestId('emit-progress'));
 
     // write key follows the route…
     expect(mockSaveStepProgressPatch).toHaveBeenCalledWith(
-      expect.objectContaining({ stepId: 'tutor', currentStep: 'tutor' }),
+      expect.objectContaining({ stepId: 'paragraph-reading', currentStep: 'paragraph-reading' }),
     );
     // …and the read key matches it (no split between write and read).
     expect(capturedProps.initialProgress).toEqual({ cpm: 42 });
@@ -138,13 +138,13 @@ describe('FullReadingPage — step-aware (no hardcoded id drift)', () => {
 
   it('falls back to the canonical id on an unregistered route segment', () => {
     (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
-      makeContext({ 'full-reading': { cpm: 7 } }),
+      makeContext({ 'key-passage-reading': { cpm: 7 } }),
     );
     renderAt('/learn/1/not-a-registered-step');
     fireEvent.click(screen.getByTestId('emit-progress'));
 
     expect(mockSaveStepProgressPatch).toHaveBeenCalledWith(
-      expect.objectContaining({ stepId: 'full-reading' }),
+      expect.objectContaining({ stepId: 'key-passage-reading' }),
     );
     expect(capturedProps.initialProgress).toEqual({ cpm: 7 });
   });

--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -31,7 +31,7 @@ const MyAssignments: React.FC = () => {
   const [classroomFilter, setClassroomFilter] = useState<string>('all');
 
   const assignmentSteps = useMemo(() => ACTIVE_STEPS, []);
-  const defaultStepPath = assignmentSteps[0]?.id ?? 'reading-annotation';
+  const defaultStepPath = assignmentSteps[0]?.id ?? 'full-text-annotate';
   const stepIdSet = useMemo(() => new Set(assignmentSteps.map((s) => s.id)), [assignmentSteps]);
 
   // Build classroom name -> teacher name lookup

--- a/frontend/src/pages/student/session-history/SpotlightStrategyRecord.tsx
+++ b/frontend/src/pages/student/session-history/SpotlightStrategyRecord.tsx
@@ -1,6 +1,6 @@
 /**
  * SpotlightStrategyRecord — 閱讀聚光燈作答紀錄（老師端 / 學生端共用）
- * Renders step_progress['reading-strategy'] for spotlight v2 + legacy guided steps.
+ * Renders step_progress['spotlight'] for spotlight v2 + legacy guided steps.
  * Issue #2083 — 老師端可檢視學生申論 / 選擇題答案
  */
 

--- a/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
+++ b/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
@@ -241,10 +241,10 @@ const TeacherSessionReportPage: React.FC = () => {
 
 
       {/* Issue #2083 — structured spotlight answers for teacher review */}
-      {report?.step_progress?.step_data?.['reading-strategy'] && (
+      {report?.step_progress?.step_data?.['spotlight'] && (
         <div className="mb-6">
           <SpotlightStrategyRecord
-            stepData={report.step_progress.step_data['reading-strategy'] as Record<string, unknown>}
+            stepData={report.step_progress.step_data['spotlight'] as Record<string, unknown>}
             spotlight={story?.spotlightV2}
             strategyExercise={
               story?.strategyExercise && !Array.isArray(story.strategyExercise)

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -435,7 +435,7 @@ const AppRoutes: React.FC = () => (
       >
         {learningRoutes}
         {/* Default: redirect to reading-annotation (new first step) */}
-        <Route index element={<Navigate to="reading-annotation" replace />} />
+        <Route index element={<Navigate to="full-text-annotate" replace />} />
       </Route>
 
       {/* Privacy policy — public, no auth required */}

--- a/frontend/src/routes/__tests__/learningRoutes.test.tsx
+++ b/frontend/src/routes/__tests__/learningRoutes.test.tsx
@@ -27,7 +27,7 @@ import {
 
 /** Returns the first enabled step id in DEFAULT_STEP_SEQUENCE */
 function firstEnabledStepId(): string {
-  return resolveActiveSteps()[0]?.id ?? 'reading-annotation';
+  return resolveActiveSteps()[0]?.id ?? 'full-text-annotate';
 }
 
 /**
@@ -152,10 +152,10 @@ describe('protected_routes_wrap_app_shell_pages — key routes require auth + sh
   it('STEP_CONFIG contains the expected learning steps', () => {
     const ids = STEP_CONFIG.map((s) => s.id);
     // Core steps that must always be present
-    expect(ids).toContain('intro');
-    expect(ids).toContain('reading-annotation');
-    expect(ids).toContain('tutor');
-    expect(ids).toContain('full-reading');
+    expect(ids).toContain('lesson-intro');
+    expect(ids).toContain('full-text-annotate');
+    expect(ids).toContain('paragraph-reading');
+    expect(ids).toContain('key-passage-reading');
     expect(ids).toContain('comprehension');
     expect(ids).toContain('report');
   });

--- a/frontend/src/routes/learningRoutes.tsx
+++ b/frontend/src/routes/learningRoutes.tsx
@@ -64,19 +64,19 @@ const SentencePracticePage    = lazy(() => import('../pages/learning/SentencePra
 type LazyPage = React.LazyExoticComponent<React.ComponentType>;
 
 const STEP_PAGE_MAP: Record<string, LazyPage> = {
-  'intro':                 IntroPage,
-  'reading-annotation':    ReadingAnnotationPage,
-  'tutor':                 TutorPage,
-  'full-reading':          FullReadingPage, // 2026-07-20 label 改為「重點朗讀」；Phase 1 接 key_reading 後唸指定段
+  'lesson-intro':                 IntroPage,
+  'full-text-annotate':    ReadingAnnotationPage,
+  'paragraph-reading':                 TutorPage,
+  'key-passage-reading':          FullReadingPage, // 2026-07-20 label 改為「重點朗讀」；Phase 1 接 key_reading 後唸指定段
   'listening':             ListeningPage,
-  'vocab':                 VocabPage,
+  'character-practice':                 VocabPage,
   'vocab-definition':      VocabDefinitionMatchPage,
   'vocab-application':     VocabApplicationPage,
-  'story-structure':       StoryStructurePage,
-  'reading-strategy':      StrategyExercisePage,
+  'keypoints-table':       StoryStructurePage,
+  'spotlight':      StrategyExercisePage,
   'sentence-practice':     SentencePracticePage,
   'comprehension':         ComprehensionMcqPage,
-  'vocab-word-search':     VocabWordSearchPage,
+  'vocab-review':     VocabWordSearchPage,
   'dictation':             DictationPage,
   'knowledge-station':     KnowledgeStationPage,
   'report':                ReportPage,
@@ -120,7 +120,7 @@ const StepEnabledGuard: React.FC<StepEnabledGuardProps> = ({ stepId, children })
   const step = STEP_REGISTRY[stepId];
 
   if (step && !step.enabled) {
-    const fallbackId = resolveActiveSteps()[0]?.id ?? 'reading-annotation';
+    const fallbackId = resolveActiveSteps()[0]?.id ?? 'full-text-annotate';
     return <Navigate to={`/learn/${storyId ?? ''}/${fallbackId}`} replace />;
   }
 

--- a/frontend/src/services/toolboxApi.ts
+++ b/frontend/src/services/toolboxApi.ts
@@ -23,15 +23,15 @@ import { handle401Response } from './apiUnauthorized';
 // Order matches frontend/src/components/tools/ToolPicker.tsx TOOL_OPTIONS
 // and backend/app/routes/learning/toolbox.py TOOL_MODEL_MAP.
 export type ToolId =
-  | 'tutor'
-  | 'full-reading'
+  | 'paragraph-reading'
+  | 'key-passage-reading'
   | 'listening'
-  | 'vocab'
+  | 'character-practice'
   | 'sentence-practice'
   | 'vocab-definition'
   | 'vocab-application'
   | 'comprehension'
-  | 'vocab-word-search'
+  | 'vocab-review'
   | 'knowledge-station';
 
 export interface ToolboxSession {

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -91,7 +91,7 @@ export interface DictationWordResult {
 export interface DictationStepData {
   word_results: DictationWordResult[];
   current_index: number;
-  phase: 'intro' | 'practice' | 'results';
+  phase: 'lesson-intro' | 'practice' | 'results';
   result?: {
     total_words: number;
     correct_count: number;
@@ -136,7 +136,7 @@ export interface StepDataMap {
   comprehension: ComprehensionStepData;
   vocab: VocabStepData;
   dictation: DictationStepData;
-  'full-reading': FullReadingStepData;
+  'key-passage-reading': FullReadingStepData;
   report: ReportStepData;
 }
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Closes #2641。

## 改了什麼

```
full-reading        → key-passage-reading   🔴 字面「全文」實際只唸一段
tutor               → paragraph-reading     🔴 完全看不出是朗讀
reading-annotation  → full-text-annotate    🔴 這個才是真的讀全文
intro               → lesson-intro
reading-strategy    → spotlight
story-structure     → keypoints-table
vocab               → character-practice
vocab-word-search   → vocab-review
```

其餘 8 個 id 本來就對得上，不動。**53 個檔、369 行**。

## 三個護欄，都有測試鎖

**`dbStepNumber` 完全沒動** — 學生進度存的是整數（`current_step: Mapped[int]`），
不是 id 字串，所以零 migration。diff 裡跟 dbStepNumber 有關的 3 行全是註解。
測試把 16 個數字全部凍結。

**舊 id 走 alias** — `LEGACY_STEP_ID_ALIASES` + `resolveStepId()`。
後台已經產出的 QR、issue 裡的連結都不會 404。

**`reading_timer` → 重點朗讀 保住** — 那是 2026-07-20 教授審查唯一定案的對應，
斷了紙本學習單就接不回平台。

## TDD

新增 `stepNaming.test.ts`：把 id→label 對照表寫成斷言、凍結所有 dbStepNumber、
逐條驗舊 id 解析、驗 `reading_timer` 對應。**改名前 28 條裡紅 20 條。**

```
config 測試   46 passed
CI 那條命令   31 passed
lint          0 errors
tsc           我新增的錯誤 0（改動前 60 個檔有錯，改動後 59）
```

tsc 那組數字是實測比對出來的 —— 我一開始看到 124 個錯以為是自己弄的，
stash 前後各跑一次才確認一個都不是我的。

## 過程中犯的一個錯，值得記著

第一版粗暴替換把 `WORKSHEET_TYPE_ALIASES` 的 **key** 也改了
（`reading_strategy` → `spotlight`）。那個 map 的 key 是 parser 產出的
學習單 section type、不是 step id，改掉會讓每一課的步驟序列**默默少一段**。

既有的 worksheet 測試抓到了 —— 12 個步驟只回傳 7 個。

## 沒做的

元件改名 `LiveTutor` → `KeyPassageReading`（37 檔引用、12 個檔要改名、
CI workflow 有釘它的路徑）另開 PR。混在這裡會讓兩邊都沒法 review。

## 既有失敗

`Frontend npm audit` / `Audit summary` 在 staging 本身就 fail，
7 個 transitive 依賴漏洞，本 PR 前後清單一字不差。