### PR TITLE
fix(#2622): 全文 QR 指向「讀全文-做記號」，不是課程簡介

### DIFF
--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -170,7 +170,7 @@ describe('LessonAudioTable', () => {
   it('builds QR values for intro and full-reading lesson routes', () => {
     const origin = 'https://staging.example.test';
 
-    expect(buildLessonQrValue(origin, 1, 'lesson-intro')).toBe('https://staging.example.test/learn/1/lesson-intro');
+    expect(buildLessonQrValue(origin, 1, 'full-text-annotate')).toBe('https://staging.example.test/learn/1/full-text-annotate');
     expect(buildLessonQrValue(origin, 1, 'key-passage-reading')).toBe(
       'https://staging.example.test/learn/1/key-passage-reading',
     );
@@ -423,7 +423,7 @@ describe('#2622 QR 交付表', () => {
     // lesson, so both codes belong on the same line.
     expect(rows).toHaveLength(2);
     expect(rows[0].lesson_no).toBe('L01');
-    expect(rows[0].full_url).toBe('https://x.test/learn/1/lesson-intro');
+    expect(rows[0].full_url).toBe('https://x.test/learn/1/full-text-annotate');
     expect(rows[0].passage_url).toBe('https://x.test/learn/1/key-passage-reading');
     // Lesson 2 is grade 8 (全文 blank per the grade rule) AND has no 念順順段
     // (has_key_reading=false), so the batch produces no passage clip for it.
@@ -504,7 +504,7 @@ describe('#2626 只有 4-7 年級交付全文', () => {
       { id: 2, lesson_number: 2, title: 'G8 課', grade: 8, grade_code: 'G8-L02', char_count: 10, has_key_reading: true },
     ] as never, 'https://x.test');
 
-    expect(rows[0].full_url).toBe('https://x.test/learn/1/lesson-intro');
+    expect(rows[0].full_url).toBe('https://x.test/learn/1/full-text-annotate');
     expect(rows[1].full_url).toBe('');
     // Positive control: this G8 lesson DOES have a 念順順段
     // (has_key_reading=true), so its 段落 code must survive even though 全文
@@ -623,5 +623,42 @@ describe('#2627 播放全文必須唸完整篇，不是只唸第一段', () => {
     expect(text).toContain('THE-KEY-PASSAGE-1');
     // A paragraph index would make the hook ignore the passage text entirely.
     expect(idx).toBeUndefined();
+  });
+});
+
+
+describe('#2622 全文 QR 必須指向真正讀全文的那一步', () => {
+  /**
+   * The 「全文」 QR pointed at lesson-intro, the 課程簡介 step, because when it
+   * was built no step was named for whole-text reading — `full-reading` was
+   * taken and read a single key passage. #2641 renamed the ids and made the
+   * real one visible: `full-text-annotate` (讀全文-做記號) renders story.content
+   * in full, and its hint says 閱讀全文.
+   *
+   * A student scanning the 全文 code landed on the lesson blurb instead of the
+   * text. Reported as 「QR code全文朗讀的部分會進到課程簡介」.
+   */
+  it('encodes full-text-annotate, not lesson-intro', () => {
+    const origin = 'https://x.test';
+    expect(buildLessonQrValue(origin, 7, 'full-text-annotate')).toBe(
+      'https://x.test/learn/7/full-text-annotate',
+    );
+  });
+
+  it('the 全文 column renders a QR for the whole-text step', async () => {
+    vi.clearAllMocks();
+    mockFetchDispatcher();
+    mockTts();
+
+    render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    const titles = within(row)
+      .getAllByRole('button', { name: 'QR' })
+      .map((b) => b.getAttribute('title'));
+
+    expect(titles.some((t) => t?.endsWith('/full-text-annotate'))).toBe(true);
+    expect(titles.some((t) => t?.endsWith('/lesson-intro'))).toBe(false);
   });
 });

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.test.tsx
@@ -662,3 +662,33 @@ describe('#2622 全文 QR 必須指向真正讀全文的那一步', () => {
     expect(titles.some((t) => t?.endsWith('/lesson-intro'))).toBe(false);
   });
 });
+
+describe('#2622 QR popup 標題要分得出全文與段落', () => {
+  /**
+   * The title compared against 'lesson-intro', which no step id uses any more
+   * after the 全文 target moved to full-text-annotate — so every dialog, both
+   * columns, was labelled 段落. A stale comparison against a value that no
+   * longer exists fails silently: it just always takes the else branch.
+   */
+  it.each([
+    ['full-text-annotate', '全文'],
+    ['key-passage-reading', '段落'],
+  ])('%s dialog is labelled %s', async (step, label) => {
+    vi.clearAllMocks();
+    mockFetchDispatcher();
+    mockTts();
+
+    render(<LessonAudioTable />);
+    await waitFor(() => screen.getByText('贏得喝采的輸家'));
+
+    const row = screen.getByText('贏得喝采的輸家').closest('[role="row"]') as HTMLElement;
+    const btn = within(row)
+      .getAllByRole('button', { name: 'QR' })
+      .find((b) => b.getAttribute('title')?.endsWith(`/${step}`));
+    expect(btn, `no QR button targeting ${step}`).toBeDefined();
+
+    fireEvent.click(btn!);
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.getAttribute('aria-label')).toContain(label);
+  });
+});

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -10,7 +10,14 @@ import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
-type LessonQrStep = 'lesson-intro' | 'key-passage-reading';
+// The 全文 code points at full-text-annotate, not lesson-intro.
+//
+// lesson-intro is the 課程簡介 blurb; full-text-annotate (讀全文-做記號) is the
+// step that renders story.content in full. The original wiring predates #2641,
+// when no id said "whole text" — `full-reading` was taken and read a single key
+// passage — so the closest thing was the intro. Reported as 「QR code全文朗讀的
+// 部分會進到課程簡介」.
+type LessonQrStep = 'full-text-annotate' | 'key-passage-reading';
 type AudioMode = 'full' | 'key';
 
 interface StoryListItem {
@@ -181,7 +188,7 @@ export function buildQrManifestRows(stories: StoryListItem[], origin: string): Q
     grade: s.grade,
     // Blank rather than a URL: the batch produces no whole-text clip for
     // grades 8-9, so handing the 教材端 a code for it would point at silence.
-    full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'lesson-intro') : '',
+    full_url: deliversFullText(s.grade) ? buildLessonQrValue(origin, s.id, 'full-text-annotate') : '',
     // Same rule on the passage side: build_demo_reading.plan_demo_audio only
     // produces demo-reading/{id}/passage.mp3 when the lesson has a 念順順段
     // (has_key_reading). Emitting a code for a lesson without one — as this
@@ -787,7 +794,7 @@ const LessonAudioTable: React.FC = () => {
               </div>
 
               {deliversFullText(story.grade)
-                ? <QrDownloadButton lessonId={story.id} step="lesson-intro" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
+                ? <QrDownloadButton lessonId={story.id} step="full-text-annotate" label="QR" filePrefix="intro-qr" lessonTitle={story.title} />
                 : <span className="text-xs text-gray-400" title="8-9 年級依規格只交付段落朗讀">—</span>}
               <QrDownloadButton lessonId={story.id} step="key-passage-reading" label="QR" filePrefix="full-reading-qr" lessonTitle={story.title} />
             </div>

--- a/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
+++ b/frontend/src/pages/admin/lesson-audio/LessonAudioTable.tsx
@@ -323,7 +323,7 @@ const QrDownloadButton: React.FC<QrButtonProps> = ({ lessonId, step, label, file
       </button>
       {preview && (
         <QrPreviewDialog
-          title={`${title}／${step === 'lesson-intro' ? '全文' : '段落'}`}
+          title={`${title}／${step === 'full-text-annotate' ? '全文' : '段落'}`}
           value={preview.value}
           dataUrl={preview.dataUrl}
           filename={qrFileName(filePrefix, lessonId)}


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Hans 回報：「QR code全文朗讀的部分會進到課程簡介」。

**`full-text-annotate`（讀全文-做記號）才是真正 render `story.content` 全文的那一步**，
hint 也寫「閱讀全文」。`lesson-intro` 只是課程簡介。

## 為什麼當初做錯

那時**沒有任何 step 叫「全文」** —— `full-reading` 這個名字被重點朗讀佔用（只唸一段），
所以只能指向最接近的 intro。#2641 改名之後真正的那一步才浮出來。

這是命名混亂第三次造成實際損失：
① 新功能接到已停用的 `tutor` ② 元件叫 `FullReading` 卻只唸一段 ③ 這次

## 驗證

```
32 tests passed
mutation  QR 改回指 intro → 1 紅
lint 0 errors ／ vite build ✓
```

三條既有斷言原本寫死 `lesson-intro`，那正是這次移除的行為，一併更新。

相關 TODO 總表 #2649