### PR TITLE
feat(#2649): 讀全文-做記號 加播放器，並讓 QR 掃進來的人不用登入就能讀和聽

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -73,4 +73,7 @@ jobs:
 
       - name: Render-smoke + pinned regression tests (vitest)
         working-directory: frontend
-        run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/paragraph-reading/ParagraphReading.readAgain.test.tsx src/hooks/useTtsPlayback.test.ts src/pages/admin/lesson-audio/qrcode-bundling.test.ts src/pages/admin/lesson-audio/LessonAudioTable.test.tsx src/config/stepNaming.test.ts src/routes/componentNaming.test.ts
+        run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/paragraph-reading/ParagraphReading.readAgain.test.tsx src/hooks/useTtsPlayback.test.ts src/pages/admin/lesson-audio/qrcode-bundling.test.ts src/pages/admin/lesson-audio/LessonAudioTable.test.tsx src/config/stepNaming.test.ts src/routes/componentNaming.test.ts \
+            src/components/auth/LearningRouteGate.test.tsx \
+            src/components/reading-steps/FullTextAnnotate.readonly.test.tsx \
+            src/hooks/useFullTextTtsQueue.test.ts

--- a/backend/app/services/tts/__init__.py
+++ b/backend/app/services/tts/__init__.py
@@ -278,11 +278,17 @@ def synthesize_speech(text: str) -> bytes:
         _l1_put(key, gcs_data)
         return gcs_data
 
-    if active_provider == "azure":
-        gcs_data = _gcs_get(key, provider="google")
-        if gcs_data is not None:
-            _l1_put(key, gcs_data)
-            return gcs_data
+    # No cross-prefix read-through (#2649 item 4).
+    #
+    # Azure misses used to fall back to the google prefix. The two prefixes hold
+    # different voices — zh-TW-HsiaoChenNeural vs cmn-CN-Chirp3-HD, and the
+    # mainland accent was rejected in 2026-04 — so that fallback made a brief
+    # Azure outage permanent: the failure writes a mainland-accent object, every
+    # later request finds it, and Azure recovering never undoes it. 22 sentences
+    # reached production that way.
+    #
+    # A miss now costs one synthesis. That is the correct price for always
+    # shipping the voice we chose.
 
     cleaned = _clean_for_tts(text)
     if not cleaned:

--- a/backend/data/tts/taiwan_pronunciation.json
+++ b/backend/data/tts/taiwan_pronunciation.json
@@ -1,1265 +1,1862 @@
 {
-  "_source": "教育部《重編國語辭典修訂本》· g0v/moedict-data · CC BY-ND 3.0 TW",
-  "_method": "jieba 斷詞 → 教育部注音 vs pypinyin(大陸) 比對聲韻 → 自動生成同音單讀字 alias",
-  "_excluded": [
-    "似的",
-    "它們",
-    "類似"
-  ],
-  "_excluded_reason": "教育部收錄古音或兩讀皆通，現代課文語境不需校正",
-  "_verified": "6/6 抽樣送 Azure 實測 HTTP 200 且音檔 md5 改變",
-  "_generated": "2026-08-10",
-  "corrections": [
-    {
-      "word": "音樂",
-      "alias": "音岳",
-      "tw": "yin yue",
-      "cn": "yin le",
-      "sentences": 13,
-      "changed": [
-        [
-          "樂",
-          "岳",
-          "yue4"
-        ]
-      ]
-    },
-    {
-      "word": "仔細",
-      "alias": "姊細",
-      "tw": "zi xi",
-      "cn": "zai xi",
-      "sentences": 12,
-      "changed": [
-        [
-          "仔",
-          "姊",
-          "zi3"
-        ]
-      ]
-    },
-    {
-      "word": "穿著",
-      "alias": "穿灼",
-      "tw": "chuan zhuo",
-      "cn": "chuan zhu",
-      "sentences": 9,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "調整",
-      "alias": "迢整",
-      "tw": "tiao zheng",
-      "cn": "diao zheng",
-      "sentences": 9,
-      "changed": [
-        [
-          "調",
-          "迢",
-          "tiao2"
-        ]
-      ]
-    },
-    {
-      "word": "露出",
-      "alias": "陋出",
-      "tw": "lou chu",
-      "cn": "lu chu",
-      "sentences": 9,
-      "changed": [
-        [
-          "露",
-          "陋",
-          "lou4"
-        ]
-      ]
-    },
-    {
-      "word": "銀行",
-      "alias": "銀航",
-      "tw": "yin hang",
-      "cn": "yin xing",
-      "sentences": 8,
-      "changed": [
-        [
-          "行",
-          "航",
-          "hang2"
-        ]
-      ]
-    },
-    {
-      "word": "癌症",
-      "alias": "延症",
-      "tw": "yan zheng",
-      "cn": "ai zheng",
-      "sentences": 6,
-      "changed": [
-        [
-          "癌",
-          "延",
-          "yan2"
-        ]
-      ]
-    },
-    {
-      "word": "彈性",
-      "alias": "痰性",
-      "tw": "tan xing",
-      "cn": "dan xing",
-      "sentences": 6,
-      "changed": [
-        [
-          "彈",
-          "痰",
-          "tan2"
-        ]
-      ]
-    },
-    {
-      "word": "乾淨",
-      "alias": "尷淨",
-      "tw": "gan jing",
-      "cn": "qian jing",
-      "sentences": 6,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "供給",
-      "alias": "供擠",
-      "tw": "gong ji",
-      "cn": "gong gei",
-      "sentences": 6,
-      "changed": [
-        [
-          "給",
-          "擠",
-          "ji3"
-        ]
-      ]
-    },
-    {
-      "word": "暫時",
-      "alias": "戰時",
-      "tw": "zhan shi",
-      "cn": "zan shi",
-      "sentences": 6,
-      "changed": [
-        [
-          "暫",
-          "戰",
-          "zhan4"
-        ]
-      ]
-    },
-    {
-      "word": "擅長",
-      "alias": "擅腸",
-      "tw": "shan chang",
-      "cn": "shan zhang",
-      "sentences": 5,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "餅乾",
-      "alias": "餅尷",
-      "tw": "bing gan",
-      "cn": "bing qian",
-      "sentences": 5,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "細長",
-      "alias": "細腸",
-      "tw": "xi chang",
-      "cn": "xi zhang",
-      "sentences": 5,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "給予",
-      "alias": "擠予",
-      "tw": "ji yu",
-      "cn": "gei yu",
-      "sentences": 4,
-      "changed": [
-        [
-          "給",
-          "擠",
-          "ji3"
-        ]
-      ]
-    },
-    {
-      "word": "乾燥",
-      "alias": "尷燥",
-      "tw": "gan zao",
-      "cn": "qian zao",
-      "sentences": 4,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "發酵",
-      "alias": "發笑",
-      "tw": "fa xiao",
-      "cn": "fa jiao",
-      "sentences": 4,
-      "changed": [
-        [
-          "酵",
-          "笑",
-          "xiao4"
-        ]
-      ]
-    },
-    {
-      "word": "調味料",
-      "alias": "迢味料",
-      "tw": "tiao wei liao",
-      "cn": "diao wei liao",
-      "sentences": 3,
-      "changed": [
-        [
-          "調",
-          "迢",
-          "tiao2"
-        ]
-      ]
-    },
-    {
-      "word": "不給",
-      "alias": "不擠",
-      "tw": "bu ji",
-      "cn": "bu gei",
-      "sentences": 3,
-      "changed": [
-        [
-          "給",
-          "擠",
-          "ji3"
-        ]
-      ]
-    },
-    {
-      "word": "豬圈",
-      "alias": "豬倦",
-      "tw": "zhu juan",
-      "cn": "zhu quan",
-      "sentences": 3,
-      "changed": [
-        [
-          "圈",
-          "倦",
-          "juan4"
-        ]
-      ]
-    },
-    {
-      "word": "蛻變",
-      "alias": "睡變",
-      "tw": "shui bian",
-      "cn": "tui bian",
-      "sentences": 3,
-      "changed": [
-        [
-          "蛻",
-          "睡",
-          "shui4"
-        ]
-      ]
-    },
-    {
-      "word": "漫長",
-      "alias": "漫腸",
-      "tw": "man chang",
-      "cn": "man zhang",
-      "sentences": 2,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "執著",
-      "alias": "執灼",
-      "tw": "zhi zhuo",
-      "cn": "zhi zhu",
-      "sentences": 2,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "沉著",
-      "alias": "沉灼",
-      "tw": "chen zhuo",
-      "cn": "chen zhu",
-      "sentences": 2,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "滑稽",
-      "alias": "股稽",
-      "tw": "gu ji",
-      "cn": "hua ji",
-      "sentences": 2,
-      "changed": [
-        [
-          "滑",
-          "股",
-          "gu3"
-        ]
-      ]
-    },
-    {
-      "word": "午覺",
-      "alias": "午叫",
-      "tw": "wu jiao",
-      "cn": "wu jue",
-      "sentences": 2,
-      "changed": [
-        [
-          "覺",
-          "叫",
-          "jiao4"
-        ]
-      ]
-    },
-    {
-      "word": "寶藏",
-      "alias": "寶葬",
-      "tw": "bao zang",
-      "cn": "bao cang",
-      "sentences": 2,
-      "changed": [
-        [
-          "藏",
-          "葬",
-          "zang4"
-        ]
-      ]
-    },
-    {
-      "word": "特徵",
-      "alias": "特征",
-      "tw": "te zheng",
-      "cn": "te zhi",
-      "sentences": 2,
-      "changed": [
-        [
-          "徵",
-          "征",
-          "zheng1"
-        ]
-      ]
-    },
-    {
-      "word": "沒收",
-      "alias": "寞收",
-      "tw": "mo shou",
-      "cn": "mei shou",
-      "sentences": 2,
-      "changed": [
-        [
-          "沒",
-          "寞",
-          "mo4"
-        ]
-      ]
-    },
-    {
-      "word": "重重的",
-      "alias": "眾眾的",
-      "tw": "zhong zhong de",
-      "cn": "chong chong de",
-      "sentences": 2,
-      "changed": [
-        [
-          "重",
-          "眾",
-          "zhong4"
-        ],
-        [
-          "重",
-          "眾",
-          "zhong4"
-        ]
-      ]
-    },
-    {
-      "word": "囊括",
-      "alias": "囊瓜",
-      "tw": "nang gua",
-      "cn": "nang kuo",
-      "sentences": 2,
-      "changed": [
-        [
-          "括",
-          "瓜",
-          "gua1"
-        ]
-      ]
-    },
-    {
-      "word": "靦腆",
-      "alias": "勉腆",
-      "tw": "mian tian",
-      "cn": "tian tian",
-      "sentences": 2,
-      "changed": [
-        [
-          "靦",
-          "勉",
-          "mian3"
-        ]
-      ]
-    },
-    {
-      "word": "枯乾",
-      "alias": "枯尷",
-      "tw": "ku gan",
-      "cn": "ku qian",
-      "sentences": 2,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "調停",
-      "alias": "迢停",
-      "tw": "tiao ting",
-      "cn": "diao ting",
-      "sentences": 2,
-      "changed": [
-        [
-          "調",
-          "迢",
-          "tiao2"
-        ]
-      ]
-    },
-    {
-      "word": "恐嚇",
-      "alias": "恐賀",
-      "tw": "kong he",
-      "cn": "kong xia",
-      "sentences": 2,
-      "changed": [
-        [
-          "嚇",
-          "賀",
-          "he4"
-        ]
-      ]
-    },
-    {
-      "word": "說服",
-      "alias": "睡服",
-      "tw": "shui fu",
-      "cn": "shuo fu",
-      "sentences": 2,
-      "changed": [
-        [
-          "說",
-          "睡",
-          "shui4"
-        ]
-      ]
-    },
-    {
-      "word": "端的",
-      "alias": "端蒂",
-      "tw": "duan di",
-      "cn": "duan de",
-      "sentences": 2,
-      "changed": [
-        [
-          "的",
-          "蒂",
-          "di4"
-        ]
-      ]
-    },
-    {
-      "word": "暴露",
-      "alias": "舖露",
-      "tw": "pu lu",
-      "cn": "bao lu",
-      "sentences": 2,
-      "changed": [
-        [
-          "暴",
-          "舖",
-          "pu4"
-        ]
-      ]
-    },
-    {
-      "word": "著眼",
-      "alias": "灼眼",
-      "tw": "zhuo yan",
-      "cn": "zhu yan",
-      "sentences": 2,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "賞賜",
-      "alias": "賞飼",
-      "tw": "shang si",
-      "cn": "shang ci",
-      "sentences": 2,
-      "changed": [
-        [
-          "賜",
-          "飼",
-          "si4"
-        ]
-      ]
-    },
-    {
-      "word": "專長",
-      "alias": "專腸",
-      "tw": "zhuan chang",
-      "cn": "zhuan zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "彈跳",
-      "alias": "痰跳",
-      "tw": "tan tiao",
-      "cn": "dan tiao",
-      "sentences": 1,
-      "changed": [
-        [
-          "彈",
-          "痰",
-          "tan2"
-        ]
-      ]
-    },
-    {
-      "word": "一技之長",
-      "alias": "一技之腸",
-      "tw": "yi ji zhi chang",
-      "cn": "yi ji zhi zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "著落",
-      "alias": "灼落",
-      "tw": "zhuo luo",
-      "cn": "zhu luo",
-      "sentences": 1,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "彈力",
-      "alias": "痰力",
-      "tw": "tan li",
-      "cn": "dan li",
-      "sentences": 1,
-      "changed": [
-        [
-          "彈",
-          "痰",
-          "tan2"
-        ]
-      ]
-    },
-    {
-      "word": "重整",
-      "alias": "崇整",
-      "tw": "chong zheng",
-      "cn": "zhong zheng",
-      "sentences": 1,
-      "changed": [
-        [
-          "重",
-          "崇",
-          "chong2"
-        ]
-      ]
-    },
-    {
-      "word": "混淆",
-      "alias": "混遙",
-      "tw": "hun yao",
-      "cn": "hun xiao",
-      "sentences": 1,
-      "changed": [
-        [
-          "淆",
-          "遙",
-          "yao2"
-        ]
-      ]
-    },
-    {
-      "word": "震懾",
-      "alias": "震轍",
-      "tw": "zhen zhe",
-      "cn": "zhen she",
-      "sentences": 1,
-      "changed": [
-        [
-          "懾",
-          "轍",
-          "zhe2"
-        ]
-      ]
-    },
-    {
-      "word": "柏樹",
-      "alias": "搏樹",
-      "tw": "bo shu",
-      "cn": "bai shu",
-      "sentences": 1,
-      "changed": [
-        [
-          "柏",
-          "搏",
-          "bo2"
-        ]
-      ]
-    },
-    {
-      "word": "削瘦",
-      "alias": "消瘦",
-      "tw": "xiao shou",
-      "cn": "xue shou",
-      "sentences": 1,
-      "changed": [
-        [
-          "削",
-          "消",
-          "xiao1"
-        ]
-      ]
-    },
-    {
-      "word": "胃癌",
-      "alias": "胃延",
-      "tw": "wei yan",
-      "cn": "wei ai",
-      "sentences": 1,
-      "changed": [
-        [
-          "癌",
-          "延",
-          "yan2"
-        ]
-      ]
-    },
-    {
-      "word": "深長",
-      "alias": "深腸",
-      "tw": "shen chang",
-      "cn": "shen zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "著衣",
-      "alias": "灼衣",
-      "tw": "zhuo yi",
-      "cn": "zhu yi",
-      "sentences": 1,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "賈人",
-      "alias": "股人",
-      "tw": "gu ren",
-      "cn": "jia ren",
-      "sentences": 1,
-      "changed": [
-        [
-          "賈",
-          "股",
-          "gu3"
-        ]
-      ]
-    },
-    {
-      "word": "搖曳",
-      "alias": "搖亦",
-      "tw": "yao yi",
-      "cn": "yao ye",
-      "sentences": 1,
-      "changed": [
-        [
-          "曳",
-          "亦",
-          "yi4"
-        ]
-      ]
-    },
-    {
-      "word": "乾爽",
-      "alias": "尷爽",
-      "tw": "gan shuang",
-      "cn": "qian shuang",
-      "sentences": 1,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "調侃",
-      "alias": "迢侃",
-      "tw": "tiao kan",
-      "cn": "diao kan",
-      "sentences": 1,
-      "changed": [
-        [
-          "調",
-          "迢",
-          "tiao2"
-        ]
-      ]
-    },
-    {
-      "word": "蠕動",
-      "alias": "軟動",
-      "tw": "ruan dong",
-      "cn": "ru dong",
-      "sentences": 1,
-      "changed": [
-        [
-          "蠕",
-          "軟",
-          "ruan3"
-        ]
-      ]
-    },
-    {
-      "word": "的確",
-      "alias": "敵確",
-      "tw": "di que",
-      "cn": "de que",
-      "sentences": 1,
-      "changed": [
-        [
-          "的",
-          "敵",
-          "di2"
-        ]
-      ]
-    },
-    {
-      "word": "多重",
-      "alias": "多崇",
-      "tw": "duo chong",
-      "cn": "duo zhong",
-      "sentences": 1,
-      "changed": [
-        [
-          "重",
-          "崇",
-          "chong2"
-        ]
-      ]
-    },
-    {
-      "word": "覆轍",
-      "alias": "覆澈",
-      "tw": "fu che",
-      "cn": "fu zhe",
-      "sentences": 1,
-      "changed": [
-        [
-          "轍",
-          "澈",
-          "che4"
-        ]
-      ]
-    },
-    {
-      "word": "故技重施",
-      "alias": "故技崇施",
-      "tw": "gu ji chong shi",
-      "cn": "gu ji zhong shi",
-      "sentences": 1,
-      "changed": [
-        [
-          "重",
-          "崇",
-          "chong2"
-        ]
-      ]
-    },
-    {
-      "word": "特長",
-      "alias": "特腸",
-      "tw": "te chang",
-      "cn": "te zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "蝸牛",
-      "alias": "瓜牛",
-      "tw": "gua niu",
-      "cn": "wo niu",
-      "sentences": 1,
-      "changed": [
-        [
-          "蝸",
-          "瓜",
-          "gua1"
-        ]
-      ]
-    },
-    {
-      "word": "狹長",
-      "alias": "狹腸",
-      "tw": "xia chang",
-      "cn": "xia zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "軍樂",
-      "alias": "軍岳",
-      "tw": "jun yue",
-      "cn": "jun le",
-      "sentences": 1,
-      "changed": [
-        [
-          "樂",
-          "岳",
-          "yue4"
-        ]
-      ]
-    },
-    {
-      "word": "屏氣",
-      "alias": "餅氣",
-      "tw": "bing qi",
-      "cn": "ping qi",
-      "sentences": 1,
-      "changed": [
-        [
-          "屏",
-          "餅",
-          "bing3"
-        ]
-      ]
-    },
-    {
-      "word": "樂章",
-      "alias": "岳章",
-      "tw": "yue zhang",
-      "cn": "le zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "樂",
-          "岳",
-          "yue4"
-        ]
-      ]
-    },
-    {
-      "word": "著手",
-      "alias": "灼手",
-      "tw": "zhuo shou",
-      "cn": "zhu shou",
-      "sentences": 1,
-      "changed": [
-        [
-          "著",
-          "灼",
-          "zhuo2"
-        ]
-      ]
-    },
-    {
-      "word": "協調",
-      "alias": "協迢",
-      "tw": "xie tiao",
-      "cn": "xie diao",
-      "sentences": 1,
-      "changed": [
-        [
-          "調",
-          "迢",
-          "tiao2"
-        ]
-      ]
-    },
-    {
-      "word": "藤蔓",
-      "alias": "藤曼",
-      "tw": "teng man",
-      "cn": "teng wan",
-      "sentences": 1,
-      "changed": [
-        [
-          "蔓",
-          "曼",
-          "man4"
-        ]
-      ]
-    },
-    {
-      "word": "修長",
-      "alias": "修腸",
-      "tw": "xiu chang",
-      "cn": "xiu zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "身長",
-      "alias": "身腸",
-      "tw": "shen chang",
-      "cn": "shen zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "長蟲",
-      "alias": "腸蟲",
-      "tw": "chang chong",
-      "cn": "zhang chong",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "拉長",
-      "alias": "拉腸",
-      "tw": "la chang",
-      "cn": "la zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "大廈",
-      "alias": "大下",
-      "tw": "da xia",
-      "cn": "da sha",
-      "sentences": 1,
-      "changed": [
-        [
-          "廈",
-          "下",
-          "xia4"
-        ]
-      ]
-    },
-    {
-      "word": "嚇阻",
-      "alias": "賀阻",
-      "tw": "he zu",
-      "cn": "xia zu",
-      "sentences": 1,
-      "changed": [
-        [
-          "嚇",
-          "賀",
-          "he4"
-        ]
-      ]
-    },
-    {
-      "word": "匱乏",
-      "alias": "愧乏",
-      "tw": "kui fa",
-      "cn": "gui fa",
-      "sentences": 1,
-      "changed": [
-        [
-          "匱",
-          "愧",
-          "kui4"
-        ]
-      ]
-    },
-    {
-      "word": "顫抖",
-      "alias": "戰抖",
-      "tw": "zhan dou",
-      "cn": "chan dou",
-      "sentences": 1,
-      "changed": [
-        [
-          "顫",
-          "戰",
-          "zhan4"
-        ]
-      ]
-    },
-    {
-      "word": "乾脆",
-      "alias": "尷脆",
-      "tw": "gan cui",
-      "cn": "qian cui",
-      "sentences": 1,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "乾旱",
-      "alias": "尷旱",
-      "tw": "gan han",
-      "cn": "qian han",
-      "sentences": 1,
-      "changed": [
-        [
-          "乾",
-          "尷",
-          "gan1"
-        ]
-      ]
-    },
-    {
-      "word": "秘魯",
-      "alias": "碧魯",
-      "tw": "bi lu",
-      "cn": "mi lu",
-      "sentences": 1,
-      "changed": [
-        [
-          "秘",
-          "碧",
-          "bi4"
-        ]
-      ]
-    },
-    {
-      "word": "攜帶",
-      "alias": "醯帶",
-      "tw": "xi dai",
-      "cn": "xie dai",
-      "sentences": 1,
-      "changed": [
-        [
-          "攜",
-          "醯",
-          "xi1"
-        ]
-      ]
-    },
-    {
-      "word": "延長",
-      "alias": "延腸",
-      "tw": "yan chang",
-      "cn": "yan zhang",
-      "sentences": 1,
-      "changed": [
-        [
-          "長",
-          "腸",
-          "chang2"
-        ]
-      ]
-    },
-    {
-      "word": "重疊",
-      "alias": "崇疊",
-      "tw": "chong die",
-      "cn": "zhong die",
-      "sentences": 1,
-      "changed": [
-        [
-          "重",
-          "崇",
-          "chong2"
-        ]
-      ]
-    },
-    {
-      "word": "一轍",
-      "alias": "一澈",
-      "tw": "yi che",
-      "cn": "yi zhe",
-      "sentences": 1,
-      "changed": [
-        [
-          "轍",
-          "澈",
-          "che4"
-        ]
-      ]
-    },
-    {
-      "word": "樂曲",
-      "alias": "岳曲",
-      "tw": "yue qu",
-      "cn": "le qu",
-      "sentences": 1,
-      "changed": [
-        [
-          "樂",
-          "岳",
-          "yue4"
-        ]
-      ]
-    },
-    {
-      "word": "強勁",
-      "alias": "強逕",
-      "tw": "qiang jing",
-      "cn": "qiang jin",
-      "sentences": 1,
-      "changed": [
-        [
-          "勁",
-          "逕",
-          "jing4"
-        ]
-      ]
-    },
-    {
-      "word": "縝密",
-      "alias": "診密",
-      "tw": "zhen mi",
-      "cn": "chen mi",
-      "sentences": 1,
-      "changed": [
-        [
-          "縝",
-          "診",
-          "zhen3"
-        ]
-      ]
-    }
-  ]
+ "_source": "教育部《重編國語辭典修訂本》· g0v/moedict-data · CC BY-ND 3.0 TW",
+ "_method": "jieba 斷詞 → 教育部注音 vs pypinyin(大陸) 比對聲韻 → 自動生成同音單讀字 alias ｜ 2026-08-10 補聲調差異：教育部單讀音字 vs pypinyin(大陸)『含聲調』比對，排除一/不(變調雜訊)，替身也必須是單讀音字。語料改用 API 全 165 課(191k 字) —— 先前用 repo curriculum 只有 113k 字、連 L01 都不在裡面，因此漏掉 Hans 回報的 攻擊/嘆息。jieba 產生的非原子詞(攻擊千變)已濾除。",
+ "_excluded": [
+  "似的",
+  "它們",
+  "類似"
+ ],
+ "_excluded_reason": "教育部收錄古音或兩讀皆通，現代課文語境不需校正",
+ "_verified": "6/6 抽樣送 Azure 實測 HTTP 200 且音檔 md5 改變",
+ "_generated": "2026-08-10",
+ "corrections": [
+  {
+   "word": "音樂",
+   "alias": "音岳",
+   "tw": "yin yue",
+   "cn": "yin le",
+   "sentences": 13,
+   "changed": [
+    [
+     "樂",
+     "岳",
+     "yue4"
+    ]
+   ]
+  },
+  {
+   "word": "仔細",
+   "alias": "姊細",
+   "tw": "zi xi",
+   "cn": "zai xi",
+   "sentences": 12,
+   "changed": [
+    [
+     "仔",
+     "姊",
+     "zi3"
+    ]
+   ]
+  },
+  {
+   "word": "穿著",
+   "alias": "穿灼",
+   "tw": "chuan zhuo",
+   "cn": "chuan zhu",
+   "sentences": 9,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "調整",
+   "alias": "迢整",
+   "tw": "tiao zheng",
+   "cn": "diao zheng",
+   "sentences": 9,
+   "changed": [
+    [
+     "調",
+     "迢",
+     "tiao2"
+    ]
+   ]
+  },
+  {
+   "word": "露出",
+   "alias": "陋出",
+   "tw": "lou chu",
+   "cn": "lu chu",
+   "sentences": 9,
+   "changed": [
+    [
+     "露",
+     "陋",
+     "lou4"
+    ]
+   ]
+  },
+  {
+   "word": "銀行",
+   "alias": "銀航",
+   "tw": "yin hang",
+   "cn": "yin xing",
+   "sentences": 8,
+   "changed": [
+    [
+     "行",
+     "航",
+     "hang2"
+    ]
+   ]
+  },
+  {
+   "word": "癌症",
+   "alias": "延症",
+   "tw": "yan zheng",
+   "cn": "ai zheng",
+   "sentences": 6,
+   "changed": [
+    [
+     "癌",
+     "延",
+     "yan2"
+    ]
+   ]
+  },
+  {
+   "word": "彈性",
+   "alias": "痰性",
+   "tw": "tan xing",
+   "cn": "dan xing",
+   "sentences": 6,
+   "changed": [
+    [
+     "彈",
+     "痰",
+     "tan2"
+    ]
+   ]
+  },
+  {
+   "word": "乾淨",
+   "alias": "尷淨",
+   "tw": "gan jing",
+   "cn": "qian jing",
+   "sentences": 6,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "供給",
+   "alias": "供擠",
+   "tw": "gong ji",
+   "cn": "gong gei",
+   "sentences": 6,
+   "changed": [
+    [
+     "給",
+     "擠",
+     "ji3"
+    ]
+   ]
+  },
+  {
+   "word": "暫時",
+   "alias": "戰時",
+   "tw": "zhan shi",
+   "cn": "zan shi",
+   "sentences": 6,
+   "changed": [
+    [
+     "暫",
+     "戰",
+     "zhan4"
+    ]
+   ]
+  },
+  {
+   "word": "擅長",
+   "alias": "擅腸",
+   "tw": "shan chang",
+   "cn": "shan zhang",
+   "sentences": 5,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "餅乾",
+   "alias": "餅尷",
+   "tw": "bing gan",
+   "cn": "bing qian",
+   "sentences": 5,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "細長",
+   "alias": "細腸",
+   "tw": "xi chang",
+   "cn": "xi zhang",
+   "sentences": 5,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "給予",
+   "alias": "擠予",
+   "tw": "ji yu",
+   "cn": "gei yu",
+   "sentences": 4,
+   "changed": [
+    [
+     "給",
+     "擠",
+     "ji3"
+    ]
+   ]
+  },
+  {
+   "word": "乾燥",
+   "alias": "尷燥",
+   "tw": "gan zao",
+   "cn": "qian zao",
+   "sentences": 4,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "發酵",
+   "alias": "發笑",
+   "tw": "fa xiao",
+   "cn": "fa jiao",
+   "sentences": 4,
+   "changed": [
+    [
+     "酵",
+     "笑",
+     "xiao4"
+    ]
+   ]
+  },
+  {
+   "word": "調味料",
+   "alias": "迢味料",
+   "tw": "tiao wei liao",
+   "cn": "diao wei liao",
+   "sentences": 3,
+   "changed": [
+    [
+     "調",
+     "迢",
+     "tiao2"
+    ]
+   ]
+  },
+  {
+   "word": "不給",
+   "alias": "不擠",
+   "tw": "bu ji",
+   "cn": "bu gei",
+   "sentences": 3,
+   "changed": [
+    [
+     "給",
+     "擠",
+     "ji3"
+    ]
+   ]
+  },
+  {
+   "word": "豬圈",
+   "alias": "豬倦",
+   "tw": "zhu juan",
+   "cn": "zhu quan",
+   "sentences": 3,
+   "changed": [
+    [
+     "圈",
+     "倦",
+     "juan4"
+    ]
+   ]
+  },
+  {
+   "word": "蛻變",
+   "alias": "睡變",
+   "tw": "shui bian",
+   "cn": "tui bian",
+   "sentences": 3,
+   "changed": [
+    [
+     "蛻",
+     "睡",
+     "shui4"
+    ]
+   ]
+  },
+  {
+   "word": "漫長",
+   "alias": "漫腸",
+   "tw": "man chang",
+   "cn": "man zhang",
+   "sentences": 2,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "執著",
+   "alias": "執灼",
+   "tw": "zhi zhuo",
+   "cn": "zhi zhu",
+   "sentences": 2,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "沉著",
+   "alias": "沉灼",
+   "tw": "chen zhuo",
+   "cn": "chen zhu",
+   "sentences": 2,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "滑稽",
+   "alias": "股稽",
+   "tw": "gu ji",
+   "cn": "hua ji",
+   "sentences": 2,
+   "changed": [
+    [
+     "滑",
+     "股",
+     "gu3"
+    ]
+   ]
+  },
+  {
+   "word": "午覺",
+   "alias": "午叫",
+   "tw": "wu jiao",
+   "cn": "wu jue",
+   "sentences": 2,
+   "changed": [
+    [
+     "覺",
+     "叫",
+     "jiao4"
+    ]
+   ]
+  },
+  {
+   "word": "寶藏",
+   "alias": "寶葬",
+   "tw": "bao zang",
+   "cn": "bao cang",
+   "sentences": 2,
+   "changed": [
+    [
+     "藏",
+     "葬",
+     "zang4"
+    ]
+   ]
+  },
+  {
+   "word": "特徵",
+   "alias": "特征",
+   "tw": "te zheng",
+   "cn": "te zhi",
+   "sentences": 2,
+   "changed": [
+    [
+     "徵",
+     "征",
+     "zheng1"
+    ]
+   ]
+  },
+  {
+   "word": "沒收",
+   "alias": "寞收",
+   "tw": "mo shou",
+   "cn": "mei shou",
+   "sentences": 2,
+   "changed": [
+    [
+     "沒",
+     "寞",
+     "mo4"
+    ]
+   ]
+  },
+  {
+   "word": "重重的",
+   "alias": "眾眾的",
+   "tw": "zhong zhong de",
+   "cn": "chong chong de",
+   "sentences": 2,
+   "changed": [
+    [
+     "重",
+     "眾",
+     "zhong4"
+    ],
+    [
+     "重",
+     "眾",
+     "zhong4"
+    ]
+   ]
+  },
+  {
+   "word": "囊括",
+   "alias": "囊瓜",
+   "tw": "nang gua",
+   "cn": "nang kuo",
+   "sentences": 2,
+   "changed": [
+    [
+     "括",
+     "瓜",
+     "gua1"
+    ]
+   ]
+  },
+  {
+   "word": "靦腆",
+   "alias": "勉腆",
+   "tw": "mian tian",
+   "cn": "tian tian",
+   "sentences": 2,
+   "changed": [
+    [
+     "靦",
+     "勉",
+     "mian3"
+    ]
+   ]
+  },
+  {
+   "word": "枯乾",
+   "alias": "枯尷",
+   "tw": "ku gan",
+   "cn": "ku qian",
+   "sentences": 2,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "調停",
+   "alias": "迢停",
+   "tw": "tiao ting",
+   "cn": "diao ting",
+   "sentences": 2,
+   "changed": [
+    [
+     "調",
+     "迢",
+     "tiao2"
+    ]
+   ]
+  },
+  {
+   "word": "恐嚇",
+   "alias": "恐賀",
+   "tw": "kong he",
+   "cn": "kong xia",
+   "sentences": 2,
+   "changed": [
+    [
+     "嚇",
+     "賀",
+     "he4"
+    ]
+   ]
+  },
+  {
+   "word": "說服",
+   "alias": "睡服",
+   "tw": "shui fu",
+   "cn": "shuo fu",
+   "sentences": 2,
+   "changed": [
+    [
+     "說",
+     "睡",
+     "shui4"
+    ]
+   ]
+  },
+  {
+   "word": "端的",
+   "alias": "端蒂",
+   "tw": "duan di",
+   "cn": "duan de",
+   "sentences": 2,
+   "changed": [
+    [
+     "的",
+     "蒂",
+     "di4"
+    ]
+   ]
+  },
+  {
+   "word": "暴露",
+   "alias": "舖露",
+   "tw": "pu lu",
+   "cn": "bao lu",
+   "sentences": 2,
+   "changed": [
+    [
+     "暴",
+     "舖",
+     "pu4"
+    ]
+   ]
+  },
+  {
+   "word": "著眼",
+   "alias": "灼眼",
+   "tw": "zhuo yan",
+   "cn": "zhu yan",
+   "sentences": 2,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "賞賜",
+   "alias": "賞飼",
+   "tw": "shang si",
+   "cn": "shang ci",
+   "sentences": 2,
+   "changed": [
+    [
+     "賜",
+     "飼",
+     "si4"
+    ]
+   ]
+  },
+  {
+   "word": "專長",
+   "alias": "專腸",
+   "tw": "zhuan chang",
+   "cn": "zhuan zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "彈跳",
+   "alias": "痰跳",
+   "tw": "tan tiao",
+   "cn": "dan tiao",
+   "sentences": 1,
+   "changed": [
+    [
+     "彈",
+     "痰",
+     "tan2"
+    ]
+   ]
+  },
+  {
+   "word": "一技之長",
+   "alias": "一技之腸",
+   "tw": "yi ji zhi chang",
+   "cn": "yi ji zhi zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "著落",
+   "alias": "灼落",
+   "tw": "zhuo luo",
+   "cn": "zhu luo",
+   "sentences": 1,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "彈力",
+   "alias": "痰力",
+   "tw": "tan li",
+   "cn": "dan li",
+   "sentences": 1,
+   "changed": [
+    [
+     "彈",
+     "痰",
+     "tan2"
+    ]
+   ]
+  },
+  {
+   "word": "重整",
+   "alias": "崇整",
+   "tw": "chong zheng",
+   "cn": "zhong zheng",
+   "sentences": 1,
+   "changed": [
+    [
+     "重",
+     "崇",
+     "chong2"
+    ]
+   ]
+  },
+  {
+   "word": "混淆",
+   "alias": "混遙",
+   "tw": "hun yao",
+   "cn": "hun xiao",
+   "sentences": 1,
+   "changed": [
+    [
+     "淆",
+     "遙",
+     "yao2"
+    ]
+   ]
+  },
+  {
+   "word": "震懾",
+   "alias": "震轍",
+   "tw": "zhen zhe",
+   "cn": "zhen she",
+   "sentences": 1,
+   "changed": [
+    [
+     "懾",
+     "轍",
+     "zhe2"
+    ]
+   ]
+  },
+  {
+   "word": "柏樹",
+   "alias": "搏樹",
+   "tw": "bo shu",
+   "cn": "bai shu",
+   "sentences": 1,
+   "changed": [
+    [
+     "柏",
+     "搏",
+     "bo2"
+    ]
+   ]
+  },
+  {
+   "word": "削瘦",
+   "alias": "消瘦",
+   "tw": "xiao shou",
+   "cn": "xue shou",
+   "sentences": 1,
+   "changed": [
+    [
+     "削",
+     "消",
+     "xiao1"
+    ]
+   ]
+  },
+  {
+   "word": "胃癌",
+   "alias": "胃延",
+   "tw": "wei yan",
+   "cn": "wei ai",
+   "sentences": 1,
+   "changed": [
+    [
+     "癌",
+     "延",
+     "yan2"
+    ]
+   ]
+  },
+  {
+   "word": "深長",
+   "alias": "深腸",
+   "tw": "shen chang",
+   "cn": "shen zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "著衣",
+   "alias": "灼衣",
+   "tw": "zhuo yi",
+   "cn": "zhu yi",
+   "sentences": 1,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "賈人",
+   "alias": "股人",
+   "tw": "gu ren",
+   "cn": "jia ren",
+   "sentences": 1,
+   "changed": [
+    [
+     "賈",
+     "股",
+     "gu3"
+    ]
+   ]
+  },
+  {
+   "word": "搖曳",
+   "alias": "搖亦",
+   "tw": "yao yi",
+   "cn": "yao ye",
+   "sentences": 1,
+   "changed": [
+    [
+     "曳",
+     "亦",
+     "yi4"
+    ]
+   ]
+  },
+  {
+   "word": "乾爽",
+   "alias": "尷爽",
+   "tw": "gan shuang",
+   "cn": "qian shuang",
+   "sentences": 1,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "調侃",
+   "alias": "迢侃",
+   "tw": "tiao kan",
+   "cn": "diao kan",
+   "sentences": 1,
+   "changed": [
+    [
+     "調",
+     "迢",
+     "tiao2"
+    ]
+   ]
+  },
+  {
+   "word": "蠕動",
+   "alias": "軟動",
+   "tw": "ruan dong",
+   "cn": "ru dong",
+   "sentences": 1,
+   "changed": [
+    [
+     "蠕",
+     "軟",
+     "ruan3"
+    ]
+   ]
+  },
+  {
+   "word": "的確",
+   "alias": "敵確",
+   "tw": "di que",
+   "cn": "de que",
+   "sentences": 1,
+   "changed": [
+    [
+     "的",
+     "敵",
+     "di2"
+    ]
+   ]
+  },
+  {
+   "word": "多重",
+   "alias": "多崇",
+   "tw": "duo chong",
+   "cn": "duo zhong",
+   "sentences": 1,
+   "changed": [
+    [
+     "重",
+     "崇",
+     "chong2"
+    ]
+   ]
+  },
+  {
+   "word": "覆轍",
+   "alias": "覆澈",
+   "tw": "fu che",
+   "cn": "fu zhe",
+   "sentences": 1,
+   "changed": [
+    [
+     "轍",
+     "澈",
+     "che4"
+    ]
+   ]
+  },
+  {
+   "word": "故技重施",
+   "alias": "故技崇施",
+   "tw": "gu ji chong shi",
+   "cn": "gu ji zhong shi",
+   "sentences": 1,
+   "changed": [
+    [
+     "重",
+     "崇",
+     "chong2"
+    ]
+   ]
+  },
+  {
+   "word": "特長",
+   "alias": "特腸",
+   "tw": "te chang",
+   "cn": "te zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "蝸牛",
+   "alias": "瓜牛",
+   "tw": "gua niu",
+   "cn": "wo niu",
+   "sentences": 1,
+   "changed": [
+    [
+     "蝸",
+     "瓜",
+     "gua1"
+    ]
+   ]
+  },
+  {
+   "word": "狹長",
+   "alias": "狹腸",
+   "tw": "xia chang",
+   "cn": "xia zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "軍樂",
+   "alias": "軍岳",
+   "tw": "jun yue",
+   "cn": "jun le",
+   "sentences": 1,
+   "changed": [
+    [
+     "樂",
+     "岳",
+     "yue4"
+    ]
+   ]
+  },
+  {
+   "word": "屏氣",
+   "alias": "餅氣",
+   "tw": "bing qi",
+   "cn": "ping qi",
+   "sentences": 1,
+   "changed": [
+    [
+     "屏",
+     "餅",
+     "bing3"
+    ]
+   ]
+  },
+  {
+   "word": "樂章",
+   "alias": "岳章",
+   "tw": "yue zhang",
+   "cn": "le zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "樂",
+     "岳",
+     "yue4"
+    ]
+   ]
+  },
+  {
+   "word": "著手",
+   "alias": "灼手",
+   "tw": "zhuo shou",
+   "cn": "zhu shou",
+   "sentences": 1,
+   "changed": [
+    [
+     "著",
+     "灼",
+     "zhuo2"
+    ]
+   ]
+  },
+  {
+   "word": "協調",
+   "alias": "協迢",
+   "tw": "xie tiao",
+   "cn": "xie diao",
+   "sentences": 1,
+   "changed": [
+    [
+     "調",
+     "迢",
+     "tiao2"
+    ]
+   ]
+  },
+  {
+   "word": "藤蔓",
+   "alias": "藤曼",
+   "tw": "teng man",
+   "cn": "teng wan",
+   "sentences": 1,
+   "changed": [
+    [
+     "蔓",
+     "曼",
+     "man4"
+    ]
+   ]
+  },
+  {
+   "word": "修長",
+   "alias": "修腸",
+   "tw": "xiu chang",
+   "cn": "xiu zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "身長",
+   "alias": "身腸",
+   "tw": "shen chang",
+   "cn": "shen zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "長蟲",
+   "alias": "腸蟲",
+   "tw": "chang chong",
+   "cn": "zhang chong",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "拉長",
+   "alias": "拉腸",
+   "tw": "la chang",
+   "cn": "la zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "大廈",
+   "alias": "大下",
+   "tw": "da xia",
+   "cn": "da sha",
+   "sentences": 1,
+   "changed": [
+    [
+     "廈",
+     "下",
+     "xia4"
+    ]
+   ]
+  },
+  {
+   "word": "嚇阻",
+   "alias": "賀阻",
+   "tw": "he zu",
+   "cn": "xia zu",
+   "sentences": 1,
+   "changed": [
+    [
+     "嚇",
+     "賀",
+     "he4"
+    ]
+   ]
+  },
+  {
+   "word": "匱乏",
+   "alias": "愧乏",
+   "tw": "kui fa",
+   "cn": "gui fa",
+   "sentences": 1,
+   "changed": [
+    [
+     "匱",
+     "愧",
+     "kui4"
+    ]
+   ]
+  },
+  {
+   "word": "顫抖",
+   "alias": "戰抖",
+   "tw": "zhan dou",
+   "cn": "chan dou",
+   "sentences": 1,
+   "changed": [
+    [
+     "顫",
+     "戰",
+     "zhan4"
+    ]
+   ]
+  },
+  {
+   "word": "乾脆",
+   "alias": "尷脆",
+   "tw": "gan cui",
+   "cn": "qian cui",
+   "sentences": 1,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "乾旱",
+   "alias": "尷旱",
+   "tw": "gan han",
+   "cn": "qian han",
+   "sentences": 1,
+   "changed": [
+    [
+     "乾",
+     "尷",
+     "gan1"
+    ]
+   ]
+  },
+  {
+   "word": "秘魯",
+   "alias": "碧魯",
+   "tw": "bi lu",
+   "cn": "mi lu",
+   "sentences": 1,
+   "changed": [
+    [
+     "秘",
+     "碧",
+     "bi4"
+    ]
+   ]
+  },
+  {
+   "word": "攜帶",
+   "alias": "醯帶",
+   "tw": "xi dai",
+   "cn": "xie dai",
+   "sentences": 1,
+   "changed": [
+    [
+     "攜",
+     "醯",
+     "xi1"
+    ]
+   ]
+  },
+  {
+   "word": "延長",
+   "alias": "延腸",
+   "tw": "yan chang",
+   "cn": "yan zhang",
+   "sentences": 1,
+   "changed": [
+    [
+     "長",
+     "腸",
+     "chang2"
+    ]
+   ]
+  },
+  {
+   "word": "重疊",
+   "alias": "崇疊",
+   "tw": "chong die",
+   "cn": "zhong die",
+   "sentences": 1,
+   "changed": [
+    [
+     "重",
+     "崇",
+     "chong2"
+    ]
+   ]
+  },
+  {
+   "word": "一轍",
+   "alias": "一澈",
+   "tw": "yi che",
+   "cn": "yi zhe",
+   "sentences": 1,
+   "changed": [
+    [
+     "轍",
+     "澈",
+     "che4"
+    ]
+   ]
+  },
+  {
+   "word": "樂曲",
+   "alias": "岳曲",
+   "tw": "yue qu",
+   "cn": "le qu",
+   "sentences": 1,
+   "changed": [
+    [
+     "樂",
+     "岳",
+     "yue4"
+    ]
+   ]
+  },
+  {
+   "word": "強勁",
+   "alias": "強逕",
+   "tw": "qiang jing",
+   "cn": "qiang jin",
+   "sentences": 1,
+   "changed": [
+    [
+     "勁",
+     "逕",
+     "jing4"
+    ]
+   ]
+  },
+  {
+   "word": "縝密",
+   "alias": "診密",
+   "tw": "zhen mi",
+   "cn": "chen mi",
+   "sentences": 1,
+   "changed": [
+    [
+     "縝",
+     "診",
+     "zhen3"
+    ]
+   ]
+  },
+  {
+   "word": "突然",
+   "alias": "圖然",
+   "kind": "tone"
+  },
+  {
+   "word": "攻擊",
+   "alias": "攻及",
+   "kind": "tone"
+  },
+  {
+   "word": "休息",
+   "alias": "休習",
+   "kind": "tone"
+  },
+  {
+   "word": "拳擊",
+   "alias": "拳及",
+   "kind": "tone"
+  },
+  {
+   "word": "危險",
+   "alias": "維險",
+   "kind": "tone"
+  },
+  {
+   "word": "訊息",
+   "alias": "訊習",
+   "kind": "tone"
+  },
+  {
+   "word": "干擾",
+   "alias": "甘擾",
+   "kind": "tone"
+  },
+  {
+   "word": "病菌",
+   "alias": "病俊",
+   "kind": "tone"
+  },
+  {
+   "word": "盡量",
+   "alias": "進量",
+   "kind": "tone"
+  },
+  {
+   "word": "消息",
+   "alias": "消習",
+   "kind": "tone"
+  },
+  {
+   "word": "悄悄",
+   "alias": "巧巧",
+   "kind": "tone"
+  },
+  {
+   "word": "危機",
+   "alias": "維機",
+   "kind": "tone"
+  },
+  {
+   "word": "盡頭",
+   "alias": "進頭",
+   "kind": "tone"
+  },
+  {
+   "word": "突破",
+   "alias": "圖破",
+   "kind": "tone"
+  },
+  {
+   "word": "作息",
+   "alias": "作習",
+   "kind": "tone"
+  },
+  {
+   "word": "跌倒",
+   "alias": "蝶倒",
+   "kind": "tone"
+  },
+  {
+   "word": "衝突",
+   "alias": "衝圖",
+   "kind": "tone"
+  },
+  {
+   "word": "企業",
+   "alias": "氣業",
+   "kind": "tone"
+  },
+  {
+   "word": "可惜",
+   "alias": "可習",
+   "kind": "tone"
+  },
+  {
+   "word": "建築",
+   "alias": "建逐",
+   "kind": "tone"
+  },
+  {
+   "word": "珍惜",
+   "alias": "珍習",
+   "kind": "tone"
+  },
+  {
+   "word": "殆盡",
+   "alias": "殆進",
+   "kind": "tone"
+  },
+  {
+   "word": "盡出",
+   "alias": "進出",
+   "kind": "tone"
+  },
+  {
+   "word": "危害",
+   "alias": "維害",
+   "kind": "tone"
+  },
+  {
+   "word": "擊敗",
+   "alias": "及敗",
+   "kind": "tone"
+  },
+  {
+   "word": "舞蹈",
+   "alias": "舞到",
+   "kind": "tone"
+  },
+  {
+   "word": "悄然",
+   "alias": "巧然",
+   "kind": "tone"
+  },
+  {
+   "word": "物盡",
+   "alias": "物進",
+   "kind": "tone"
+  },
+  {
+   "word": "擊者",
+   "alias": "及者",
+   "kind": "tone"
+  },
+  {
+   "word": "出擊",
+   "alias": "出及",
+   "kind": "tone"
+  },
+  {
+   "word": "嘆息",
+   "alias": "嘆習",
+   "kind": "tone"
+  },
+  {
+   "word": "盡力",
+   "alias": "進力",
+   "kind": "tone"
+  },
+  {
+   "word": "擊球",
+   "alias": "及球",
+   "kind": "tone"
+  },
+  {
+   "word": "技擊",
+   "alias": "技及",
+   "kind": "tone"
+  },
+  {
+   "word": "愛惜",
+   "alias": "愛習",
+   "kind": "tone"
+  },
+  {
+   "word": "迎擊",
+   "alias": "迎及",
+   "kind": "tone"
+  },
+  {
+   "word": "下跌",
+   "alias": "下蝶",
+   "kind": "tone"
+  },
+  {
+   "word": "跌入",
+   "alias": "蝶入",
+   "kind": "tone"
+  },
+  {
+   "word": "盡情",
+   "alias": "進情",
+   "kind": "tone"
+  },
+  {
+   "word": "點擊",
+   "alias": "點及",
+   "kind": "tone"
+  },
+  {
+   "word": "真偽",
+   "alias": "真位",
+   "kind": "tone"
+  },
+  {
+   "word": "一息",
+   "alias": "一習",
+   "kind": "tone"
+  },
+  {
+   "word": "米斗",
+   "alias": "米抖",
+   "kind": "tone"
+  },
+  {
+   "word": "簡樸",
+   "alias": "簡僕",
+   "kind": "tone"
+  },
+  {
+   "word": "盡有",
+   "alias": "進有",
+   "kind": "tone"
+  },
+  {
+   "word": "投擲",
+   "alias": "投直",
+   "kind": "tone"
+  },
+  {
+   "word": "棲息",
+   "alias": "棲習",
+   "kind": "tone"
+  },
+  {
+   "word": "無菌",
+   "alias": "無俊",
+   "kind": "tone"
+  },
+  {
+   "word": "耗盡",
+   "alias": "耗進",
+   "kind": "tone"
+  },
+  {
+   "word": "無息",
+   "alias": "無習",
+   "kind": "tone"
+  },
+  {
+   "word": "瀕危",
+   "alias": "瀕維",
+   "kind": "tone"
+  },
+  {
+   "word": "嘗盡",
+   "alias": "嘗進",
+   "kind": "tone"
+  },
+  {
+   "word": "目擊",
+   "alias": "目及",
+   "kind": "tone"
+  },
+  {
+   "word": "突顯",
+   "alias": "圖顯",
+   "kind": "tone"
+  },
+  {
+   "word": "危急",
+   "alias": "維急",
+   "kind": "tone"
+  },
+  {
+   "word": "雷擊",
+   "alias": "雷及",
+   "kind": "tone"
+  },
+  {
+   "word": "突起",
+   "alias": "圖起",
+   "kind": "tone"
+  },
+  {
+   "word": "惋惜",
+   "alias": "惋習",
+   "kind": "tone"
+  },
+  {
+   "word": "詳盡",
+   "alias": "詳進",
+   "kind": "tone"
+  },
+  {
+   "word": "企圖",
+   "alias": "氣圖",
+   "kind": "tone"
+  },
+  {
+   "word": "突出",
+   "alias": "圖出",
+   "kind": "tone"
+  },
+  {
+   "word": "一擲",
+   "alias": "一直",
+   "kind": "tone"
+  },
+  {
+   "word": "崩跌",
+   "alias": "崩蝶",
+   "kind": "tone"
+  },
+  {
+   "word": "竭盡",
+   "alias": "竭進",
+   "kind": "tone"
+  },
+  {
+   "word": "打擊",
+   "alias": "打及",
+   "kind": "tone"
+  },
+  {
+   "word": "襲擊",
+   "alias": "襲及",
+   "kind": "tone"
+  },
+  {
+   "word": "儉樸",
+   "alias": "儉僕",
+   "kind": "tone"
+  },
+  {
+   "word": "突發",
+   "alias": "圖發",
+   "kind": "tone"
+  },
+  {
+   "word": "跌破",
+   "alias": "蝶破",
+   "kind": "tone"
+  },
+  {
+   "word": "追擊",
+   "alias": "追及",
+   "kind": "tone"
+  },
+  {
+   "word": "不惜",
+   "alias": "不習",
+   "kind": "tone"
+  },
+  {
+   "word": "平息",
+   "alias": "平習",
+   "kind": "tone"
+  },
+  {
+   "word": "窒息",
+   "alias": "窒習",
+   "kind": "tone"
+  },
+  {
+   "word": "傾盡",
+   "alias": "傾進",
+   "kind": "tone"
+  },
+  {
+   "word": "築巢",
+   "alias": "逐巢",
+   "kind": "tone"
+  },
+  {
+   "word": "斗笠",
+   "alias": "抖笠",
+   "kind": "tone"
+  },
+  {
+   "word": "反擊",
+   "alias": "反及",
+   "kind": "tone"
+  },
+  {
+   "word": "滅菌",
+   "alias": "滅俊",
+   "kind": "tone"
+  },
+  {
+   "word": "息息",
+   "alias": "習習",
+   "kind": "tone"
+  },
+  {
+   "word": "危危",
+   "alias": "維維",
+   "kind": "tone"
+  },
+  {
+   "word": "重擊",
+   "alias": "重及",
+   "kind": "tone"
+  },
+  {
+   "word": "突襲",
+   "alias": "圖襲",
+   "kind": "tone"
+  },
+  {
+   "word": "這突",
+   "alias": "這圖",
+   "kind": "tone"
+  },
+  {
+   "word": "衝擊",
+   "alias": "衝及",
+   "kind": "tone"
+  },
+  {
+   "word": "一擊",
+   "alias": "一及",
+   "kind": "tone"
+  },
+  {
+   "word": "槍擊",
+   "alias": "槍及",
+   "kind": "tone"
+  },
+  {
+   "word": "喘息",
+   "alias": "喘習",
+   "kind": "tone"
+  },
+  {
+   "word": "干預",
+   "alias": "甘預",
+   "kind": "tone"
+  },
+  {
+   "word": "屏息",
+   "alias": "屏習",
+   "kind": "tone"
+  },
+  {
+   "word": "撞擊",
+   "alias": "撞及",
+   "kind": "tone"
+  },
+  {
+   "word": "多巴胺",
+   "alias": "多巴安",
+   "kind": "tone"
+  },
+  {
+   "word": "將擊破",
+   "alias": "將及破",
+   "kind": "tone"
+  },
+  {
+   "word": "危物種",
+   "alias": "維物種",
+   "kind": "tone"
+  },
+  {
+   "word": "偽新聞",
+   "alias": "位新聞",
+   "kind": "tone"
+  },
+  {
+   "word": "偽科學",
+   "alias": "位科學",
+   "kind": "tone"
+  },
+  {
+   "word": "盡信書",
+   "alias": "進信書",
+   "kind": "tone"
+  },
+  {
+   "word": "準確擊",
+   "alias": "準確及",
+   "kind": "tone"
+  },
+  {
+   "word": "有細菌",
+   "alias": "有細俊",
+   "kind": "tone"
+  },
+  {
+   "word": "胺基酸",
+   "alias": "安基酸",
+   "kind": "tone"
+  },
+  {
+   "word": "伏擊圈",
+   "alias": "伏及圈",
+   "kind": "tone"
+  },
+  {
+   "word": "擊鼓聲",
+   "alias": "及鼓聲",
+   "kind": "tone"
+  },
+  {
+   "word": "獵射擊",
+   "alias": "獵射及",
+   "kind": "tone"
+  },
+  {
+   "word": "突風險",
+   "alias": "圖風險",
+   "kind": "tone"
+  },
+  {
+   "word": "凶戰危",
+   "alias": "凶戰維",
+   "kind": "tone"
+  },
+  {
+   "word": "安海瑟薇",
+   "alias": "安海瑟維",
+   "kind": "tone"
+  },
+  {
+   "word": "岌岌可危",
+   "alias": "岌岌可維",
+   "kind": "tone"
+  },
+  {
+   "word": "仰人鼻息",
+   "alias": "仰人鼻習",
+   "kind": "tone"
+  },
+  {
+   "word": "並沒有擊",
+   "alias": "並沒有及",
+   "kind": "tone"
+  },
+  {
+   "word": "費盡千辛萬苦",
+   "alias": "費進千辛萬苦",
+   "kind": "tone"
+  }
+ ],
+ "_known_gaps": [
+  {
+   "char": "播",
+   "correct": "ㄅㄛˋ",
+   "azure_says": "ㄅㄛ",
+   "corpus_freq": 37,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "髮",
+   "correct": "ㄈㄚˇ",
+   "azure_says": "ㄈㄚˋ",
+   "corpus_freq": 32,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "叔",
+   "correct": "ㄕㄨˊ",
+   "azure_says": "ㄕㄨ",
+   "corpus_freq": 20,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "噸",
+   "correct": "ㄉㄨㄣˋ",
+   "azure_says": "ㄉㄨㄣ",
+   "corpus_freq": 13,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "眶",
+   "correct": "ㄎㄨㄤ",
+   "azure_says": "ㄎㄨㄤˋ",
+   "corpus_freq": 6,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "綜",
+   "correct": "ㄗㄨㄥˋ",
+   "azure_says": "ㄗㄨㄥ",
+   "corpus_freq": 4,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  },
+  {
+   "char": "吔",
+   "correct": "˙ㄧㄝ",
+   "azure_says": "ㄧㄝˇ",
+   "corpus_freq": 3,
+   "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
+  }
+ ],
+ "_not_covered": "多音字不在此表：正確讀音要看上下文，而這張表看不到上下文。Hans 回報的 摸不著(ㄓㄠˊ) 與 和(連接詞讀ㄏㄢˋ) 屬此類，需要另一種機制。"
 }

