### PR TITLE
fix(#2649/#2627): 補上 Hans 回報的聲調讀音 + 堵住中國腔回讀 + 朗讀預抓下一句

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -76,4 +76,5 @@ jobs:
         run: npx vitest run src/__smoke__/render-smoke.test.tsx src/hooks/useStepProgressPersistence.resetTutorStep.test.ts src/components/reading-steps/paragraph-reading/ParagraphReading.readAgain.test.tsx src/hooks/useTtsPlayback.test.ts src/pages/admin/lesson-audio/qrcode-bundling.test.ts src/pages/admin/lesson-audio/LessonAudioTable.test.tsx src/config/stepNaming.test.ts src/routes/componentNaming.test.ts \
             src/components/auth/LearningRouteGate.test.tsx \
             src/components/reading-steps/FullTextAnnotate.readonly.test.tsx \
-            src/hooks/useFullTextTtsQueue.test.ts
+            src/hooks/useFullTextTtsQueue.test.ts \
+            src/services/ttsApi.prefetch.test.ts

--- a/frontend/src/services/ttsApi.prefetch.test.ts
+++ b/frontend/src/services/ttsApi.prefetch.test.ts
@@ -1,0 +1,141 @@
+/**
+ * While one sentence plays, the next one should already be on its way.
+ *
+ * Playback was strictly serial: request a sentence, wait for it, play it, then
+ * request the next one. Every uncached sentence therefore inserted its full
+ * synthesis time as silence — measured at 4.5s on a cold key passage in the
+ * admin panel (#2627).
+ *
+ * The wait is avoidable. A sentence takes seconds to *say* and well under a
+ * second to fetch, so the fetch for sentence N+1 fits comfortably inside the
+ * playback of sentence N. Owner's words: 「你不能夠在全文朗讀之前你就一句一句
+ * 人家還在讀的時候就趕快趕快預先處理嗎？」
+ *
+ * Doing it in the shared loop fixes every caller at once — Intro, the whole-
+ * lesson walk, and the admin panel — rather than one prefetch per feature.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const SENTENCES = ['第一句。', '第二句。', '第三句。'];
+
+/** Order of events: 'fetch:<text>' and 'play:<text>'. */
+let timeline: string[] = [];
+let resolvePlay: Array<() => void> = [];
+
+function installMocks() {
+  timeline = [];
+  resolvePlay = [];
+
+  global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes('/api/tts/mapping/')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          lesson_id: 1,
+          paragraphs: [{ index: 0, sentences: SENTENCES.map((t) => ({ text: t, hash: t, chars: t.length })) }],
+        }),
+      } as unknown as Response;
+    }
+    const body = JSON.parse(String(init?.body ?? '{}'));
+    timeline.push(`fetch:${body.text}`);
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      blob: async () => ({ size: 128 }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+
+  global.URL.createObjectURL = vi.fn(() => 'blob:stub');
+  global.URL.revokeObjectURL = vi.fn();
+
+  // An Audio element that only finishes when the test says so, so we can
+  // inspect what happened *during* playback rather than after it.
+  class StubAudio {
+    src = '';
+    currentTime = 0;
+    paused = false;
+    onended: (() => void) | null = null;
+    private handlers: Record<string, Array<() => void>> = {};
+    constructor(src?: string) {
+      this.src = src ?? '';
+    }
+    addEventListener(ev: string, fn: () => void) {
+      (this.handlers[ev] ||= []).push(fn);
+    }
+    removeEventListener() {}
+    pause() {
+      this.paused = true;
+    }
+    play() {
+      timeline.push('play');
+      return new Promise<void>((res) => {
+        resolvePlay.push(() => {
+          (this.handlers.ended || []).forEach((f) => f());
+          this.onended?.();
+        });
+        res();
+      });
+    }
+  }
+  vi.stubGlobal('Audio', StubAudio as unknown as typeof Audio);
+}
+
+describe('sentence prefetch', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    installMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('requests the next sentence before the current one has finished', async () => {
+    const { speakText } = await import('./ttsApi');
+
+    const done = speakText('第一句。第二句。第三句。');
+
+    // Let the first fetch + play get going.
+    await vi.waitFor(() => expect(timeline).toContain('play'));
+
+    const beforeFirstEnds = [...timeline];
+    const fetched = beforeFirstEnds.filter((e) => e.startsWith('fetch:'));
+
+    expect(fetched).toContain('fetch:第一句。');
+    expect(fetched).toContain(
+      'fetch:第二句。',
+    );
+
+    // Drain so the promise settles and the test doesn't leak a pending walk.
+    // Bounded rather than while-empty: a resolve can queue the next play, so
+    // an unbounded loop here would hang the run instead of failing it.
+    for (let i = 0; i < 30; i += 1) {
+      if (resolvePlay.length) resolvePlay.shift()!();
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    await done.catch(() => {});
+  });
+
+  it('still plays every sentence, in order', async () => {
+    const { speakText } = await import('./ttsApi');
+    const done = speakText('第一句。第二句。第三句。');
+
+    for (let i = 0; i < 30; i += 1) {
+      if (resolvePlay.length) resolvePlay.shift()!();
+      await Promise.resolve();
+    }
+    await done.catch(() => {});
+
+    const played = timeline.filter((e) => e === 'play').length;
+    expect(played).toBe(SENTENCES.length);
+
+    // Each sentence fetched exactly once — prefetching must not double-charge
+    // us for synthesis.
+    for (const s of SENTENCES) {
+      expect(timeline.filter((e) => e === `fetch:${s}`)).toHaveLength(1);
+    }
+  });
+});

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -301,7 +301,34 @@ async function _fetchLessonSentences(
  * On any other error: throws (existing behaviour, caught by outer try/catch in
  * speakText callers or surfaced to the user as a silent skip).
  */
+/**
+ * Requests in flight, so two callers asking for the same sentence at the same
+ * time produce one synthesis rather than two.
+ *
+ * Needed once prefetch exists: the prefetch for sentence N+1 is still on the
+ * wire when the loop arrives at N+1, and the plain `_urlCache` check misses it
+ * because nothing has been cached *yet*. Without this we paid for every
+ * prefetched sentence twice.
+ */
+const _inFlight = new Map<string, Promise<string | null>>();
+
 async function _fetchAudioUrl(sentence: string): Promise<string | null> {
+  const cached = _urlCache.get(sentence);
+  if (cached) return cached;
+
+  const pending = _inFlight.get(sentence);
+  if (pending) return pending;
+
+  const request = _fetchAudioUrlUncached(sentence);
+  _inFlight.set(sentence, request);
+  try {
+    return await request;
+  } finally {
+    _inFlight.delete(sentence);
+  }
+}
+
+async function _fetchAudioUrlUncached(sentence: string): Promise<string | null> {
   let audioUrl = _urlCache.get(sentence);
   if (!audioUrl) {
     // If still within a rate-limit window, skip this sentence silently.
@@ -360,7 +387,8 @@ async function _speakViaBackend(
 
   if (sentences.length === 0) return;
 
-  for (const sentence of sentences) {
+  for (let i = 0; i < sentences.length; i += 1) {
+    const sentence = sentences[i];
     if (_cancelRequested) break;
     if (!sentence.trim()) continue;
 
@@ -368,8 +396,33 @@ async function _speakViaBackend(
     // null = 429 rate-limited — skip this sentence (toast already fired)
     if (audioUrl === null) continue;
     if (_cancelRequested) break;
+
+    // Fetch the next sentence while this one is being said (#2627).
+    //
+    // Playback used to be strictly serial, so every uncached sentence inserted
+    // its whole synthesis time as silence — 4.5s on a cold key passage. A
+    // sentence takes seconds to say and well under a second to fetch, so the
+    // next fetch fits inside the current playback and the gap disappears.
+    //
+    // Deliberately not awaited, and deliberately before the play: the point is
+    // that it overlaps. _fetchAudioUrl caches by sentence text, so when the
+    // loop arrives at i+1 it is a local hit rather than a second request.
+    _prefetchSentence(sentences[i + 1]);
+
     await _playSingleAudio(audioUrl);
   }
+}
+
+/**
+ * Warm the cache for a sentence without playing it. Errors are swallowed —
+ * a failed prefetch must never break playback; the real request will retry
+ * and surface the failure then.
+ */
+function _prefetchSentence(sentence: string | undefined): void {
+  if (!sentence || !sentence.trim()) return;
+  if (_cancelRequested) return;
+  if (_urlCache.has(sentence)) return;
+  void _fetchAudioUrl(sentence).catch(() => undefined);
 }
 
 async function _speakViaBackendWithProgress(


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

三件事，全部有回歸鎖且做過 mutation 驗證。

## 1. 昨天那張讀音表，一條都沒修到 Hans 回報的詞

這是最該講的一件。#2648 上了 89 條校正，而 Hans 報的四個詞**一個都不在裡面**。

原因是那次比對**只比聲韻、把聲調丟掉**（因為 一/不 會變調，留著聲調就一堆雜訊）—— 而他報的正好全是聲調：

```
攻擊   教育部 ㄐㄧˊ   Azure ㄐㄧ
嘆息   教育部 ㄒㄧˊ   Azure ㄒㄧ
```

改成**留聲調、改排除 一/不**，多抓到 19 個字。這些字在教育部辭典都只有一個讀音（擊到哪裡都是 ㄐㄧˊ），所以不看上下文也能安全替換；替身字也要求單讀音，否則只是把不確定搬到別處。

**語料也拿錯了。** 原本讀 `backend/data/curriculum`，只有 11.3 萬字，而且**裡面根本沒有第 1 課** —— 攻擊從頭到尾就沒被列為候選。現在改抓 API 全 165 課（19.1 萬字），並斷言拿到的筆數等於回應的 `total`。這個坑 CLAUDE.md 早就寫過，我還是踩了。

147 個候選丟掉 38 個：jieba 會切出 `攻擊千變` 這種不是詞的東西，短的那條已經涵蓋同樣的修正。**是既有的「沒有一條是另一條子字串」測試把它抓出來的**。

**沒有涵蓋的，寫在檔案裡而不是留白**：`摸不著` 和 `和`。這兩個是多音字（著 5 個讀音、和 6 個），哪個對要看句子。盲目替換會修好 `摸不著` 同時弄壞 `顯著`。另外 7 個字（播 髮 叔 噸 眶 綜 吔）登記為 known gap —— 真的有聲調差異，但找不到夠常見的單讀音替身。

## 2. Azure 快取 miss 會去讀中國腔

`tts/__init__.py` 在 azure 模式 miss 時**回讀 google prefix**。兩個 prefix 裝的是不同聲音，而 `cmn-CN-Chirp3-HD` 是 2026-04 已經否決的中國腔。

所以一次短暫的 Azure 失敗會變成永久的：失敗時寫進一個中國腔物件，之後每次請求都命中它，**Azure 恢復也救不回**。目前線上有 22 句就在這個狀態。

拿掉。miss 現在就是付一次合成的錢 —— 那是「永遠送出我們選的聲音」該付的價格。

三條測試，第三條才讓前兩條有意義：**azure 真的有的物件仍然要走快取**。把所有 GCS 讀取都弄壞，前兩條負向測試自己還是綠的。

## 3. 播下一句要提前抓（Young 的提法）

原本是嚴格串列：抓一句 → 等 → 播 → 再抓下一句。每個沒快取的句子就把整段合成時間變成靜音。staging 實測：**冷快取 4,487 ms 才出聲**，暖的 571 ms。

改成播第 N 句的同時就去抓 N+1。一句話「唸」要好幾秒、「抓」不到一秒，剛好塞得進去。

> 「你不能夠在全文朗讀之前你就一句一句人家還在讀的時候就趕快趕快預先處理嗎？」

改在共用迴圈裡，所以 Intro、全文朗讀、後台三個地方一次修好。

**這順帶逼出一個會多花錢的 bug**：預抓的請求還在飛的時候迴圈就走到 N+1 了，而 `_urlCache` 檢查看不到「還沒存進來」的東西 → 每個預抓過的句子都抓兩次。加了 in-flight 去重。第二條測試斷言「每句剛好抓一次」，當場就抓到了。

## 驗證

| | |
|---|---|
| lint | 0 errors |
| vite build | ✓ |
| 前端測試 | 73 passed |
| 後端 spec 契約 | 751 passed / 4 xfailed |
| mutation | 9 個，每一個都殺掉它該殺的測試 |

## 落地後還要做一件事

新的校正表只影響**之後**合成的音檔。**線上已快取的 574 句（6515 句的 8.8%）仍然是舊讀音**，要等這個 PR 部署完才能刪 —— 現在刪會用舊表重合成，白花錢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)