### PR TITLE
fix(#2627): 播放全文唸完整篇、播放段落唸重點段

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -555,3 +555,73 @@ describe('#2622 段落 QR 只發給真的有段落的課（no 空砲）', () => 
     expect(passageCodes).toBe(2);
   });
 });
+describe('#2627 播放全文必須唸完整篇，不是只唸第一段', () => {
+  /**
+   * `speakText(text, lessonId, paragraphIdx)` plays ONE paragraph: given a
+   * lessonId and an index, the hook prefers the backend's cached sentences for
+   * that paragraph and ignores the `text` argument entirely.
+   *
+   * The admin panel passed a hardcoded 0, so 「播放全文」 read paragraph 0 —
+   * 76 of lesson 1's 711 characters — and 「播放段落」 was overridden to the
+   * same paragraph, which is why both buttons sounded identical.
+   *
+   * There is no whole-lesson playback in the hook. The component has to walk
+   * the paragraphs itself.
+   */
+  it('walks every paragraph for 全文, not just index 0', async () => {
+    vi.clearAllMocks();
+    mockFetchDispatcher((id) => ({
+      paragraphs: [`p0-of-${id}`, `p1-of-${id}`, `p2-of-${id}`],
+      key_reading: { passage: `key-of-${id}` },
+    }));
+    mockTts();
+
+    const { rerender } = render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: /播放全文/ }));
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(1));
+    expect(mockSpeakText.mock.calls[0]).toEqual(['p0-of-1', 1, 0]);
+
+    // Paragraph 0 starts, then finishes: the hook reports speaking, then idle.
+    // The component must pick that up and play paragraph 1 — an earlier version
+    // stopped here, reading 76 of the lesson's 711 characters.
+    mockTts({ isTtsSpeaking: true });
+    rerender(<LessonAudioTable />);
+    mockTts();
+    rerender(<LessonAudioTable />);
+
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(2));
+    expect(mockSpeakText.mock.calls[1]).toEqual(['p1-of-1', 1, 1]);
+
+    mockTts({ isTtsSpeaking: true });
+    rerender(<LessonAudioTable />);
+    mockTts();
+    rerender(<LessonAudioTable />);
+
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalledTimes(3));
+    expect(mockSpeakText.mock.calls[2]).toEqual(['p2-of-1', 1, 2]);
+  });
+
+  it('段落 uses the key passage, not paragraph 0', async () => {
+    vi.clearAllMocks();
+    mockFetchDispatcher((id) => ({
+      paragraphs: [`p0-of-${id}`, `p1-of-${id}`],
+      key_reading: { passage: `THE-KEY-PASSAGE-${id}` },
+    }));
+    mockTts();
+
+    render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: /播放段落/ }));
+
+    await waitFor(() => expect(mockSpeakText).toHaveBeenCalled());
+    const [text, , idx] = mockSpeakText.mock.calls[0];
+    expect(text).toContain('THE-KEY-PASSAGE-1');
+    // A paragraph index would make the hook ignore the passage text entirely.
+    expect(idx).toBeUndefined();
+  });
+});

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -479,8 +479,13 @@ const LessonAudioTable: React.FC = () => {
     }
   }, [sortedStories]);
 