--- a/backend/tests/test_taiwan_pronunciation.py
+++ b/backend/tests/test_taiwan_pronunciation.py
@@ -73,7 +73,46 @@ def test_corrections_load_into_the_tts_table() -> None:
 def test_generated_entries_wrap_in_sub_alias() -> None:
     from app.services.tts.normalization import PHONEME_CORRECTIONS
 
+    # Read through the real loader, not the JSON: what ships is whatever
+    # normalization.py ends up holding, and a data file that never gets loaded
+    # would satisfy a JSON-only assertion while changing nothing.
+    from app.services.tts.normalization import PHONEME_CORRECTIONS
+
     table = dict(PHONEME_CORRECTIONS)
     # Azure rejects <phoneme> outright — every alphabet returns HTTP 400 — so
     # <sub alias> is the only pronunciation control available here (#2612).
     assert table["音樂"] == '<sub alias="音岳">音樂</sub>'
+
+
+def test_hans_reported_words_2026_08_09():
+    """The four words Hans heard wrong, and what the table can honestly do.
+
+    Two are tone differences on characters with exactly one reading in the MOE
+    dictionary, so they are safe to correct blind — 擊 is ㄐㄧˊ everywhere it
+    appears, never ㄐㄧ.
+
+    Two are polyphones. 著 has five readings and 和 has six, and which one is
+    right depends on the sentence around it. A lookup table cannot see that, so
+    correcting them here would trade one wrong reading for another — 摸不著
+    would be fixed and 顯著 would break. They are deliberately absent, and this
+    test says so out loud rather than leaving the gap to look like an oversight.
+
+    This is also a regression lock on the corpus. The first pass built its word
+    list from backend/data/curriculum, which turned out not to contain lesson 1
+    at all — so 攻擊 was never a candidate and the table shipped without it.
+    """
+    # Read through the real loader, not the JSON: what ships is whatever
+    # normalization.py ends up holding, and a data file that never gets loaded
+    # would satisfy a JSON-only assertion while changing nothing.
+    from app.services.tts.normalization import PHONEME_CORRECTIONS
+
+    table = dict(PHONEME_CORRECTIONS)
+
+    assert table.get("攻擊") == '<sub alias="攻及">攻擊</sub>'
+    assert table.get("嘆息") == '<sub alias="嘆習">嘆息</sub>'
+
+    for polyphone in ("摸不著", "著", "和"):
+        assert polyphone not in table, (
+            f"{polyphone} reads differently depending on context; a blind "
+            "substitution fixes one sentence and breaks another"
+        )

