### PR TITLE
fix(#2612): 台灣讀音校正改由教育部辭典自動產生（89 條 / 253 句）

### DIFF
--- a/backend/app/services/tts/normalization.py
+++ b/backend/app/services/tts/normalization.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import json
+import logging
 import re
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +55,42 @@ PHONEME_CORRECTIONS: list[tuple[str, str]] = [
         '<sub alias="打得漂亮">打得漂亮</sub>',
     ),
 ]
+
+
+def _load_taiwan_corrections() -> list[tuple[str, str]]:
+    """Generated Taiwan-reading corrections from the MOE dictionary.
+
+    The hand-maintained list above is four entries added one at a time as
+    someone happened to hear a mistake. That does not converge: the 2026-05-01
+    expert review's audit found 4298 items needing review across 31 characters
+    and 22 were ever fixed, and the four cases reported on 2026-08-09 were none
+    of them in the table.
+
+    These entries are derived instead: segment the corpus, look each word up in
+    教育部《重編國語辭典修訂本》, compare against pypinyin's mainland reading, and
+    for each differing syllable pick a character whose only reading is the
+    Taiwanese one. Adding coverage means regenerating the file, not appending
+    another tuple here.
+
+    Missing or malformed file degrades to the hand-maintained entries rather
+    than failing synthesis — a pronunciation nicety must never take down TTS.
+    """
+    path = Path(__file__).resolve().parents[3] / "data" / "tts" / "taiwan_pronunciation.json"
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))["corrections"]
+    except (OSError, ValueError, KeyError) as exc:  # pragma: no cover
+        logger.warning("Taiwan pronunciation data unavailable (%s); using built-ins only", exc)
+        return []
+    return [(r["word"], f'<sub alias="{r["alias"]}">{r["word"]}</sub>') for r in rows]
+
+
+# Longest first: _apply_phoneme_corrections scans left to right and takes the
+# first match, so a shorter key that is a prefix of a longer one would win and
+# leave the rest of the longer phrase uncorrected.
+PHONEME_CORRECTIONS = sorted(
+    PHONEME_CORRECTIONS + _load_taiwan_corrections(),
+    key=lambda kv: -len(kv[0]),
+)
 
 _PHONEME_CORRECTIONS = PHONEME_CORRECTIONS
 