+  // Which paragraph of a whole-lesson walk plays next. Null when idle or when
+  // playing a key passage (which is a single clip, not a walk).
+  const paragraphQueueRef = useRef<{ storyId: number; total: number; next: number; requestId: number } | null>(null);
+
   const stopCurrentPlayback = useCallback(() => {
     activeRequestRef.current += 1;
+    paragraphQueueRef.current = null;
     stopTts();
     // Belt and braces: pause the element directly as well.
     //
@@ -533,13 +538,35 @@ const LessonAudioTable: React.FC = () => {
     try {
       const detail = await fetchStoryDetail(story.id, token);
       if (activeRequestRef.current !== requestId) return; // superseded by a later click
+      const paragraphs = detail.paragraphs ?? detail.content ?? [];
       const fullText = detailToFullText(detail);
-      const text = mode === 'key' ? (detail.key_reading?.passage || fullText) : fullText;
       setIsFetchingDetail(false);
-      // Use sentence-level playback (lessonId + paragraphIdx) so the first
-      // sentence starts in ~150ms instead of waiting ~10s for the entire text
-      // to synthesize as one blob. (#2627)
-      speakText(text, story.id, 0);
+
+      if (mode === 'key') {
+        // The key passage is its own text, not a paragraph of the lesson, so it
+        // must go through the single-shot path. Passing a paragraph index here
+        // is what made 「播放段落」 read paragraph 0 instead — the hook prefers
+        // the backend's cached sentences for that index and drops the text.
+        speakText(detail.key_reading?.passage || fullText);
+        return;
+      }
+
+      // Whole lesson: walk the paragraphs.
+      //
+      // speakText(text, lessonId, paragraphIdx) plays exactly ONE paragraph —
+      // there is no whole-lesson mode in the hook. This previously passed a
+      // hardcoded 0, so 「播放全文」 read 76 of lesson 1's 711 characters and
+      // stopped, which also made it indistinguishable from 「播放段落」.
+      //
+      // The walk is worth keeping over one big synthesis: each paragraph hits
+      // the backend's per-sentence cache, so the first words start in ~150ms
+      // rather than after a ~10s synthesis of the entire text.
+      if (paragraphs.length === 0) {
+        speakText(fullText);
+        return;
+      }
+      paragraphQueueRef.current = { storyId: story.id, total: paragraphs.length, next: 1, requestId };
+      speakText(paragraphs[0], story.id, 0);
     } catch (err) {
       if (activeRequestRef.current !== requestId) return;
       setIsFetchingDetail(false);
@@ -561,6 +588,40 @@ const LessonAudioTable: React.FC = () => {
       started.clear();
     };
   }, []);
+
+  // Advance the whole-lesson walk when a paragraph finishes.
+  //
+  // The hook reports playback through isTtsSpeaking/isTtsLoading; a paragraph is
+  // done when both fall back to false while a queue is still pending. There is
+  // no per-clip completion callback to hook into, so this watches the state the
+  // hook already publishes.
+  const wasPlayingRef = useRef(false);
+  useEffect(() => {
+    const busy = isTtsSpeaking || isTtsLoading;
+    const justFinished = wasPlayingRef.current && !busy;
+    wasPlayingRef.current = busy;
+    if (!justFinished) return;
+
+    const q = paragraphQueueRef.current;
+    // A newer click supersedes the walk — activeRequestRef moves on every
+    // play and every stop, so a stale queue can never resume over a new clip.
+    if (!q || q.requestId !== activeRequestRef.current) return;
+
+    if (q.next >= q.total) {
+      paragraphQueueRef.current = null;
+      setActiveKey(null);
+      return;
+    }
+    const idx = q.next;
+    q.next += 1;
+    fetchStoryDetail(q.storyId, token)
+      .then((d) => {
+        if (paragraphQueueRef.current?.requestId !== activeRequestRef.current) return;
+        const ps = d.paragraphs ?? d.content ?? [];
+        if (ps[idx]) speakText(ps[idx], q.storyId, idx);
+      })
+      .catch(() => { paragraphQueueRef.current = null; });
+  }, [isTtsSpeaking, isTtsLoading, speakText, token]);
 
   useEffect(() => {
     loadStories();


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

兩顆按鈕都只唸 76 個字（L01 全文是 711 字），聽起來一模一樣。

## 根因

```js
speakText(text, story.id, 0)
//                        ^ 我在修 #2627 時寫死的
```

`speakText(text, lessonId, paragraphIdx)` **一次只播一段** —— 給了索引，hook 會優先讀
後端該段的句子快取，**傳進去的 text 整個被忽略**。

所以全文被截成第 0 段，段落也被蓋成第 0 段。hook 裡沒有「整篇」這個模式，我當時以為有。

## 修法

**段落**：重點段不是課文的某一段，改走單次合成、不帶索引

**全文**：元件自己逐段接力，用 hook 的 `isTtsSpeaking` / `isTtsLoading` 落回 false 當作
該段播完的訊號（hook 沒有 per-clip 完成回呼）

保留接力而不是整篇一次合成，是為了守住 #2627 的效果 ——
每段都命中句子快取，第一句 ~150ms 出聲，而不是等 ~10 秒整篇合成完。

佇列帶著啟動它的 requestId，新的點擊或停止都會讓舊佇列失效。

## mutation 抓到我第一版測試是假的

第一版用 `if/else` 接受兩種播放形狀，**把接力整個刪掉仍然 28 綠**。
現在斷言三次呼叫的確切內容，同一個 mutation 就紅。

```
95 tests passed
lint 0 errors
vite build ✓
```