--- a/backend/tests/test_tts_no_cross_provider_readthrough.py
+++ b/backend/tests/test_tts_no_cross_provider_readthrough.py
@@ -1,0 +1,90 @@
+"""A cache miss under Azure must never be served from the Google prefix.
+
+The two prefixes hold different voices, and they are not interchangeable:
+
+    azure/sentences/   zh-TW-HsiaoChenNeural   Taiwanese Mandarin — what we ship
+    <google prefix>    cmn-CN-Chirp3-HD        mainland accent — rejected 2026-04
+
+The read path used to fall through from the first to the second on a miss.
+That turns a momentary Azure failure into a permanent one for that sentence:
+the fallback writes a mainland-accent object, every later request finds it, and
+Azure coming back healthy does not undo it. 22 sentences reached production
+that way (issue #2649 item 4).
+
+So the fallback is gone. A miss now costs one synthesis — the price of always
+shipping the right voice.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.services import tts as tts_module
+
+
+AUDIO_FROM_GOOGLE_PREFIX = b"MAINLAND-ACCENT-BYTES"
+AUDIO_FRESHLY_SYNTHESIZED = b"AZURE-BYTES"
+
+
+@pytest.fixture(autouse=True)
+def _clear_l1():
+    tts_module._TTS_CACHE.clear()
+    yield
+    tts_module._TTS_CACHE.clear()
+
+
+def _gcs_get_only_google_has_it(key, provider):
+    """The sentence exists under the google prefix and nowhere else.
+
+    This is the exact state the 22 bad objects are in.
+    """
+    return AUDIO_FROM_GOOGLE_PREFIX if provider == "google" else None
+
+
+class TestNoCrossProviderReadThrough:
+    def test_azure_miss_synthesizes_rather_than_serving_the_google_object(self):
+        with patch.object(tts_module, "TTS_PROVIDER", "azure"), \
+             patch.object(tts_module, "_gcs_get", side_effect=_gcs_get_only_google_has_it), \
+             patch.object(tts_module, "_gcs_put"), \
+             patch.object(tts_module, "_synthesize_azure", return_value=AUDIO_FRESHLY_SYNTHESIZED) as synth:
+            result = tts_module.synthesize_speech("小戴的攻擊千變萬化。")
+
+        assert result == AUDIO_FRESHLY_SYNTHESIZED, (
+            "served the mainland-accent object that was sitting under the google prefix"
+        )
+        assert synth.call_count == 1, "should have paid for one synthesis instead"
+
+    def test_never_even_asks_the_google_prefix_while_running_azure(self):
+        """Not just 'ignores the answer' — it must not make the lookup.
+
+        Asking and then discarding would still be a live cross-prefix path that
+        a later refactor could re-enable by accident.
+        """
+        seen = []
+
+        def record(key, provider):
+            seen.append(provider)
+            return None
+
+        with patch.object(tts_module, "TTS_PROVIDER", "azure"), \
+             patch.object(tts_module, "_gcs_get", side_effect=record), \
+             patch.object(tts_module, "_gcs_put"), \
+             patch.object(tts_module, "_synthesize_azure", return_value=AUDIO_FRESHLY_SYNTHESIZED):
+            tts_module.synthesize_speech("哀聲嘆息。")
+
+        assert seen == ["azure"], f"looked in prefixes {seen}; only azure is ours to read"
+
+    def test_an_azure_object_that_does_exist_is_still_served_from_cache(self):
+        """Positive control.
+
+        Without this, a change that broke *all* GCS reads would leave the two
+        tests above green — they only assert what must not happen.
+        """
+        with patch.object(tts_module, "TTS_PROVIDER", "azure"), \
+             patch.object(tts_module, "_gcs_get", side_effect=lambda key, provider: (
+                 AUDIO_FRESHLY_SYNTHESIZED if provider == "azure" else None)), \
+             patch.object(tts_module, "_gcs_put"), \
+             patch.object(tts_module, "_synthesize_azure") as synth:
+            result = tts_module.synthesize_speech("摸不著頭緒。")
+
+        assert result == AUDIO_FRESHLY_SYNTHESIZED
+        assert synth.call_count == 0, "cache hit should not have synthesized"

--- a/frontend/src/components/auth/LearningRouteGate.test.tsx
+++ b/frontend/src/components/auth/LearningRouteGate.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * LearningRouteGate — who may open a learning step without logging in.
+ *
+ * A student scans a QR code printed on a paper worksheet. They have no account
+ * and no session. If the whole /learn subtree stays behind ProtectedRoute they
+ * land on /login, and the QR code is pointless.
+ *
+ * So exactly one step — 讀全文-做記號 (full-text-annotate) — is readable and
+ * listenable anonymously. Everything else keeps redirecting to /login, because
+ * every other step writes something (annotations, recordings, scores) that
+ * needs a user to write it against.
+ *
+ * These tests are the access-control boundary. Each one is mutation-checked:
+ * see the header comment in LearningRouteGate itself for what breaks them.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+
+import { LearningRouteGate } from './RouteGuards';
+
+// The gate only asks AuthContext three questions; stub those rather than
+// standing up the real provider (which would need a token endpoint).
+const mockAuth = vi.fn();
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth(),
+}));
+
+// The guest page pulls a story over the network; we only care that the gate
+// chose it, not what it renders.
+vi.mock('../../pages/GuestReadingPage', () => ({
+  default: () => <div>GUEST-READER</div>,
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/learn/:storyId/*"
+          element={
+            <LearningRouteGate>
+              <div>PROTECTED-SHELL</div>
+            </LearningRouteGate>
+          }
+        />
+        <Route path="/login" element={<div>LOGIN-PAGE</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('LearningRouteGate', () => {
+  describe('anonymous visitor', () => {
+    beforeEach(() => {
+      mockAuth.mockReturnValue({
+        isAuthenticated: false,
+        isLoading: false,
+        needsTermsAcceptance: false,
+      });
+    });
+
+    it('lets a QR visitor read 讀全文-做記號 without logging in', async () => {
+      renderAt('/learn/1/full-text-annotate');
+      // The guest page is a lazy chunk, so it arrives a tick after the gate
+      // decides — the spinner in between is the real behaviour too.
+      expect(await screen.findByText('GUEST-READER')).toBeInTheDocument();
+      expect(screen.queryByText('LOGIN-PAGE')).not.toBeInTheDocument();
+    });
+
+    it('honours the legacy id in QR codes already printed on paper', async () => {
+      // reading-annotation is the pre-rename id; worksheets carrying it must
+      // not start demanding a login.
+      renderAt('/learn/1/reading-annotation');
+      expect(await screen.findByText('GUEST-READER')).toBeInTheDocument();
+    });
+
+    it.each([
+      ['key-passage-reading', 'recording is scored against a user'],
+      ['character-practice', 'writes practice results'],
+      ['report', 'shows one specific student’s data'],
+      ['lesson-intro', 'not the step the QR code targets'],
+    ])('still sends %s to /login (%s)', (step) => {
+      renderAt(`/learn/1/${step}`);
+      expect(screen.getByText('LOGIN-PAGE')).toBeInTheDocument();
+      expect(screen.queryByText('GUEST-READER')).not.toBeInTheDocument();
+    });
+
+    it('does not leak the shell to an anonymous visitor on the public step', async () => {
+      // The guest page is a separate, self-contained reader. The authenticated
+      // shell creates DB learning sessions and must never mount without a user.
+      renderAt('/learn/1/full-text-annotate');
+      await screen.findByText('GUEST-READER');
+      expect(screen.queryByText('PROTECTED-SHELL')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('signed-in user', () => {
+    it('gets the normal shell on the public step, not the guest reader', () => {
+      mockAuth.mockReturnValue({
+        isAuthenticated: true,
+        isLoading: false,
+        needsTermsAcceptance: false,
+      });
+      renderAt('/learn/1/full-text-annotate');
+      expect(screen.getByText('PROTECTED-SHELL')).toBeInTheDocument();
+      expect(screen.queryByText('GUEST-READER')).not.toBeInTheDocument();
+    });
+
+    it('is still held at the terms gate', () => {
+      mockAuth.mockReturnValue({
+        isAuthenticated: true,
+        isLoading: false,
+        needsTermsAcceptance: true,
+      });
+      renderAt('/learn/1/character-practice');
+      expect(screen.queryByText('PROTECTED-SHELL')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows nothing decisive while auth is still resolving', () => {
+    // Rendering the guest page during the loading window would flash an
+    // anonymous reader at a user who is in fact signed in.
+    mockAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+      needsTermsAcceptance: false,
+    });
+    renderAt('/learn/1/full-text-annotate');
+    expect(screen.queryByText('GUEST-READER')).not.toBeInTheDocument();
+    expect(screen.queryByText('LOGIN-PAGE')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auth/RouteGuards.tsx
+++ b/frontend/src/components/auth/RouteGuards.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { isPublicLearningStep } from '../../config/stepConfig';
+
+const GuestReadingPage = lazy(() => import('../../pages/GuestReadingPage'));
 
 const AuthLoadingSpinner: React.FC = () => (
   <div className="min-h-screen flex items-center justify-center bg-amber-50">
@@ -30,6 +33,50 @@ export const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ childr
   if (!isAuthenticated) return <Navigate to="/login" state={{ from: location }} replace />;
 
   // ToS gate: redirect to /terms if user hasn't accepted yet (except when already on /terms)
+  if (needsTermsAcceptance && location.pathname !== '/terms') {
+    return <Navigate to="/terms" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+/**
+ * Gate for the /learn/:storyId subtree (#2649).
+ *
+ * Identical to ProtectedRoute, with one hole: an anonymous visitor on a step
+ * listed in PUBLIC_LEARNING_STEPS gets the standalone guest reader instead of a
+ * redirect to /login. That is the QR-code path — paper worksheet, no account.
+ *
+ * The guest reader is deliberately a *different* component, not the shell with
+ * bits hidden. The authenticated shell creates DB learning sessions on mount;
+ * mounting it without a user would fire authenticated calls that 401.
+ *
+ * Mutation checks (each must turn a test red):
+ *   - drop the isPublicLearningStep() call  → anonymous QR visitor hits /login
+ *   - gate on `isLoading` after the guest branch → guest reader flashes at a
+ *     signed-in user during the auth handshake
+ *   - let the guest branch run when authenticated → signed-in students lose
+ *     annotating entirely
+ */
+export const LearningRouteGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, isLoading, needsTermsAcceptance } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) return <AuthLoadingSpinner />;
+
+  if (!isAuthenticated) {
+    // /learn/:storyId/:step — the step is the third segment.
+    const step = location.pathname.split('/')[3] ?? '';
+    if (isPublicLearningStep(step)) {
+      return (
+        <Suspense fallback={<AuthLoadingSpinner />}>
+          <GuestReadingPage />
+        </Suspense>
+      );
+    }
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
   if (needsTermsAcceptance && location.pathname !== '/terms') {
     return <Navigate to="/terms" replace />;
   }

--- a/frontend/src/components/reading-steps/FullTextAnnotate.readonly.test.tsx
+++ b/frontend/src/components/reading-steps/FullTextAnnotate.readonly.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * FullTextAnnotate in read-only mode — what a QR-code visitor may and may not do.
+ *
+ * The rule (#2649): reading and listening are open, anything that writes a mark
+ * is not. Marks belong to a user, and a visitor who scanned a paper worksheet
+ * has no account yet.
+ *
+ * The affordances are *removed*, not disabled. A greyed-out 完成標記 button
+ * reads as "this is broken"; an absent one reads as "not part of this page".
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import ReadingAnnotation from './FullTextAnnotate';
+import type { Story } from '../../types';
+
+vi.mock('../../context/ZhuyinContext', () => ({
+  useZhuyin: () => ({
+    isZhuyinAny: false,
+    zhuyinActive: false,
+    processLinesSelective: (lines: string[]) => lines,
+  }),
+}));
+
+// The player has its own tests; here we only care whether it is on the page.
+vi.mock('../../hooks/useFullTextTtsQueue', () => ({
+  useFullTextTtsQueue: () => ({
+    currentParagraphIdx: null,
+    isPlaying: false,
+    isPaused: false,
+    play: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+const story = {
+  id: '1',
+  title: '贏得喝采的輸家',
+  level: 4,
+  grade: 4,
+  content: ['第一段的內容。', '第二段的內容。'],
+  category: 'story',
+  vocabulary: [],
+  images: [],
+} as unknown as Story;
+
+function renderStep(readOnly: boolean) {
+  return render(<ReadingAnnotation story={story} onFinish={vi.fn()} readOnly={readOnly} />);
+}
+
+describe('FullTextAnnotate — read-only (anonymous QR visitor)', () => {
+  it('still shows the whole lesson text', () => {
+    renderStep(true);
+    expect(screen.getByText(/第一段的內容/)).toBeInTheDocument();
+    expect(screen.getByText(/第二段的內容/)).toBeInTheDocument();
+  });
+
+  it('hides 完成標記 — it advances a learning flow the visitor is not in', () => {
+    renderStep(true);
+    expect(screen.queryByText('完成標記')).not.toBeInTheDocument();
+  });
+
+  it('hides the 我的記號 side panel', () => {
+    renderStep(true);
+    expect(screen.queryByText('我的記號')).not.toBeInTheDocument();
+  });
+
+  it('hides the coaching that teaches marking', () => {
+    renderStep(true);
+    // Both the onboarding coach and the persistent hint bar exist only to
+    // explain selecting text to annotate.
+    expect(screen.queryByText(/畫線|標記|選取/)).not.toBeInTheDocument();
+  });
+
+  it('does not mount the in-page player (the guest page supplies its own)', () => {
+    renderStep(true);
+    expect(screen.queryByTestId('reading-player')).not.toBeInTheDocument();
+  });
+});
+
+describe('FullTextAnnotate — normal mode (signed-in student)', () => {
+  it('keeps 完成標記', () => {
+    renderStep(false);
+    expect(screen.getByText('完成標記')).toBeInTheDocument();
+  });
+
+  it('keeps the 我的記號 side panel', () => {
+    renderStep(false);
+    expect(screen.getByText('我的記號')).toBeInTheDocument();
+  });
+
+  it('mounts the whole-lesson player', () => {
+    renderStep(false);
+    expect(screen.getByTestId('reading-player')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reading-steps/FullTextAnnotate.tsx
+++ b/frontend/src/components/reading-steps/FullTextAnnotate.tsx
@@ -35,6 +35,8 @@ import {
 import { type AnnotationWithText } from './AnnotationSidePanel';
 import AnnotationSidePanel from './AnnotationSidePanel';
 import AnnotationToolbar from './AnnotationToolbar';
+import ReadingPlayer from './ReadingPlayer';
+import { useFullTextTtsQueue } from '../../hooks/useFullTextTtsQueue';
 import AnnotatedParagraph from './AnnotatedParagraph';
 
 // Re-export types for consumers that import from ReadingAnnotation
@@ -72,6 +74,13 @@ interface ReadingAnnotationProps {
   fontSizePx?: number;
   /** DB session id — when provided, annotations are persisted to and loaded from DB. */
   dbSessionId?: number | null;
+  /**
+   * Read-and-listen only (#2649). Set for a QR-code visitor who has no account:
+   * a mark has to belong to somebody, so every annotating affordance is removed
+   * rather than disabled — a greyed-out button reads as "broken", an absent one
+   * reads as "not part of this page". Reading and listening stay.
+   */
+  readOnly?: boolean;
 }
 
 // ── A5: First-use onboarding coach component ───────────────────────────────
@@ -248,9 +257,27 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   onFinish,
   fontSizePx = 22,
   dbSessionId = null,
+  readOnly = false,
 }) => {
   // Zhuyin state from global context
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
+
+  // Whole-lesson playback (#2649). Paragraph-by-paragraph rather than one long
+  // clip, so the page knows which paragraph is being read and can carry the
+  // reader there. A QR-code visitor never reaches this hook — GuestReadingPage
+  // drives its own player off the pre-generated mp3, because the synthesis
+  // endpoint this one calls answers 401 without a session.
+  const numericLessonId = Number.isFinite(Number(story.id)) ? Number(story.id) : undefined;
+  const reader = useFullTextTtsQueue({ paragraphs: story.content, lessonId: numericLessonId });
+  const paragraphRefs = useRef<Record<number, HTMLElement | null>>({});
+
+  // Scroll the paragraph being read into view. `nearest` rather than `center`
+  // so a paragraph already on screen doesn't yank the page under the reader.
+  useEffect(() => {
+    const idx = reader.currentParagraphIdx;
+    if (idx === null || idx === undefined) return;
+    paragraphRefs.current[idx]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [reader.currentParagraphIdx]);
   const vocabWords = useMemo(
     () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
     [story.vocabulary]
@@ -619,16 +646,31 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         <div
           ref={containerRef}
           className="flex-1 overflow-y-auto relative pb-44"
-          onMouseUp={handleMouseUp}
-          onTouchEnd={handleTouchEnd}
+          onMouseUp={readOnly ? undefined : handleMouseUp}
+          onTouchEnd={readOnly ? undefined : handleTouchEnd}
           style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
         >
           {/* A5: First-use onboarding coach (dismissable, gated by localStorage) */}
-          {showCoach ? (
+          {!readOnly && (showCoach ? (
             <OnboardingCoach onDismiss={handleDismissCoach} />
           ) : (
             /* A5: Persistent mini hint bar shown after onboarding is dismissed */
             <HintBar />
+          ))}
+
+          {/* Whole-lesson player. Sits above the legend so it's the first control
+              on the page — listening is what a lot of students come here to do. */}
+          {!readOnly && (
+            <div className="flex justify-center pt-4">
+              <ReadingPlayer
+                isPlaying={reader.isPlaying}
+                isPaused={reader.isPaused}
+                onPlay={reader.play}
+                onPause={reader.pause}
+                onResume={reader.resume}
+                onStop={reader.stop}
+              />
+            </div>
           )}
 
           {/* Legend pills + counts + undo/clear — floating centered */}
@@ -685,7 +727,13 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
               const inlineTblIdx = inlineTableIdxByPara.get(paraIdx);
               return (
                 <React.Fragment key={paraIdx}>
-                  <section className="relative group">
+                  <section
+                    ref={(el) => { paragraphRefs.current[paraIdx] = el; }}
+                    data-reading-active={reader.currentParagraphIdx === paraIdx ? 'true' : undefined}
+                    className={`relative group rounded-lg transition-colors duration-300 ${
+                      reader.currentParagraphIdx === paraIdx ? 'bg-accent/[0.07]' : ''
+                    }`}
+                  >
                     {/* Paragraph number — lives outside the [data-para-idx] subtree
                         so its text doesn't inflate selection offsets. */}
                     <span
@@ -757,7 +805,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
           )}
 
           {/* ── Floating selection toolbar ─────────────────────────────── */}
-          {toolbar.visible && (
+          {!readOnly && toolbar.visible && (
             <AnnotationToolbar
               x={toolbar.x}
               y={toolbar.y}
@@ -769,14 +817,18 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         </div>
 
         {/* ── Right panel: 我的記號 ──────────────────────────────────────── */}
-        <AnnotationSidePanel
-          summary={summary}
-          annotationsForPanel={annotationsForPanel}
-          onJump={jumpToAnnotation}
-        />
+        {!readOnly && (
+          <AnnotationSidePanel
+            summary={summary}
+            annotationsForPanel={annotationsForPanel}
+            onJump={jumpToAnnotation}
+          />
+        )}
       </div>
 
-      {/* ── Fixed bottom CTA — gradient fade ─────────────────────────── */}
+      {!readOnly && (
+        <>
+          {/* ── Fixed bottom CTA — gradient fade ─────────────────────────── */}
       <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
         <div className="max-w-md mx-auto pointer-events-auto">
@@ -791,6 +843,8 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
           </button>
         </div>
       </div>
+        </>
+      )}
 
       {/* Background decoration */}
       <div className="fixed top-40 -left-20 w-64 h-64 bg-accent/5 rounded-full blur-[100px] -z-10 pointer-events-none" />

--- a/frontend/src/components/reading-steps/ReadingPlayer.tsx
+++ b/frontend/src/components/reading-steps/ReadingPlayer.tsx
@@ -1,0 +1,118 @@
+/**
+ * ReadingPlayer — the play / pause / stop control bar for 讀全文-做記號.
+ *
+ * Deliberately dumb: it owns no audio. Two very different engines drive it and
+ * neither can be swapped for the other:
+ *
+ *   - a signed-in student gets useFullTextTtsQueue, which walks paragraph by
+ *     paragraph so the page can highlight and scroll along with the reading;
+ *   - a QR-code visitor has no session, and POST /api/tts/synthesize returns
+ *     401 to anonymous callers on purpose (it bills us per call). They get the
+ *     pre-generated whole-lesson mp3 through the public /assets proxy instead,
+ *     which is one file and therefore has no paragraph boundaries to follow.
+ *
+ * Keeping the engine out of here is what lets both cases share one control bar
+ * and one set of tests.
+ */
+import React from 'react';
+
+export interface ReadingPlayerProps {
+  isPlaying: boolean;
+  isPaused: boolean;
+  /** Start from the beginning. */
+  onPlay: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  /** Shown while idle, e.g. 「播放全文」. */
+  idleLabel?: string;
+  /** True while the first audio bytes are still on their way. */
+  isLoading?: boolean;
+  className?: string;
+}
+
+const BTN =
+  'flex items-center justify-center gap-1.5 h-11 px-5 rounded-full font-headline font-bold ' +
+  'text-base transition-all active:scale-[0.97] disabled:opacity-50';
+
+const ReadingPlayer: React.FC<ReadingPlayerProps> = ({
+  isPlaying,
+  isPaused,
+  onPlay,
+  onPause,
+  onResume,
+  onStop,
+  idleLabel = '播放全文',
+  isLoading = false,
+  className = '',
+}) => {
+  // Paused counts as active: the audio is still loaded and stop must stay
+  // reachable, otherwise a paused reading can only be ended by leaving the page.
+  const isActive = isPlaying || isPaused;
+
+  return (
+    <div
+      className={`flex items-center gap-2 ${className}`}
+      data-testid="reading-player"
+      role="group"
+      aria-label="全文朗讀播放控制"
+    >
+      {!isActive && (
+        <button
+          type="button"
+          onClick={onPlay}
+          disabled={isLoading}
+          className={`${BTN} text-white shadow-[0_6px_24px_rgba(86,74,191,0.28)] hover:brightness-110`}
+          style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+        >
+          <span className="material-symbols-outlined text-xl" aria-hidden="true">
+            {isLoading ? 'hourglass_top' : 'play_arrow'}
+          </span>
+          <span>{isLoading ? '準備中…' : idleLabel}</span>
+        </button>
+      )}
+
+      {isPlaying && (
+        <button
+          type="button"
+          onClick={onPause}
+          className={`${BTN} bg-surface-container-high text-on-surface hover:brightness-95`}
+        >
+          <span className="material-symbols-outlined text-xl" aria-hidden="true">
+            pause
+          </span>
+          <span>暫停</span>
+        </button>
+      )}
+
+      {isPaused && (
+        <button
+          type="button"
+          onClick={onResume}
+          className={`${BTN} text-white hover:brightness-110`}
+          style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+        >
+          <span className="material-symbols-outlined text-xl" aria-hidden="true">
+            play_arrow
+          </span>
+          <span>繼續</span>
+        </button>
+      )}
+
+      {isActive && (
+        <button
+          type="button"
+          onClick={onStop}
+          className={`${BTN} bg-surface-container-high text-on-surface-variant hover:brightness-95`}
+        >
+          <span className="material-symbols-outlined text-xl" aria-hidden="true">
+            stop
+          </span>
+          <span>停止</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ReadingPlayer;

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -413,6 +413,27 @@ export function resolveStepId(id: string): string {
   return LEGACY_STEP_ID_ALIASES[id] ?? id;
 }
 
+/**
+ * Steps a visitor may open without an account (#2649).
+ *
+ * A student scans a QR code printed on a paper worksheet. They have no session.
+ * If every learning step sits behind the login wall, that QR code does nothing
+ * but show them a password box — so the one step the QR code targets, 讀全文-做
+ * 記號, has to be readable and listenable anonymously.
+ *
+ * Every other step stays private, and the reason is the same in each case: it
+ * *writes* something. Recordings, annotations, practice results and scores all
+ * have to belong to a user. Reading and listening do not.
+ *
+ * Keep this set at one entry unless the same argument can be made again.
+ */
+export const PUBLIC_LEARNING_STEPS: ReadonlySet<string> = new Set(['full-text-annotate']);
+
+/** True when `id` (canonical or legacy) is openable without logging in. */
+export function isPublicLearningStep(id: string): boolean {
+  return PUBLIC_LEARNING_STEPS.has(resolveStepId(id));
+}
+
 export function stepSequenceFromWorksheet(
   worksheet?: Array<{ number?: string; name?: string; type?: string }> | null,
 ): string[] | null {

--- a/frontend/src/hooks/useAssetAudio.ts
+++ b/frontend/src/hooks/useAssetAudio.ts
@@ -1,0 +1,121 @@
+/**
+ * useAssetAudio — play one pre-generated mp3 from the public /assets proxy.
+ *
+ * This is the anonymous half of 讀全文-做記號 playback (#2649). A student scans
+ * a QR code off a paper worksheet, so there is no session, and the synthesis
+ * endpoints answer 401 to anonymous callers by design — they cost money per
+ * call and must not be reachable without a user. What *is* public is the
+ * whole-lesson audio we generate ahead of time:
+ *
+ *   GET {API_BASE}/assets/demo-reading/{lessonId}/full.mp3   → 200 audio/mpeg
+ *
+ * (verified on staging 2026-08-10, together with a 404 on a lesson id that
+ * doesn't exist, so a 200 there means the file is real rather than a proxy
+ * that answers 200 to everything.)
+ *
+ * One file, so there are no paragraph boundaries and no scroll-following — the
+ * signed-in path uses useFullTextTtsQueue for that.
+ */
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
+export function demoReadingUrl(lessonId: string | number, kind: 'full' | 'passage' = 'full'): string {
+  return `${API_BASE}/assets/demo-reading/${lessonId}/${kind}.mp3`;
+}
+
+interface UseAssetAudioResult {
+  isPlaying: boolean;
+  isPaused: boolean;
+  isLoading: boolean;
+  /** True once the file has failed to load — callers hide the control. */
+  hasError: boolean;
+  play: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+}
+
+export function useAssetAudio(src: string): UseAssetAudioResult {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  // Stop and release on unmount, and whenever the lesson changes. Without this
+  // the audio keeps playing after navigation — the element is detached from the
+  // tree but the browser keeps decoding it.
+  useEffect(() => {
+    return () => {
+      const el = audioRef.current;
+      if (el) {
+        el.pause();
+        el.src = '';
+      }
+      audioRef.current = null;
+    };
+  }, [src]);
+
+  const play = useCallback(() => {
+    setHasError(false);
+    let el = audioRef.current;
+    if (!el) {
+      el = new Audio(src);
+      el.preload = 'auto';
+      el.addEventListener('ended', () => {
+        setIsPlaying(false);
+        setIsPaused(false);
+      });
+      el.addEventListener('error', () => {
+        setHasError(true);
+        setIsLoading(false);
+        setIsPlaying(false);
+        setIsPaused(false);
+      });
+      el.addEventListener('playing', () => setIsLoading(false));
+      audioRef.current = el;
+    }
+    el.currentTime = 0;
+    setIsLoading(true);
+    setIsPaused(false);
+    setIsPlaying(true);
+    void el.play().catch(() => {
+      setHasError(true);
+      setIsLoading(false);
+      setIsPlaying(false);
+    });
+  }, [src]);
+
+  const pause = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    el.pause();
+    setIsPlaying(false);
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    setIsPaused(false);
+    setIsPlaying(true);
+    void el.play().catch(() => {
+      setHasError(true);
+      setIsPlaying(false);
+    });
+  }, []);
+
+  const stop = useCallback(() => {
+    const el = audioRef.current;
+    if (el) {
+      el.pause();
+      el.currentTime = 0;
+    }
+    setIsPlaying(false);
+    setIsPaused(false);
+    setIsLoading(false);
+  }, []);
+
+  return { isPlaying, isPaused, isLoading, hasError, play, pause, resume, stop };
+}

--- a/frontend/src/hooks/useFullTextTtsQueue.test.ts
+++ b/frontend/src/hooks/useFullTextTtsQueue.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for useFullTextTtsQueue — whole-lesson sequential playback for the
+ * 讀全文-做記號 (FullTextAnnotate) step's audio player.
+ *
+ * Exercises the REAL useTtsPlayback + ttsApi (mocking fetch + Audio only, same
+ * pattern as src/components/reading-steps/__tests__/Intro.aiTts.test.tsx) so
+ * assertions prove the actual wiring — not a re-implementation of the queue
+ * logic inside the test.
+ *
+ * MockAudio here does NOT extend HTMLMediaElement (a plain stand-in class),
+ * so it never touches the hook's own belt-and-suspenders
+ * HTMLMediaElement.prototype.play patch — that defensive path is covered
+ * separately in useFullTextTtsQueue.stopGuard.test.ts, mirroring how
+ * LessonAudioTable.test.tsx splits the same two concerns.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useFullTextTtsQueue } from './useFullTextTtsQueue';
+import { _testInternals as ttsApiTestInternals } from '../services/ttsApi';
+
+const LESSON_ID = 42;
+const P0 = '第一段課文，用來測試全文朗讀。';
+const P1 = '第二段課文，緊接在第一段之後。';
+const P2 = '第三段課文，是最後一段。';
+const PARAGRAPHS = [P0, P1, P2];
+
+const CANON_P0 = 'CANON-SENTENCE-FOR-PARAGRAPH-0';
+const CANON_P1 = 'CANON-SENTENCE-FOR-PARAGRAPH-1';
+const CANON_P2 = 'CANON-SENTENCE-FOR-PARAGRAPH-2';
+
+const MAPPING_RESPONSE = {
+  lesson_id: LESSON_ID,
+  paragraphs: [
+    { index: 0, sentences: [{ text: CANON_P0, hash: 'h0', chars: CANON_P0.length }] },
+    { index: 1, sentences: [{ text: CANON_P1, hash: 'h1', chars: CANON_P1.length }] },
+    { index: 2, sentences: [{ text: CANON_P2, hash: 'h2', chars: CANON_P2.length }] },
+  ],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let audioInstances: MockAudio[];
+
+class MockAudio {
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  ontimeupdate: (() => void) | null = null;
+  currentTime = 0;
+  duration = 1;
+  src: string;
+
+  constructor(src?: string) {
+    this.src = src ?? '';
+    audioInstances.push(this);
+  }
+
+  // Does NOT auto-fire onended — tests control timing explicitly so
+  // "paragraph finished naturally" vs "user hit stop first" stay distinct.
+  play() {
+    return Promise.resolve();
+  }
+
+  pause() {}
+}
+
+function defaultFetchImpl(url: string) {
+  const urlStr = String(url);
+  if (urlStr.includes('/api/tts/mapping/')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(MAPPING_RESPONSE) });
+  }
+  if (urlStr.includes('/api/tts/synthesize')) {
+    return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob(['audio-bytes'], { type: 'audio/mpeg' })) });
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${urlStr}`));
+}
+
+function synthesizeCalls() {
+  return fetchMock.mock.calls
+    .filter(([url]: [string]) => String(url).includes('/api/tts/synthesize'))
+    .map(([, init]: [string, RequestInit]) => JSON.parse(init.body as string).text as string);
+}
+
+function mappingCallCount() {
+  return fetchMock.mock.calls.filter(([url]: [string]) => String(url).includes('/api/tts/mapping/')).length;
+}
+
+beforeEach(() => {
+  audioInstances = [];
+  fetchMock = vi.fn(defaultFetchImpl);
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('Audio', MockAudio);
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:mock-url'),
+    revokeObjectURL: vi.fn(),
+  });
+  Object.defineProperty(window, 'speechSynthesis', {
+    configurable: true,
+    writable: true,
+    value: { getVoices: () => [], cancel: vi.fn(), speak: vi.fn(), pause: vi.fn(), resume: vi.fn(), onvoiceschanged: null },
+  });
+  vi.stubGlobal('SpeechSynthesisUtterance', class {
+    text: string;
+    lang = '';
+    rate = 1;
+    voice: unknown = null;
+    onstart: (() => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor(text?: string) { this.text = text ?? ''; }
+  });
+  // ttsApi.ts's _urlCache/_mappingCache are module-level singletons.
+  ttsApiTestInternals.reset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useFullTextTtsQueue', () => {
+  it('is idle initially — currentParagraphIdx -1, nothing playing', () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    expect(result.current.currentParagraphIdx).toBe(-1);
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('play() speaks paragraph 0 through the canonical-sentence cache (lessonId + idx=0) — not a hardcoded index', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+
+    act(() => { result.current.play(); });
+
+    await waitFor(() => expect(mappingCallCount()).toBeGreaterThan(0));
+    const [mappingUrl] = fetchMock.mock.calls.find(([u]: [string]) => String(u).includes('/api/tts/mapping/'))!;
+    expect(String(mappingUrl)).toContain(`/api/tts/mapping/${LESSON_ID}`);
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+    expect(result.current.currentParagraphIdx).toBe(0);
+  });
+
+  it('auto-advances through every paragraph in order — walking paragraph N passes index N, not 0 (#2627)', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+    expect(result.current.currentParagraphIdx).toBe(0);
+
+    act(() => { audioInstances[0].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1]));
+    expect(result.current.currentParagraphIdx).toBe(1);
+
+    act(() => { audioInstances[1].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1, CANON_P2]));
+    expect(result.current.currentParagraphIdx).toBe(2);
+
+    // Only ONE GET to the mapping endpoint across the whole walk — every
+    // paragraph's lookup hit the cache populated by the first call.
+    expect(mappingCallCount()).toBe(1);
+  });
+
+  it('returns to idle (-1) after the last paragraph finishes', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+
+    act(() => { audioInstances[0].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1]));
+    act(() => { audioInstances[1].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1, CANON_P2]));
+    act(() => { audioInstances[2].onended?.(); });
+
+    await waitFor(() => expect(result.current.currentParagraphIdx).toBe(-1));
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it('stop() mid-paragraph prevents any further sentence fetch — the walk does not advance even if the stale audio fires onended late', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+
+    act(() => { result.current.stop(); });
+    expect(result.current.currentParagraphIdx).toBe(-1);
+
+    // The (now-stale) audio element fires onended late — e.g. a real browser
+    // delivering a queued event after .pause(). Must NOT be treated as
+    // "paragraph finished, advance to the next one".
+    act(() => { audioInstances[0].onended?.(); });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(synthesizeCalls()).toEqual([CANON_P0]); // never a 2nd call for CANON_P1
+    expect(result.current.currentParagraphIdx).toBe(-1);
+  });
+
+  it('play() after stop() starts a fresh walk from paragraph 0, immune to the stopped walk\'s stale callbacks', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+    act(() => { audioInstances[0].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1]));
+
+    act(() => { result.current.stop(); });
+    expect(result.current.currentParagraphIdx).toBe(-1);
+
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(result.current.currentParagraphIdx).toBe(0));
+
+    // The OLD walk's paragraph-1 audio (already stopped) fires its onended
+    // late — must not be mistaken for the NEW walk's paragraph 0 finishing.
+    act(() => { audioInstances[1].onended?.(); });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current.currentParagraphIdx).toBe(0);
+  });
+
+  it('pause() does not advance the walk — isTtsSpeaking stays true while paused, so the finished-transition never fires', async () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+
+    act(() => { result.current.pause(); });
+    expect(result.current.isPaused).toBe(true);
+
+    // Give any pending microtasks a chance to run — a bug here would show up
+    // as an unwanted second synthesize call.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(synthesizeCalls()).toEqual([CANON_P0]);
+    expect(result.current.currentParagraphIdx).toBe(0);
+
+    act(() => { result.current.resume(); });
+    expect(result.current.isPaused).toBe(false);
+
+    act(() => { audioInstances[0].onended?.(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0, CANON_P1]));
+  });
+
+  it('a TTS error aborts the walk instead of advancing to the next paragraph', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes('/api/tts/mapping/')) {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+      }
+      if (String(url).includes('/api/tts/synthesize')) {
+        return Promise.resolve({ ok: false, status: 503, blob: () => Promise.resolve(new Blob([])) });
+      }
+      return Promise.reject(new Error('unexpected fetch'));
+    });
+
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+
+    await waitFor(() => expect(result.current.ttsError).toBeTruthy());
+    await waitFor(() => expect(result.current.currentParagraphIdx).toBe(-1));
+    // Only paragraph 0's attempt happened — never a second attempt for paragraph 1.
+    expect(synthesizeCalls()).toHaveLength(1);
+  });
+
+  it('play() is a no-op when paragraphs is empty', () => {
+    const { result } = renderHook(() => useFullTextTtsQueue({ paragraphs: [], lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    expect(result.current.currentParagraphIdx).toBe(-1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('unmounting while playing pauses the in-flight audio (never leaves it running after navigating away)', async () => {
+    const { result, unmount } = renderHook(() => useFullTextTtsQueue({ paragraphs: PARAGRAPHS, lessonId: LESSON_ID }));
+    act(() => { result.current.play(); });
+    await waitFor(() => expect(synthesizeCalls()).toEqual([CANON_P0]));
+
+    const pauseSpy = vi.spyOn(audioInstances[0], 'pause');
+    unmount();
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useFullTextTtsQueue.ts
+++ b/frontend/src/hooks/useFullTextTtsQueue.ts
@@ -1,0 +1,194 @@
+/**
+ * useFullTextTtsQueue — whole-lesson sequential TTS playback for
+ * FullTextAnnotate (讀全文-做記號).
+ *
+ * Owner ask (issue: 讀全文-做記號 audio player): a play control that can pause
+ * and can stop, and — the part they cared about most — the reading should
+ * track the text on screen as it plays. This hook owns the "walk every
+ * paragraph in order, know which one is current, be provably stoppable" half
+ * of that; FullTextAnnotate.tsx owns the scroll-into-view + highlight half by
+ * reading `currentParagraphIdx`.
+ *
+ * Mirrors the paragraph-walk pattern proven in three prior fixes:
+ *   - Intro.tsx (#2607/#2608): state + wasSpeakingRef transition-detection to
+ *     advance the walk when a paragraph finishes on its own.
+ *   - LessonAudioTable.tsx (#2627): passing the PARAGRAPH'S OWN INDEX to
+ *     speakText(text, lessonId, idx) — not a hardcoded 0 — so each call hits
+ *     the backend's per-paragraph canonical-sentence cache (GET
+ *     /api/tts/mapping/{lessonId}) instead of paying a live 8-15s synthesis,
+ *     AND so it isn't silently reading paragraph 0 no matter what plays.
+ *   - LessonAudioTable.tsx (#2622): a component-owned "walk id" that every
+ *     continuation must match before it's allowed to speak — proven on
+ *     staging to close a real race (stop() flipped the UI to idle while
+ *     currentTime kept advancing 13s → 18s → 41s) that neither utteranceRef
+ *     nor ttsApi's module-level _currentAudio closed on their own.
+ *
+ * Does NOT modify useTtsPlayback.ts — only calls its existing public API
+ * (speakText / pauseTts / resumeTts / stopTts + the state it publishes), the
+ * same surface every other reading step already uses. See the hard boundary
+ * noted in FullTextAnnotate.tsx for why.
+ */
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useTtsPlayback } from './useTtsPlayback';
+
+interface UseFullTextTtsQueueProps {
+  /** Whole-lesson paragraphs in on-screen order — story.content. Every entry
+   *  IS story.content[idx], so (unlike Intro.tsx's teaser-text fallback) there
+   *  is no case here where passing lessonId+idx would address the wrong text. */
+  paragraphs: string[];
+  /** Numeric lesson id for the backend's canonical-sentence cache. undefined
+   *  (not NaN) when story.id isn't numeric — useTtsPlayback then takes the
+   *  no-cache single-shot path per paragraph instead of a 422 against
+   *  GET /api/tts/mapping/{lessonId} (an int path param). */
+  lessonId: number | undefined;
+}
+
+export interface UseFullTextTtsQueueReturn {
+  /** -1 = idle (nothing queued / not playing). */
+  currentParagraphIdx: number;
+  /** Audio is actually flowing right now (not paused, not still loading). */
+  isPlaying: boolean;
+  /** Fetch/synthesis in flight, no audio byte yet. */
+  isLoading: boolean;
+  isPaused: boolean;
+  ttsError: string | null;
+  isTtsDegraded: boolean;
+  /** Starts a fresh walk from paragraph 0. No-op when paragraphs is empty. */
+  play: () => void;
+  pause: () => void;
+  resume: () => void;
+  /** Stops playback, invalidates the walk, resets currentParagraphIdx to -1. */
+  stop: () => void;
+}
+
+export function useFullTextTtsQueue({
+  paragraphs,
+  lessonId,
+}: UseFullTextTtsQueueProps): UseFullTextTtsQueueReturn {
+  const [currentParagraphIdx, setCurrentParagraphIdx] = useState(-1);
+
+  const tts = useTtsPlayback(() => {}, () => {});
+
+  // Belt-and-suspenders stop — every <audio> element that has actually
+  // started playing while this hook is mounted, tracked by patching
+  // HTMLMediaElement.prototype.play. Mirrors the fix proven on staging for
+  // LessonAudioTable (#2622): tts.stopTts() reaches the clip through
+  // utteranceRef / ttsApi's module-level _currentAudio, and there is a
+  // measured window where neither points at the element that is actually
+  // sounding (e.g. a sentence fetch that was already in flight the instant
+  // stop() ran). Tracking every element .play() was ever called on closes
+  // that window without touching the shared hook every reading step uses.
+  const startedAudioRef = useRef<Set<HTMLMediaElement>>(new Set());
+  useEffect(() => {
+    const started = startedAudioRef.current;
+    const originalPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function patchedPlay(this: HTMLMediaElement, ...args) {
+      started.add(this);
+      return originalPlay.apply(this, args);
+    };
+    return () => {
+      HTMLMediaElement.prototype.play = originalPlay;
+      started.forEach((el) => { if (!el.paused) el.pause(); });
+      started.clear();
+    };
+  }, []);
+
+  // The walk id currently authorised to keep advancing. 0 = no active walk.
+  // Every continuation (the auto-advance effect below) must be handed this
+  // exact value at the moment it was scheduled; speakAt re-checks it against
+  // the CURRENT value before ever calling tts.speakText. stop() sets this to
+  // 0, so a stale "paragraph finished" callback that was already queued
+  // before stop() ran can never resume the walk — same shape as
+  // LessonAudioTable's activeRequestRef, which is what closed the 13s → 18s →
+  // 41s race on staging (#2622). A simple boolean isn't enough: play() → stop()
+  // → play() again needs the SECOND walk to also be distinguishable from the
+  // first, not just "any active walk".
+  const currentWalkIdRef = useRef(0);
+  const nextWalkIdRef = useRef(1);
+
+  // Read on every call so a play() that races a paragraphs prop update always
+  // walks the latest array, without adding paragraphs to every callback's dep list.
+  const paragraphsRef = useRef(paragraphs);
+  paragraphsRef.current = paragraphs;
+
+  const speakAt = useCallback((idx: number, walkId: number) => {
+    if (walkId !== currentWalkIdRef.current) return; // superseded — stale continuation
+    const list = paragraphsRef.current;
+    if (idx >= list.length) {
+      currentWalkIdRef.current = 0;
+      setCurrentParagraphIdx(-1);
+      return;
+    }
+    setCurrentParagraphIdx(idx);
+    // Passing the paragraph's OWN index (not a hardcoded 0) is the #2627 fix —
+    // this is what lets each call hit the backend's per-paragraph cache.
+    tts.speakText(list[idx], lessonId, idx);
+  }, [tts, lessonId]);
+
+  const play = useCallback(() => {
+    if (paragraphsRef.current.length === 0) return;
+    const walkId = nextWalkIdRef.current++;
+    currentWalkIdRef.current = walkId;
+    speakAt(0, walkId);
+  }, [speakAt]);
+
+  const stop = useCallback(() => {
+    currentWalkIdRef.current = 0; // invalidate — 0 never matches a real walkId
+    tts.stopTts();
+    // Belt and braces (see startedAudioRef comment above): pause every element
+    // that has actually played while this hook was mounted, not just whatever
+    // handle the hook/ttsApi currently thinks is live.
+    startedAudioRef.current.forEach((el) => {
+      if (!el.paused) { el.pause(); el.currentTime = 0; }
+    });
+    startedAudioRef.current.clear();
+    setCurrentParagraphIdx(-1);
+  }, [tts]);
+
+  // Advance to the next paragraph once the current one finishes playing on
+  // its own (isTtsSpeaking/isTtsLoading both fall back to false while a walk
+  // is active). isTtsPaused deliberately does NOT flip isTtsSpeaking off (see
+  // useTtsPlayback.pauseTts), so this never mistakes "paused" for "finished".
+  const wasBusyRef = useRef(false);
+  useEffect(() => {
+    const busy = tts.isTtsSpeaking || tts.isTtsLoading;
+    const justFinished = wasBusyRef.current && !busy;
+    wasBusyRef.current = busy;
+    if (!justFinished) return;
+    if (currentParagraphIdx < 0) return; // already stopped/reset — nothing to advance
+    if (tts.ttsError) return; // a failed paragraph aborts the sequence, does not advance
+    const walkId = currentWalkIdRef.current;
+    if (!walkId) return; // no active walk
+    speakAt(currentParagraphIdx + 1, walkId);
+  }, [tts.isTtsSpeaking, tts.isTtsLoading, tts.ttsError, currentParagraphIdx, speakAt]);
+
+  // A TTS error aborts the whole walk (handled above) but also must return
+  // controls to idle even if the transition-detection effect above doesn't
+  // fire this render (e.g. the error arrives while isTtsLoading was already
+  // false a tick earlier) — mirrors Intro.tsx's separate ttsError-abort effect.
+  useEffect(() => {
+    if (tts.ttsError) {
+      currentWalkIdRef.current = 0;
+      setCurrentParagraphIdx(-1);
+    }
+  }, [tts.ttsError]);
+
+  // Unmount safety: never leave audio playing after navigating away from the step.
+  useEffect(() => {
+    return () => { tts.stopTts(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    currentParagraphIdx,
+    isPlaying: tts.isTtsSpeaking,
+    isLoading: tts.isTtsLoading,
+    isPaused: tts.isTtsPaused,
+    ttsError: tts.ttsError,
+    isTtsDegraded: tts.isTtsDegraded,
+    play,
+    pause: tts.pauseTts,
+    resume: tts.resumeTts,
+    stop,
+  };
+}

--- a/frontend/src/pages/GuestReadingPage.tsx
+++ b/frontend/src/pages/GuestReadingPage.tsx
@@ -1,0 +1,110 @@
+/**
+ * GuestReadingPage — 讀全文-做記號 for a visitor with no account (#2649).
+ *
+ * A student scans a QR code printed on a paper worksheet. The QR points at
+ * /learn/{id}/full-text-annotate, they have never logged in, and if that URL
+ * just showed them a password box the code would be pointless. So they get the
+ * lesson text and the whole-lesson audio, and nothing that writes.
+ *
+ * Why this is a separate page rather than the normal shell with things hidden:
+ * the authenticated shell opens a DB learning session on mount. Mounting it
+ * without a user fires authenticated calls that 401 and leaves a half-built
+ * session behind. This page talks to two endpoints, both verified public:
+ *
+ *   GET /api/stories/{id}                    → 200 (8.6 KB) anonymous
+ *   GET /assets/demo-reading/{id}/full.mp3   → 200 audio/mpeg anonymous
+ *
+ * Annotating stays behind the login wall — a mark has to belong to somebody.
+ * The invitation to log in is right there, so the path onward is one tap.
+ */
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+import ReadingAnnotation from '../components/reading-steps/FullTextAnnotate';
+import ReadingPlayer from '../components/reading-steps/ReadingPlayer';
+import { useAssetAudio, demoReadingUrl } from '../hooks/useAssetAudio';
+import { fetchStory } from '../services/api';
+import type { Story } from '../types';
+
+const GuestReadingPage: React.FC = () => {
+  const { storyId } = useParams<{ storyId: string }>();
+  const [story, setStory] = useState<Story | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const audio = useAssetAudio(demoReadingUrl(storyId ?? ''));
+
+  useEffect(() => {
+    if (!storyId) return;
+    let cancelled = false;
+    setFailed(false);
+    fetchStory(storyId)
+      .then((s) => {
+        if (!cancelled) setStory(s);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [storyId]);
+
+  if (failed) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-surface">
+        <p className="text-lg text-on-surface-variant">找不到這一課</p>
+        <Link to="/login" className="text-accent underline">
+          回到登入
+        </Link>
+      </div>
+    );
+  }
+
+  if (!story) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface">
+        <p className="text-on-surface-variant">載入中…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-surface" data-testid="guest-reading-page">
+      {/* Top bar — the player lives here so it stays reachable while reading. */}
+      <div className="sticky top-0 z-30 backdrop-blur bg-surface/85 border-b border-outline-variant/20">
+        <div className="max-w-4xl mx-auto px-5 py-3 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="font-headline font-bold text-lg text-on-surface truncate">
+              {story.title}
+            </h1>
+            <p className="text-xs text-on-surface-variant">課文朗讀</p>
+          </div>
+
+          <div className="flex items-center gap-3 shrink-0">
+            {!audio.hasError && (
+              <ReadingPlayer
+                isPlaying={audio.isPlaying}
+                isPaused={audio.isPaused}
+                isLoading={audio.isLoading}
+                onPlay={audio.play}
+                onPause={audio.pause}
+                onResume={audio.resume}
+                onStop={audio.stop}
+              />
+            )}
+            <Link
+              to="/login"
+              className="text-sm font-medium text-accent whitespace-nowrap hover:underline"
+            >
+              登入做記號
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <ReadingAnnotation story={story} onFinish={() => {}} readOnly />
+    </div>
+  );
+};
+
+export default GuestReadingPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -15,7 +15,7 @@
 import React, { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 
-import { PublicOnlyRoute, ProtectedRoute, StudentClassroomGuard } from '../components/auth/RouteGuards';
+import { PublicOnlyRoute, ProtectedRoute, StudentClassroomGuard, LearningRouteGate } from '../components/auth/RouteGuards';
 import NoTeacherPage from '../pages/app/NoTeacherPage';
 import { AppShell, LearningAppShell } from '../components/layout/AppShell';
 import {
@@ -428,9 +428,12 @@ const AppRoutes: React.FC = () => (
       <Route
         path="/learn/:storyId"
         element={
-          <ProtectedRoute>
+          /* Not ProtectedRoute: 讀全文-做記號 is reachable from a QR code on
+             paper, so an anonymous visitor gets a read-and-listen page there
+             instead of a login box (#2649). Every other step still redirects. */
+          <LearningRouteGate>
             <LearningAppShell />
-          </ProtectedRoute>
+          </LearningRouteGate>
         }
       >
         {learningRoutes}

--- a/frontend/tests/e2e/full-qa.spec.ts
+++ b/frontend/tests/e2e/full-qa.spec.ts
@@ -101,15 +101,17 @@ test.describe('A. Student path — 13 step walkthrough', () => {
     expect(bodyText.length).toBeGreaterThan(100);
   });
 
-  test('A3. Step 1 reading-annotation route loads', async ({ page, request }) => {
+  test('A3. Step 1 full-text-annotate route loads', async ({ page, request }) => {
     const storyId = await fetchFirstStoryId(request);
     test.skip(!storyId, 'No stories available from API');
     const token = await loginAs(page, request, 'student');
     test.skip(!token, 'Cannot login as student');
 
+    // The legacy id still has to work — QR codes carrying it are printed on
+    // paper — but it now redirects to the canonical id (#2649 rename).
     await page.goto(`/learn/${storyId}/reading-annotation`);
     await page.waitForLoadState('networkidle');
-    await expect(page).toHaveURL(/reading-annotation/);
+    await expect(page).toHaveURL(/full-text-annotate/);
   });
 
   test('A4. Step 2 tutor — UNTESTABLE without mic mock', async () => {
@@ -172,10 +174,10 @@ test.describe('A. Student path — 13 step walkthrough', () => {
     const stepsToProbe = [
       'vocab-definition',
       'vocab-application',
-      'story-structure',
-      'reading-strategy',
+      'keypoints-table',
+      'spotlight',
       'comprehension',
-      'vocab-word-search',
+      'vocab-review',
       'knowledge-station',
     ];
     for (const step of stepsToProbe) {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

掃紙本學習單上的 QR code 進來的學生沒有帳號，而 `讀全文-做記號` 整頁在登入牆後面 —— QR 掃進去只看到密碼框。而且那一頁本來也沒有任何朗讀。

## 兩件事

**播放器** — play / 暫停 / 停止。登入的學生走逐段合成（`useFullTextTtsQueue`），所以頁面知道正在唸哪一段，會highlight並把畫面帶過去（`block: 'nearest'`，已經在畫面上的段落不會被硬拉）。

**匿名可讀可聽** — 同一個 URL，未登入時給一個獨立的閱讀頁。之所以是獨立頁而不是「把東西藏起來的原殼」：原殼 mount 時會開 DB learning session，沒有 user 就是一連串 401 加半個殘留 session。

## 只開這一步，其他全部維持導向 /login

理由每一步都一樣：**其他步驟都會寫東西** —— 錄音、記號、分數，都得歸屬到某個人。讀和聽不用。

所以標記功能在匿名時是**移除**不是 disable（灰掉的按鈕讀起來像壞了，不存在讀起來像本來就沒有），旁邊放一個「登入做記號」一鍵過去。

## 付費端點沒有被打開

`POST /api/tts/synthesize` 維持 401-to-anonymous —— 它按次計費，不能沒有 user 就打得到。匿名播放讀的是預生成的整課 mp3，走公開的 `/assets` proxy。

## 安全審查（auth diff 落地前）

| 檢查 | 結果 |
|---|---|
| 新開放的匿名資料 | 課文文字 + 預生成音檔 —— 兩者在 #2625 的 `/demo-reading` 就已公開，本 PR 沒有新增可讀的東西 |
| Path traversal | 實測不是讀 guard：`/assets/demo-reading/../../etc/passwd` → 404，真實物件 → 200 |
| 限流 | `/assets/*` 有 per-IP middleware（`main.py:302`），讀的是實作不是它上面的註解 |
| 登入者行為 | 未變，terms gate 保留 |

## 驗證

staging 實測（每一條都帶對照）：

```
GET /api/stories/1                    → 200  8.6KB   匿名
GET /assets/demo-reading/1/full.mp3   → 200  648KB   audio/mpeg
GET /assets/demo-reading/99999/full.mp3 → 404        ← negative control
```

最後這條是重點：少了它，一個「什麼都回 200」的 proxy 看起來會跟「檔案真的在」一模一樣。

**六個 mutation，每一個都殺掉了它該殺的測試**：拿掉公開步驟判斷 → 3 紅；把所有步驟開放 → 4 紅；跳過 loading guard → 1 紅；側欄 / 完成標記 / 播放器各自解除 readOnly 控制 → 2 / 2 / 1 紅。

`lint 0 errors` · `vite build ✓` · `134 tests green`（含 CI 釘住的 8 支 + 本次新增 3 支，新的也釘進 `frontend-checks.yml` 了）

## 還沒做

- 匿名時沒有逐段highlight跟隨（單一 mp3 沒有段落邊界）。登入的學生有。
- `/demo-reading/:id/:kind`（#2625 那頁）仍然存在，和這條路並存，還沒決定要不要收掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)