--- a/backend/data/tts/taiwan_pronunciation.json
+++ b/backend/data/tts/taiwan_pronunciation.json
@@ -1,0 +1,1265 @@
+{
+  "_source": "教育部《重編國語辭典修訂本》· g0v/moedict-data · CC BY-ND 3.0 TW",
+  "_method": "jieba 斷詞 → 教育部注音 vs pypinyin(大陸) 比對聲韻 → 自動生成同音單讀字 alias",
+  "_excluded": [
+    "似的",
+    "它們",
+    "類似"
+  ],
+  "_excluded_reason": "教育部收錄古音或兩讀皆通，現代課文語境不需校正",
+  "_verified": "6/6 抽樣送 Azure 實測 HTTP 200 且音檔 md5 改變",
+  "_generated": "2026-08-10",
+  "corrections": [
+    {
+      "word": "音樂",
+      "alias": "音岳",
+      "tw": "yin yue",
+      "cn": "yin le",
+      "sentences": 13,
+      "changed": [
+        [
+          "樂",
+          "岳",
+          "yue4"
+        ]
+      ]
+    },
+    {
+      "word": "仔細",
+      "alias": "姊細",
+      "tw": "zi xi",
+      "cn": "zai xi",
+      "sentences": 12,
+      "changed": [
+        [
+          "仔",
+          "姊",
+          "zi3"
+        ]
+      ]
+    },
+    {
+      "word": "穿著",
+      "alias": "穿灼",
+      "tw": "chuan zhuo",
+      "cn": "chuan zhu",
+      "sentences": 9,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "調整",
+      "alias": "迢整",
+      "tw": "tiao zheng",
+      "cn": "diao zheng",
+      "sentences": 9,
+      "changed": [
+        [
+          "調",
+          "迢",
+          "tiao2"
+        ]
+      ]
+    },
+    {
+      "word": "露出",
+      "alias": "陋出",
+      "tw": "lou chu",
+      "cn": "lu chu",
+      "sentences": 9,
+      "changed": [
+        [
+          "露",
+          "陋",
+          "lou4"
+        ]
+      ]
+    },
+    {
+      "word": "銀行",
+      "alias": "銀航",
+      "tw": "yin hang",
+      "cn": "yin xing",
+      "sentences": 8,
+      "changed": [
+        [
+          "行",
+          "航",
+          "hang2"
+        ]
+      ]
+    },
+    {
+      "word": "癌症",
+      "alias": "延症",
+      "tw": "yan zheng",
+      "cn": "ai zheng",
+      "sentences": 6,
+      "changed": [
+        [
+          "癌",
+          "延",
+          "yan2"
+        ]
+      ]
+    },
+    {
+      "word": "彈性",
+      "alias": "痰性",
+      "tw": "tan xing",
+      "cn": "dan xing",
+      "sentences": 6,
+      "changed": [
+        [
+          "彈",
+          "痰",
+          "tan2"
+        ]
+      ]
+    },
+    {
+      "word": "乾淨",
+      "alias": "尷淨",
+      "tw": "gan jing",
+      "cn": "qian jing",
+      "sentences": 6,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "供給",
+      "alias": "供擠",
+      "tw": "gong ji",
+      "cn": "gong gei",
+      "sentences": 6,
+      "changed": [
+        [
+          "給",
+          "擠",
+          "ji3"
+        ]
+      ]
+    },
+    {
+      "word": "暫時",
+      "alias": "戰時",
+      "tw": "zhan shi",
+      "cn": "zan shi",
+      "sentences": 6,
+      "changed": [
+        [
+          "暫",
+          "戰",
+          "zhan4"
+        ]
+      ]
+    },
+    {
+      "word": "擅長",
+      "alias": "擅腸",
+      "tw": "shan chang",
+      "cn": "shan zhang",
+      "sentences": 5,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "餅乾",
+      "alias": "餅尷",
+      "tw": "bing gan",
+      "cn": "bing qian",
+      "sentences": 5,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "細長",
+      "alias": "細腸",
+      "tw": "xi chang",
+      "cn": "xi zhang",
+      "sentences": 5,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "給予",
+      "alias": "擠予",
+      "tw": "ji yu",
+      "cn": "gei yu",
+      "sentences": 4,
+      "changed": [
+        [
+          "給",
+          "擠",
+          "ji3"
+        ]
+      ]
+    },
+    {
+      "word": "乾燥",
+      "alias": "尷燥",
+      "tw": "gan zao",
+      "cn": "qian zao",
+      "sentences": 4,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "發酵",
+      "alias": "發笑",
+      "tw": "fa xiao",
+      "cn": "fa jiao",
+      "sentences": 4,
+      "changed": [
+        [
+          "酵",
+          "笑",
+          "xiao4"
+        ]
+      ]
+    },
+    {
+      "word": "調味料",
+      "alias": "迢味料",
+      "tw": "tiao wei liao",
+      "cn": "diao wei liao",
+      "sentences": 3,
+      "changed": [
+        [
+          "調",
+          "迢",
+          "tiao2"
+        ]
+      ]
+    },
+    {
+      "word": "不給",
+      "alias": "不擠",
+      "tw": "bu ji",
+      "cn": "bu gei",
+      "sentences": 3,
+      "changed": [
+        [
+          "給",
+          "擠",
+          "ji3"
+        ]
+      ]
+    },
+    {
+      "word": "豬圈",
+      "alias": "豬倦",
+      "tw": "zhu juan",
+      "cn": "zhu quan",
+      "sentences": 3,
+      "changed": [
+        [
+          "圈",
+          "倦",
+          "juan4"
+        ]
+      ]
+    },
+    {
+      "word": "蛻變",
+      "alias": "睡變",
+      "tw": "shui bian",
+      "cn": "tui bian",
+      "sentences": 3,
+      "changed": [
+        [
+          "蛻",
+          "睡",
+          "shui4"
+        ]
+      ]
+    },
+    {
+      "word": "漫長",
+      "alias": "漫腸",
+      "tw": "man chang",
+      "cn": "man zhang",
+      "sentences": 2,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "執著",
+      "alias": "執灼",
+      "tw": "zhi zhuo",
+      "cn": "zhi zhu",
+      "sentences": 2,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "沉著",
+      "alias": "沉灼",
+      "tw": "chen zhuo",
+      "cn": "chen zhu",
+      "sentences": 2,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "滑稽",
+      "alias": "股稽",
+      "tw": "gu ji",
+      "cn": "hua ji",
+      "sentences": 2,
+      "changed": [
+        [
+          "滑",
+          "股",
+          "gu3"
+        ]
+      ]
+    },
+    {
+      "word": "午覺",
+      "alias": "午叫",
+      "tw": "wu jiao",
+      "cn": "wu jue",
+      "sentences": 2,
+      "changed": [
+        [
+          "覺",
+          "叫",
+          "jiao4"
+        ]
+      ]
+    },
+    {
+      "word": "寶藏",
+      "alias": "寶葬",
+      "tw": "bao zang",
+      "cn": "bao cang",
+      "sentences": 2,
+      "changed": [
+        [
+          "藏",
+          "葬",
+          "zang4"
+        ]
+      ]
+    },
+    {
+      "word": "特徵",
+      "alias": "特征",
+      "tw": "te zheng",
+      "cn": "te zhi",
+      "sentences": 2,
+      "changed": [
+        [
+          "徵",
+          "征",
+          "zheng1"
+        ]
+      ]
+    },
+    {
+      "word": "沒收",
+      "alias": "寞收",
+      "tw": "mo shou",
+      "cn": "mei shou",
+      "sentences": 2,
+      "changed": [
+        [
+          "沒",
+          "寞",
+          "mo4"
+        ]
+      ]
+    },
+    {
+      "word": "重重的",
+      "alias": "眾眾的",
+      "tw": "zhong zhong de",
+      "cn": "chong chong de",
+      "sentences": 2,
+      "changed": [
+        [
+          "重",
+          "眾",
+          "zhong4"
+        ],
+        [
+          "重",
+          "眾",
+          "zhong4"
+        ]
+      ]
+    },
+    {
+      "word": "囊括",
+      "alias": "囊瓜",
+      "tw": "nang gua",
+      "cn": "nang kuo",
+      "sentences": 2,
+      "changed": [
+        [
+          "括",
+          "瓜",
+          "gua1"
+        ]
+      ]
+    },
+    {
+      "word": "靦腆",
+      "alias": "勉腆",
+      "tw": "mian tian",
+      "cn": "tian tian",
+      "sentences": 2,
+      "changed": [
+        [
+          "靦",
+          "勉",
+          "mian3"
+        ]
+      ]
+    },
+    {
+      "word": "枯乾",
+      "alias": "枯尷",
+      "tw": "ku gan",
+      "cn": "ku qian",
+      "sentences": 2,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "調停",
+      "alias": "迢停",
+      "tw": "tiao ting",
+      "cn": "diao ting",
+      "sentences": 2,
+      "changed": [
+        [
+          "調",
+          "迢",
+          "tiao2"
+        ]
+      ]
+    },
+    {
+      "word": "恐嚇",
+      "alias": "恐賀",
+      "tw": "kong he",
+      "cn": "kong xia",
+      "sentences": 2,
+      "changed": [
+        [
+          "嚇",
+          "賀",
+          "he4"
+        ]
+      ]
+    },
+    {
+      "word": "說服",
+      "alias": "睡服",
+      "tw": "shui fu",
+      "cn": "shuo fu",
+      "sentences": 2,
+      "changed": [
+        [
+          "說",
+          "睡",
+          "shui4"
+        ]
+      ]
+    },
+    {
+      "word": "端的",
+      "alias": "端蒂",
+      "tw": "duan di",
+      "cn": "duan de",
+      "sentences": 2,
+      "changed": [
+        [
+          "的",
+          "蒂",
+          "di4"
+        ]
+      ]
+    },
+    {
+      "word": "暴露",
+      "alias": "舖露",
+      "tw": "pu lu",
+      "cn": "bao lu",
+      "sentences": 2,
+      "changed": [
+        [
+          "暴",
+          "舖",
+          "pu4"
+        ]
+      ]
+    },
+    {
+      "word": "著眼",
+      "alias": "灼眼",
+      "tw": "zhuo yan",
+      "cn": "zhu yan",
+      "sentences": 2,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "賞賜",
+      "alias": "賞飼",
+      "tw": "shang si",
+      "cn": "shang ci",
+      "sentences": 2,
+      "changed": [
+        [
+          "賜",
+          "飼",
+          "si4"
+        ]
+      ]
+    },
+    {
+      "word": "專長",
+      "alias": "專腸",
+      "tw": "zhuan chang",
+      "cn": "zhuan zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "彈跳",
+      "alias": "痰跳",
+      "tw": "tan tiao",
+      "cn": "dan tiao",
+      "sentences": 1,
+      "changed": [
+        [
+          "彈",
+          "痰",
+          "tan2"
+        ]
+      ]
+    },
+    {
+      "word": "一技之長",
+      "alias": "一技之腸",
+      "tw": "yi ji zhi chang",
+      "cn": "yi ji zhi zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "著落",
+      "alias": "灼落",
+      "tw": "zhuo luo",
+      "cn": "zhu luo",
+      "sentences": 1,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "彈力",
+      "alias": "痰力",
+      "tw": "tan li",
+      "cn": "dan li",
+      "sentences": 1,
+      "changed": [
+        [
+          "彈",
+          "痰",
+          "tan2"
+        ]
+      ]
+    },
+    {
+      "word": "重整",
+      "alias": "崇整",
+      "tw": "chong zheng",
+      "cn": "zhong zheng",
+      "sentences": 1,
+      "changed": [
+        [
+          "重",
+          "崇",
+          "chong2"
+        ]
+      ]
+    },
+    {
+      "word": "混淆",
+      "alias": "混遙",
+      "tw": "hun yao",
+      "cn": "hun xiao",
+      "sentences": 1,
+      "changed": [
+        [
+          "淆",
+          "遙",
+          "yao2"
+        ]
+      ]
+    },
+    {
+      "word": "震懾",
+      "alias": "震轍",
+      "tw": "zhen zhe",
+      "cn": "zhen she",
+      "sentences": 1,
+      "changed": [
+        [
+          "懾",
+          "轍",
+          "zhe2"
+        ]
+      ]
+    },
+    {
+      "word": "柏樹",
+      "alias": "搏樹",
+      "tw": "bo shu",
+      "cn": "bai shu",
+      "sentences": 1,
+      "changed": [
+        [
+          "柏",
+          "搏",
+          "bo2"
+        ]
+      ]
+    },
+    {
+      "word": "削瘦",
+      "alias": "消瘦",
+      "tw": "xiao shou",
+      "cn": "xue shou",
+      "sentences": 1,
+      "changed": [
+        [
+          "削",
+          "消",
+          "xiao1"
+        ]
+      ]
+    },
+    {
+      "word": "胃癌",
+      "alias": "胃延",
+      "tw": "wei yan",
+      "cn": "wei ai",
+      "sentences": 1,
+      "changed": [
+        [
+          "癌",
+          "延",
+          "yan2"
+        ]
+      ]
+    },
+    {
+      "word": "深長",
+      "alias": "深腸",
+      "tw": "shen chang",
+      "cn": "shen zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "著衣",
+      "alias": "灼衣",
+      "tw": "zhuo yi",
+      "cn": "zhu yi",
+      "sentences": 1,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "賈人",
+      "alias": "股人",
+      "tw": "gu ren",
+      "cn": "jia ren",
+      "sentences": 1,
+      "changed": [
+        [
+          "賈",
+          "股",
+          "gu3"
+        ]
+      ]
+    },
+    {
+      "word": "搖曳",
+      "alias": "搖亦",
+      "tw": "yao yi",
+      "cn": "yao ye",
+      "sentences": 1,
+      "changed": [
+        [
+          "曳",
+          "亦",
+          "yi4"
+        ]
+      ]
+    },
+    {
+      "word": "乾爽",
+      "alias": "尷爽",
+      "tw": "gan shuang",
+      "cn": "qian shuang",
+      "sentences": 1,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "調侃",
+      "alias": "迢侃",
+      "tw": "tiao kan",
+      "cn": "diao kan",
+      "sentences": 1,
+      "changed": [
+        [
+          "調",
+          "迢",
+          "tiao2"
+        ]
+      ]
+    },
+    {
+      "word": "蠕動",
+      "alias": "軟動",
+      "tw": "ruan dong",
+      "cn": "ru dong",
+      "sentences": 1,
+      "changed": [
+        [
+          "蠕",
+          "軟",
+          "ruan3"
+        ]
+      ]
+    },
+    {
+      "word": "的確",
+      "alias": "敵確",
+      "tw": "di que",
+      "cn": "de que",
+      "sentences": 1,
+      "changed": [
+        [
+          "的",
+          "敵",
+          "di2"
+        ]
+      ]
+    },
+    {
+      "word": "多重",
+      "alias": "多崇",
+      "tw": "duo chong",
+      "cn": "duo zhong",
+      "sentences": 1,
+      "changed": [
+        [
+          "重",
+          "崇",
+          "chong2"
+        ]
+      ]
+    },
+    {
+      "word": "覆轍",
+      "alias": "覆澈",
+      "tw": "fu che",
+      "cn": "fu zhe",
+      "sentences": 1,
+      "changed": [
+        [
+          "轍",
+          "澈",
+          "che4"
+        ]
+      ]
+    },
+    {
+      "word": "故技重施",
+      "alias": "故技崇施",
+      "tw": "gu ji chong shi",
+      "cn": "gu ji zhong shi",
+      "sentences": 1,
+      "changed": [
+        [
+          "重",
+          "崇",
+          "chong2"
+        ]
+      ]
+    },
+    {
+      "word": "特長",
+      "alias": "特腸",
+      "tw": "te chang",
+      "cn": "te zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "蝸牛",
+      "alias": "瓜牛",
+      "tw": "gua niu",
+      "cn": "wo niu",
+      "sentences": 1,
+      "changed": [
+        [
+          "蝸",
+          "瓜",
+          "gua1"
+        ]
+      ]
+    },
+    {
+      "word": "狹長",
+      "alias": "狹腸",
+      "tw": "xia chang",
+      "cn": "xia zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "軍樂",
+      "alias": "軍岳",
+      "tw": "jun yue",
+      "cn": "jun le",
+      "sentences": 1,
+      "changed": [
+        [
+          "樂",
+          "岳",
+          "yue4"
+        ]
+      ]
+    },
+    {
+      "word": "屏氣",
+      "alias": "餅氣",
+      "tw": "bing qi",
+      "cn": "ping qi",
+      "sentences": 1,
+      "changed": [
+        [
+          "屏",
+          "餅",
+          "bing3"
+        ]
+      ]
+    },
+    {
+      "word": "樂章",
+      "alias": "岳章",
+      "tw": "yue zhang",
+      "cn": "le zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "樂",
+          "岳",
+          "yue4"
+        ]
+      ]
+    },
+    {
+      "word": "著手",
+      "alias": "灼手",
+      "tw": "zhuo shou",
+      "cn": "zhu shou",
+      "sentences": 1,
+      "changed": [
+        [
+          "著",
+          "灼",
+          "zhuo2"
+        ]
+      ]
+    },
+    {
+      "word": "協調",
+      "alias": "協迢",
+      "tw": "xie tiao",
+      "cn": "xie diao",
+      "sentences": 1,
+      "changed": [
+        [
+          "調",
+          "迢",
+          "tiao2"
+        ]
+      ]
+    },
+    {
+      "word": "藤蔓",
+      "alias": "藤曼",
+      "tw": "teng man",
+      "cn": "teng wan",
+      "sentences": 1,
+      "changed": [
+        [
+          "蔓",
+          "曼",
+          "man4"
+        ]
+      ]
+    },
+    {
+      "word": "修長",
+      "alias": "修腸",
+      "tw": "xiu chang",
+      "cn": "xiu zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "身長",
+      "alias": "身腸",
+      "tw": "shen chang",
+      "cn": "shen zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "長蟲",
+      "alias": "腸蟲",
+      "tw": "chang chong",
+      "cn": "zhang chong",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "拉長",
+      "alias": "拉腸",
+      "tw": "la chang",
+      "cn": "la zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "大廈",
+      "alias": "大下",
+      "tw": "da xia",
+      "cn": "da sha",
+      "sentences": 1,
+      "changed": [
+        [
+          "廈",
+          "下",
+          "xia4"
+        ]
+      ]
+    },
+    {
+      "word": "嚇阻",
+      "alias": "賀阻",
+      "tw": "he zu",
+      "cn": "xia zu",
+      "sentences": 1,
+      "changed": [
+        [
+          "嚇",
+          "賀",
+          "he4"
+        ]
+      ]
+    },
+    {
+      "word": "匱乏",
+      "alias": "愧乏",
+      "tw": "kui fa",
+      "cn": "gui fa",
+      "sentences": 1,
+      "changed": [
+        [
+          "匱",
+          "愧",
+          "kui4"
+        ]
+      ]
+    },
+    {
+      "word": "顫抖",
+      "alias": "戰抖",
+      "tw": "zhan dou",
+      "cn": "chan dou",
+      "sentences": 1,
+      "changed": [
+        [
+          "顫",
+          "戰",
+          "zhan4"
+        ]
+      ]
+    },
+    {
+      "word": "乾脆",
+      "alias": "尷脆",
+      "tw": "gan cui",
+      "cn": "qian cui",
+      "sentences": 1,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "乾旱",
+      "alias": "尷旱",
+      "tw": "gan han",
+      "cn": "qian han",
+      "sentences": 1,
+      "changed": [
+        [
+          "乾",
+          "尷",
+          "gan1"
+        ]
+      ]
+    },
+    {
+      "word": "秘魯",
+      "alias": "碧魯",
+      "tw": "bi lu",
+      "cn": "mi lu",
+      "sentences": 1,
+      "changed": [
+        [
+          "秘",
+          "碧",
+          "bi4"
+        ]
+      ]
+    },
+    {
+      "word": "攜帶",
+      "alias": "醯帶",
+      "tw": "xi dai",
+      "cn": "xie dai",
+      "sentences": 1,
+      "changed": [
+        [
+          "攜",
+          "醯",
+          "xi1"
+        ]
+      ]
+    },
+    {
+      "word": "延長",
+      "alias": "延腸",
+      "tw": "yan chang",
+      "cn": "yan zhang",
+      "sentences": 1,
+      "changed": [
+        [
+          "長",
+          "腸",
+          "chang2"
+        ]
+      ]
+    },
+    {
+      "word": "重疊",
+      "alias": "崇疊",
+      "tw": "chong die",
+      "cn": "zhong die",
+      "sentences": 1,
+      "changed": [
+        [
+          "重",
+          "崇",
+          "chong2"
+        ]
+      ]
+    },
+    {
+      "word": "一轍",
+      "alias": "一澈",
+      "tw": "yi che",
+      "cn": "yi zhe",
+      "sentences": 1,
+      "changed": [
+        [
+          "轍",
+          "澈",
+          "che4"
+        ]
+      ]
+    },
+    {
+      "word": "樂曲",
+      "alias": "岳曲",
+      "tw": "yue qu",
+      "cn": "le qu",
+      "sentences": 1,
+      "changed": [
+        [
+          "樂",
+          "岳",
+          "yue4"
+        ]
+      ]
+    },
+    {
+      "word": "強勁",
+      "alias": "強逕",
+      "tw": "qiang jing",
+      "cn": "qiang jin",
+      "sentences": 1,
+      "changed": [
+        [
+          "勁",
+          "逕",
+          "jing4"
+        ]
+      ]
+    },
+    {
+      "word": "縝密",
+      "alias": "診密",
+      "tw": "zhen mi",
+      "cn": "chen mi",
+      "sentences": 1,
+      "changed": [
+        [
+          "縝",
+          "診",
+          "zhen3"
+        ]
+      ]
+    }
+  ]
+}

--- a/backend/tests/test_taiwan_pronunciation.py
+++ b/backend/tests/test_taiwan_pronunciation.py
@@ -1,0 +1,79 @@
+"""Locks the Taiwan pronunciation corrections to their data file.
+
+The four cases Hans reported on 2026-08-09 (攻擊/嘆息/摸不著/和) were none of
+them in PHONEME_CORRECTIONS, which had held the same four hand-added entries
+since the 2026-05-01 expert review flagged 破音字 as a risk. That review's audit
+scanned 31 characters and surfaced 4298 items needing human review; 22 were ever
+fixed. Hand-maintaining the table does not converge.
+
+The corrections now come from a generated data file whose authority is the MOE
+dictionary, so adding coverage means regenerating rather than appending.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+DATA = Path(__file__).resolve().parents[1] / "data" / "tts" / "taiwan_pronunciation.json"
+
+
+@pytest.fixture(scope="module")
+def data() -> dict:
+    return json.loads(DATA.read_text(encoding="utf-8"))
+
+
+def test_data_file_exists_and_is_attributed(data: dict) -> None:
+    assert data["_source"].startswith("教育部")
+    assert "corrections" in data
+    assert len(data["corrections"]) >= 50
+
+
+def test_every_alias_differs_from_its_word(data: dict) -> None:
+    # An alias identical to the word is a no-op that looks like coverage.
+    for row in data["corrections"]:
+        assert row["alias"] != row["word"], row["word"]
+
+
+def test_alias_preserves_length(data: dict) -> None:
+    # <sub> replaces the whole span; a different length means the substitution
+    # would change the sentence's character count and break cursor alignment.
+    for row in data["corrections"]:
+        assert len(row["alias"]) == len(row["word"]), row["word"]
+
+
+def test_alias_is_plain_han_characters(data: dict) -> None:
+    # Azure reads the alias as text. Anything non-Han would be spelled out.
+    for row in data["corrections"]:
+        assert re.fullmatch(r"[一-鿿]+", row["alias"]), row
+
+
+def test_no_word_is_a_substring_of_another(data: dict) -> None:
+    # Sequential replacement over overlapping keys double-substitutes: an alias
+    # emitted by one rule can match a later rule's key. Caught this way in #2612.
+    words = [r["word"] for r in data["corrections"]]
+    for w in words:
+        for other in words:
+            if w != other:
+                assert w not in other, f"{w} is inside {other}"
+
+
+def test_corrections_load_into_the_tts_table() -> None:
+    from app.services.tts.normalization import PHONEME_CORRECTIONS
+
+    keys = {k for k, _ in PHONEME_CORRECTIONS}
+    # The four hand-added entries must survive alongside the generated ones.
+    assert "喝采" in keys
+    # And the generated set must actually be wired in.
+    assert "音樂" in keys, "data file is not reaching PHONEME_CORRECTIONS"
+
+
+def test_generated_entries_wrap_in_sub_alias() -> None:
+    from app.services.tts.normalization import PHONEME_CORRECTIONS
+
+    table = dict(PHONEME_CORRECTIONS)
+    # Azure rejects <phoneme> outright — every alphabet returns HTTP 400 — so
+    # <sub alias> is the only pronunciation control available here (#2612).
+    assert table["音樂"] == '<sub alias="音岳">音樂</sub>'


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Hans 2026-08-09 回報四個唸錯的字，**一個都不在校正表裡** ——
那張表從 2026-05-01 專家審查（曾教授舉例「喝彩」）之後就只有手動加的 4 條。

## 手動維護不會收斂

```
2026-05-01 審查後的盤點   31 個字 / 57 課 / 5155 處
needs_human_review        4298 筆   ← 人工看不完
實際修正                    22 筆   ← 卡住
```

每有人聽到一個錯字，就要手動加一條。這正是要終結的循環。

## 改成資料驅動

教育部《重編國語辭典修訂本》—— g0v 以 CC BY-ND 開放，161,194 詞條、每筆帶注音。
**Hans 那四個查它全中，一字不差。**

```
jieba 斷詞 → 查教育部注音 → 與 pypinyin(大陸) 比對聲韻
→ 差異音節自動選一個「只有台灣讀音」的字當 alias
→ 89 條校正，涵蓋 253 句
```

以後加涵蓋是**重新產生檔案**，不是再手動加一條 tuple。

## 前三次比對都產出垃圾，記在 commit 裡

```
取 heteronyms[0]   → 古義排前面（大家→gū jiā）
保留聲調            → 一/不 變調與輕聲標法淹沒真訊號
substring 比對      → 跨詞邊界造出「的是」「子都」
```

斷詞 + 只比聲韻，訊號才乾淨。

## 實測驗過，不是假設

六組 alias 各合成兩次（帶與不帶 `<sub>`），**全部 HTTP 200 且 md5 不同** ——
Azure 真的照 alias 唸。這點關鍵在於 `<phoneme>` 在這裡完全不能用（四種 alphabet 全 400）。

## 回歸根因

```
2026-08-07  TTS 從 Gemini 切到 Azure
Gemini      prompt「請使用台灣用語的繁體中文」→ LLM 會照做
Azure       zh-TW-HsiaoChenNeural 固定語音，沒有 prompt → 訓練資料怎麼唸就怎麼唸
```

所有出問題的音檔都在切換之後產生。**不是誰把東西改壞，是換 provider 失去了那個 prompt。**

## 人工排除三條，理由寫在檔案裡

`它們`、`似的`、`類似` —— 教育部收錄古音或兩讀皆通，現代課文語境不需校正。

## 驗證

```
7 tests passed
mutation  拿掉載入器 → 2 紅；還原 → 7 綠
TTS 既有測試  改動前 4 failed → 改動後 3 failed（沒弄壞，還修好一個）
```

檔案缺失或格式壞掉會退回內建 4 條，不會讓合成掛掉。