### PR TITLE
feat(#2655): 讓 1306 個舊讀音快取 key 失效的 purge script（dry-run 預設）

### DIFF
--- a/backend/app/services/tts/normalization.py
+++ b/backend/app/services/tts/normalization.py
@@ -191,6 +191,41 @@ def _he_conjunction_positions(text: str) -> frozenset[int]:
 _HE_CONJUNCTION = '<sub alias="漢">和</sub>'
 
 
+def escape_for_ssml(text: str) -> str:
+    """XML-escape a sentence before it enters the SSML body.
+
+    Lives here rather than inline in the Azure provider because it is the
+    first half of a pair: _apply_phoneme_corrections is documented to take
+    ALREADY-escaped text, so anything that wants to know what the corrections
+    would do to a sentence has to escape it the same way first. One definition
+    means the answer cannot drift from what the provider actually sends.
+    """
+    return (
+        text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def corrections_change_text(text: str) -> bool:
+    """True when synthesizing this sentence today would differ from the plain
+    text — i.e. some correction fires on it.
+
+    Asks the transform, not the table. _has_phoneme_corrections only consults
+    PHONEME_CORRECTIONS, so it went stale the moment the 和 conjunction rule
+    (#2661) landed as a separate branch inside _apply_phoneme_corrections: a
+    sentence whose only change is 和 → 漢 answers False there while the
+    synthesizer happily rewrites it. Comparing before and after cannot fall
+    behind that way — a future rule added anywhere in the pass is covered
+    without touching this function.
+    """
+    escaped = escape_for_ssml(text)
+    return _apply_phoneme_corrections(escaped) != escaped
+
+
 def _apply_phoneme_corrections(text_escaped: str) -> str:
     # Single left-to-right pass over the ORIGINAL text — never re-scan text
     # we just emitted. Sequential `result.replace(...)` per pattern (the old

--- a/backend/app/services/tts/providers/azure.py
+++ b/backend/app/services/tts/providers/azure.py
@@ -5,7 +5,7 @@ import urllib.error
 import urllib.request
 
 from .. import TTSError
-from ..normalization import _apply_phoneme_corrections
+from ..normalization import _apply_phoneme_corrections, escape_for_ssml
 
 AZURE_SPEECH_KEY = os.environ.get("AZURE_SPEECH_KEY", "")
 AZURE_SPEECH_REGION = os.environ.get("AZURE_SPEECH_REGION", "eastus")
@@ -18,14 +18,7 @@ def _synthesize_azure(text: str) -> bytes:
 
     url = f"https://{AZURE_SPEECH_REGION}.tts.speech.microsoft.com/cognitiveservices/v1"
 
-    text_escaped = (
-        text
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
-    )
+    text_escaped = escape_for_ssml(text)
     ssml_body = _apply_phoneme_corrections(text_escaped)
 
     # #2082 A1: brisker pace ~260-270 字/分 (product-tunable; was 0.95)

--- a/backend/scripts/purge_stale_tts_cache.py
+++ b/backend/scripts/purge_stale_tts_cache.py
@@ -23,9 +23,11 @@ current table.
 
 Selection never guesses. `pronunciation` mode derives candidates from
 backend/data/sentences.v2.jsonl, the same corpus the serving path uses to
-build a lesson's sentence list, and keeps only sentences the live correction
-table actually fires on. `mainland-orphans` mode lists the google prefix and
-keeps only objects with no azure counterpart.
+build a lesson's sentence list, and keeps the ones the live transform actually
+rewrites — asked by running it, not by consulting the table it reads from.
+Candidates cover both units the runtime requests: individual sentences, and
+whole paragraphs since #2662 made a paragraph one request. `mainland-orphans`
+mode lists the google prefix and keeps only objects with no azure counterpart.
 
 Deleting is opt-in. Without --delete this reports and exits, and even with it
 only the objects this run itself flagged are removed — never a prefix sweep.
@@ -47,6 +49,7 @@ making a student pay the first-hit latency, run batch_azure_tts.py afterwards.
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import logging
 import sys
@@ -93,8 +96,39 @@ def load_corpus_sentences(path: Path = SENTENCES_PATH) -> list[dict]:
     return rows
 
 
+def build_paragraph_texts(sentences: list[dict]) -> list[dict]:
+    """Reconstruct each paragraph exactly as the player synthesizes it.
+
+    Since #2662 a paragraph is one TTS request — the pitch contour resets at
+    every request, so per-sentence clips read like a list rather than someone
+    reading. The client rebuilds the paragraph as `canonical.join('').trim()`
+    over the mapping's sentence list, so that is reproduced verbatim here; any
+    other join produces a key the runtime never looks up.
+
+    Both granularities live in the bucket at once (the keys are just sha256 of
+    whatever text was sent), so both have to be enumerated. Sentence keys alone
+    would repeat, one unit up, exactly the miss that #2661 caused.
+    """
+    grouped: dict[tuple, list[dict]] = {}
+    for row in sentences:
+        grouped.setdefault((row.get("lesson_id"), row.get("paragraph_idx")), []).append(row)
+
+    paragraphs: list[dict] = []
+    for (lesson_id, paragraph_idx), rows in grouped.items():
+        ordered = sorted(rows, key=lambda r: r.get("sentence_idx", 0))
+        text = "".join(r["text"] for r in ordered).strip()
+        if text:
+            paragraphs.append({
+                "lesson_id": lesson_id,
+                "paragraph_idx": paragraph_idx,
+                "sentence_idx": None,
+                "text": text,
+            })
+    return paragraphs
+
+
 def select_pronunciation_affected(sentences: list[dict]) -> list[dict]:
-    """Sentences whose synthesized reading today differs from what is cached.
+    """Every cached text unit whose synthesized reading now differs.
 
     Asks corrections_change_text — the transform itself — not a word list and
     not _has_phoneme_corrections. Both of those go stale: a copied list dies
@@ -103,18 +137,36 @@ def select_pronunciation_affected(sentences: list[dict]) -> list[dict]:
     _apply_phoneme_corrections. Selecting on the predicate would have skipped
     every sentence whose only change is 和 → 漢 — including 「和」向心力 on
     L01, one of the sentences actually reported — and reported success.
+
+    Covers sentences and paragraphs, because both are units the runtime asks
+    for and therefore both are units the bucket holds. A single-granularity
+    sweep looks complete and is not.
     """
+    candidates = [{**row, "unit": "sentence"} for row in sentences]
+    candidates += [{**row, "unit": "paragraph"} for row in build_paragraph_texts(sentences)]
+
     affected: list[dict] = []
-    for row in sentences:
+    seen: set[str] = set()
+    for row in candidates:
         text = row["text"]
-        if corrections_change_text(text):
-            affected.append({
-                "lesson_id": row.get("lesson_id"),
-                "paragraph_idx": row.get("paragraph_idx"),
-                "sentence_idx": row.get("sentence_idx"),
-                "text": text,
-                "key": _cache_key(text),
-            })
+        if not corrections_change_text(text):
+            continue
+        key = _cache_key(text)
+        # A one-sentence paragraph has the same text as its only sentence, so
+        # the same key arrives twice. Deduplicating here rather than at delete
+        # time keeps the reported count equal to the number of objects — an
+        # inflated "973 flagged" that deletes 900 is a number nobody can check.
+        if key in seen:
+            continue
+        seen.add(key)
+        affected.append({
+            "unit": row["unit"],
+            "lesson_id": row.get("lesson_id"),
+            "paragraph_idx": row.get("paragraph_idx"),
+            "sentence_idx": row.get("sentence_idx"),
+            "text": text,
+            "key": key,
+        })
     return affected
 
 
@@ -230,8 +282,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode == "pronunciation":
         sentences = load_corpus_sentences()
         affected = select_pronunciation_affected(sentences)
-        logger.info("Corpus: %d sentences, %d affected by the current correction table (%.1f%%)",
-                    len(sentences), len(affected), 100.0 * len(affected) / max(len(sentences), 1))
+        by_unit = collections.Counter(a.get("unit") for a in affected)
+        logger.info(
+            "Corpus: %d sentences in %d paragraphs. Affected: %d sentence(s) + %d paragraph(s).",
+            len(sentences), len(build_paragraph_texts(sentences)),
+            by_unit["sentence"], by_unit["paragraph"],
+        )
         prefixes = [AZURE_PREFIX]
         if args.include_dormant_prefixes:
             prefixes += [GEMINI_PREFIX, GOOGLE_PREFIX]

--- a/backend/scripts/purge_stale_tts_cache.py
+++ b/backend/scripts/purge_stale_tts_cache.py
@@ -57,7 +57,7 @@ sys.path.insert(0, str(ROOT / "backend"))
 
 from app.services.tts.normalization import (  # noqa: E402
     _cache_key,
-    _has_phoneme_corrections,
+    corrections_change_text,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
@@ -94,16 +94,20 @@ def load_corpus_sentences(path: Path = SENTENCES_PATH) -> list[dict]:
 
 
 def select_pronunciation_affected(sentences: list[dict]) -> list[dict]:
-    """Sentences the *current* correction table changes the reading of.
+    """Sentences whose synthesized reading today differs from what is cached.
 
-    Asks the live table via _has_phoneme_corrections rather than re-listing
-    words here. A hardcoded copy would drift the moment the table is
-    regenerated, and then this script would quietly purge the wrong set.
+    Asks corrections_change_text — the transform itself — not a word list and
+    not _has_phoneme_corrections. Both of those go stale: a copied list dies
+    when the table is regenerated, and the predicate already died once, when
+    #2661 added the 和 conjunction rule as its own branch inside
+    _apply_phoneme_corrections. Selecting on the predicate would have skipped
+    every sentence whose only change is 和 → 漢 — including 「和」向心力 on
+    L01, one of the sentences actually reported — and reported success.
     """
     affected: list[dict] = []
     for row in sentences:
         text = row["text"]
-        if _has_phoneme_corrections(text):
+        if corrections_change_text(text):
             affected.append({
                 "lesson_id": row.get("lesson_id"),
                 "paragraph_idx": row.get("paragraph_idx"),

--- a/backend/scripts/purge_stale_tts_cache.py
+++ b/backend/scripts/purge_stale_tts_cache.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Delete TTS cache objects that are stale rather than merely old (#2649 items 3 & 4a).
+
+Two fixes landed on 2026-08-10 that change what synthesis *would* produce
+without touching a single object already in the bucket:
+
+  #2612/c53c68d3  the Taiwan reading table was rebuilt from the MOE dictionary
+                  (198 entries, now including 攻擊 and 嘆息 — the words Hans
+                  reported). The table is applied as SSML <sub> at synthesis
+                  time, so every sentence cached before it shipped still holds
+                  the old reading.
+
+  #2649/abad95d7  an Azure cache miss no longer falls through to the google
+                  prefix, so the mainland-accent objects written during the
+                  2026-08-08 Azure outage stop being served. They are now
+                  unreachable, not gone.
+
+The cache key is sha256 of the raw sentence text (normalization._cache_key),
+which does not change when the correction table does — that is the whole
+problem: a stale object keeps winning the lookup forever. Deleting the object
+is the invalidation mechanism; the next request re-synthesizes with the
+current table.
+
+Selection never guesses. `pronunciation` mode derives candidates from
+backend/data/sentences.v2.jsonl, the same corpus the serving path uses to
+build a lesson's sentence list, and keeps only sentences the live correction
+table actually fires on. `mainland-orphans` mode lists the google prefix and
+keeps only objects with no azure counterpart.
+
+Deleting is opt-in. Without --delete this reports and exits, and even with it
+only the objects this run itself flagged are removed — never a prefix sweep.
+
+Usage:
+  set -a; source backend/.env; set +a
+
+  # what would be deleted (safe anytime)
+  python backend/scripts/purge_stale_tts_cache.py --mode pronunciation
+  python backend/scripts/purge_stale_tts_cache.py --mode mainland-orphans
+
+  # actually delete, writing an evidence file naming every object removed
+  python backend/scripts/purge_stale_tts_cache.py --mode pronunciation \
+      --delete --report /tmp/purge-pronunciation.json
+
+Re-synthesis happens lazily on the next request. To pre-warm instead of
+making a student pay the first-hit latency, run batch_azure_tts.py afterwards.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.services.tts.normalization import (  # noqa: E402
+    _cache_key,
+    _has_phoneme_corrections,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("purge-tts")
+
+GCS_BUCKET = "lingoleap-tts-cache"
+AZURE_PREFIX = "azure/sentences"
+GOOGLE_PREFIX = "tts-cache"
+GEMINI_PREFIX = "gemini31-prompt-only-v2/sentences"
+
+SENTENCES_PATH = ROOT / "backend" / "data" / "sentences.v2.jsonl"
+
+
+def load_corpus_sentences(path: Path = SENTENCES_PATH) -> list[dict]:
+    """Every sentence in the serving corpus, in file order.
+
+    This is the same JSONL build_lesson_tts_mapping() reads, so a key computed
+    here is the key the runtime looks up. Deriving candidates from the corpus
+    (rather than from the bucket) is what makes the selection auditable: the
+    bucket only holds sha256 names, which cannot be turned back into text.
+    """
+    rows: list[dict] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            text = row.get("text", "")
+            if text.strip():
+                rows.append(row)
+    return rows
+
+
+def select_pronunciation_affected(sentences: list[dict]) -> list[dict]:
+    """Sentences the *current* correction table changes the reading of.
+
+    Asks the live table via _has_phoneme_corrections rather than re-listing
+    words here. A hardcoded copy would drift the moment the table is
+    regenerated, and then this script would quietly purge the wrong set.
+    """
+    affected: list[dict] = []
+    for row in sentences:
+        text = row["text"]
+        if _has_phoneme_corrections(text):
+            affected.append({
+                "lesson_id": row.get("lesson_id"),
+                "paragraph_idx": row.get("paragraph_idx"),
+                "sentence_idx": row.get("sentence_idx"),
+                "text": text,
+                "key": _cache_key(text),
+            })
+    return affected
+
+
+def find_existing(bucket, affected: list[dict], prefixes: list[str]) -> list[dict]:
+    """Keep only candidates that actually have an object, and record where.
+
+    One list_blobs per prefix beats len(affected) × len(prefixes) exists()
+    calls — the same reason batch_azure_tts.py lists instead of probing.
+    """
+    present: dict[str, set[str]] = {}
+    for prefix in prefixes:
+        names = set()
+        for blob in bucket.list_blobs(prefix=f"{prefix}/"):
+            if blob.name.endswith(".mp3"):
+                names.add(blob.name.rsplit("/", 1)[-1][: -len(".mp3")])
+        present[prefix] = names
+        logger.info("  %s/ holds %d object(s)", prefix, len(names))
+
+    hits: list[dict] = []
+    for cand in affected:
+        paths = [f"{p}/{cand['key']}.mp3" for p in prefixes if cand["key"] in present[p]]
+        if paths:
+            hits.append({**cand, "paths": paths})
+    return hits
+
+
+def select_mainland_orphans(bucket) -> list[dict]:
+    """Objects under the google prefix with no azure counterpart (#2649 item 4).
+
+    These are the sentences the 2026-08-08 Azure outage wrote in the mainland
+    voice. abad95d7 already stopped them being served; this removes them so a
+    future cross-prefix read — or a provider switch back to google — cannot
+    resurrect a voice that was rejected in 2026-04.
+
+    An object present under BOTH prefixes is left alone: azure wins the lookup,
+    so the google copy is dormant history, not a live mainland-accent hazard.
+    """
+    azure_keys = {
+        b.name.rsplit("/", 1)[-1][: -len(".mp3")]
+        for b in bucket.list_blobs(prefix=f"{AZURE_PREFIX}/")
+        if b.name.endswith(".mp3")
+    }
+    logger.info("  %s/ holds %d object(s)", AZURE_PREFIX, len(azure_keys))
+
+    google_names = [
+        b.name for b in bucket.list_blobs(prefix=f"{GOOGLE_PREFIX}/")
+        if b.name.endswith(".mp3")
+    ]
+    orphans = [
+        {"key": name.rsplit("/", 1)[-1][: -len(".mp3")], "text": None, "paths": [name]}
+        for name in google_names
+        if name.rsplit("/", 1)[-1][: -len(".mp3")] not in azure_keys
+    ]
+    logger.info("  %s/ holds %d object(s), %d without an azure counterpart",
+                GOOGLE_PREFIX, len(google_names), len(orphans))
+    return orphans
+
+
+def get_bucket(name: str):
+    """The single place this script reaches real GCS.
+
+    A named seam rather than an inline `storage.Client()` in main(): tests
+    replace this one function, instead of patching sys.modules and hoping
+    `from google.cloud import storage` resolves through the cache — it does
+    not once any other test in the session has imported the real module,
+    which is how a green test file turns red purely from run order.
+    """
+    from google.cloud import storage
+
+    return storage.Client().bucket(name)
+
+
+def apply_delete(bucket, flagged: list[dict]) -> list[str]:
+    """Delete exactly the paths already flagged. Does no selection of its own.
+
+    An object that is already gone (a second run, a concurrent partial delete)
+    is not an error and is not counted as a deletion.
+    """
+    from google.api_core.exceptions import NotFound
+
+    deleted: list[str] = []
+    for item in flagged:
+        for path in item["paths"]:
+            try:
+                bucket.blob(path).delete()
+                deleted.append(path)
+            except NotFound:
+                logger.info("  %s already gone (skipping)", path)
+    return deleted
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--bucket", default=GCS_BUCKET)
+    ap.add_argument("--mode", choices=("pronunciation", "mainland-orphans"),
+                    default="pronunciation")
+    ap.add_argument("--include-dormant-prefixes", action="store_true",
+                    help="pronunciation mode: also purge the google/gemini31 copies. "
+                         "Off by default — with cross-prefix read-through gone "
+                         "(abad95d7) only the azure copy can reach a student, and "
+                         "the others cost nothing to keep.")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="stop after N flagged items (0 = no limit); for a small "
+                         "first pass before committing to the whole set")
+    ap.add_argument("--report", type=Path,
+                    help="write the flagged/deleted set here as JSON evidence")
+    ap.add_argument("--delete", action="store_true",
+                    help="actually delete (default: report only)")
+    args = ap.parse_args(argv)
+
+    bucket = get_bucket(args.bucket)
+
+    if args.mode == "pronunciation":
+        sentences = load_corpus_sentences()
+        affected = select_pronunciation_affected(sentences)
+        logger.info("Corpus: %d sentences, %d affected by the current correction table (%.1f%%)",
+                    len(sentences), len(affected), 100.0 * len(affected) / max(len(sentences), 1))
+        prefixes = [AZURE_PREFIX]
+        if args.include_dormant_prefixes:
+            prefixes += [GEMINI_PREFIX, GOOGLE_PREFIX]
+        flagged = find_existing(bucket, affected, prefixes)
+    else:
+        flagged = select_mainland_orphans(bucket)
+
+    if args.limit:
+        flagged = flagged[: args.limit]
+
+    object_count = sum(len(f["paths"]) for f in flagged)
+    logger.info("Flagged %d cached sentence(s) / %d object(s).", len(flagged), object_count)
+    for item in flagged[:10]:
+        logger.info("  %s  %s", item["paths"], (item.get("text") or "")[:30])
+    if len(flagged) > 10:
+        logger.info("  ... and %d more (see --report for the full list)", len(flagged) - 10)
+
+    deleted: list[str] = []
+    if args.delete and flagged:
+        deleted = apply_delete(bucket, flagged)
+        logger.info("Deleted %d object(s). They re-synthesize on the next request; "
+                    "run batch_azure_tts.py to pre-warm instead.", len(deleted))
+    elif not args.delete:
+        logger.info("Dry-run (default) — pass --delete to remove these %d object(s).",
+                    object_count)
+
+    if args.report:
+        args.report.write_text(json.dumps({
+            "mode": args.mode,
+            "bucket": args.bucket,
+            "applied": bool(args.delete),
+            "flagged_sentences": len(flagged),
+            "flagged_objects": object_count,
+            "deleted_objects": deleted,
+            "items": flagged,
+        }, ensure_ascii=False, indent=2), encoding="utf-8")
+        logger.info("Report written: %s", args.report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_purge_stale_tts_cache.py
+++ b/backend/tests/test_purge_stale_tts_cache.py
@@ -71,8 +71,9 @@ def test_flags_the_words_hans_reported_and_leaves_clean_sentences_alone(purge):
         {"lesson_id": 2, "paragraph_idx": 0, "sentence_idx": 0, "text": "今天天氣很好。"},
     ]
     affected = purge.select_pronunciation_affected(rows)
+    sentences = [a["text"] for a in affected if a["unit"] == "sentence"]
 
-    assert [a["text"] for a in affected] == ["她的攻擊很凌厲。", "他發出一聲嘆息。"]
+    assert sentences == ["她的攻擊很凌厲。", "他發出一聲嘆息。"]
 
 
 def test_key_matches_the_runtime_lookup(purge):
@@ -86,9 +87,11 @@ def test_key_matches_the_runtime_lookup(purge):
 
 
 def test_polyphones_the_table_excludes_are_not_flagged(purge):
-    """摸不著 and 和 were deliberately left out — 著 has five readings, 和 six,
-    and correcting them blind fixes 摸不著 while breaking 顯著. If this ever
-    turns red, the table grew an unsafe entry, not the purger."""
+    """摸不著 needs ㄓㄠˊ, and 著 is the only character in the dictionary with
+    that reading — there is nothing to substitute, so it stays uncorrected and
+    the data file says why. (和 was in this category until #2661 found 漢 as a
+    stand-in; it is corrected now.) If this turns red, the table grew an unsafe
+    entry — the purger is the messenger."""
     rows = [
         {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "他摸不著頭緒。"},
     ]
@@ -181,6 +184,61 @@ def test_the_predicate_compares_the_exact_string_azure_is_sent(purge, monkeypatc
 
     assert _apply_phoneme_corrections(escape_for_ssml(text)) in sent["body"]
     assert "&amp;" in sent["body"] and "a & b" not in sent["body"]
+
+
+def test_paragraphs_are_rebuilt_the_way_the_player_sends_them(purge):
+    """#2662 made a paragraph one TTS request, joined as canonical.join('')
+    then trimmed. Any other join — a space, a newline — hashes to a key the
+    runtime never looks up, so the purge would delete nothing and say it did."""
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "第二句。"},
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "第一句。"},
+        {"lesson_id": 1, "paragraph_idx": 1, "sentence_idx": 0, "text": "另一段。"},
+    ]
+
+    paragraphs = purge.build_paragraph_texts(rows)
+
+    assert [p["text"] for p in paragraphs] == ["第一句。第二句。", "另一段。"]
+
+
+def test_a_paragraph_is_flagged_even_when_no_single_sentence_is(purge):
+    """The whole point of covering both units. Sentence-only selection leaves
+    the paragraph object serving the old reading, and the evidence file still
+    reads as a complete purge."""
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她很努力。"},
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "她的攻擊很凌厲。"},
+    ]
+
+    affected = purge.select_pronunciation_affected(rows)
+    units = {a["unit"] for a in affected}
+
+    assert units == {"sentence", "paragraph"}
+    assert any(a["unit"] == "paragraph" and a["text"] == "她很努力。她的攻擊很凌厲。" for a in affected)
+    # The clean sentence on its own is still not flagged — coverage widened,
+    # the filter did not loosen.
+    assert not any(a["unit"] == "sentence" and a["text"] == "她很努力。" for a in affected)
+
+
+def test_a_clean_paragraph_is_not_flagged(purge):
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "今天天氣很好。"},
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "我們去公園。"},
+    ]
+
+    assert purge.select_pronunciation_affected(rows) == []
+
+
+def test_paragraph_key_matches_the_runtime_lookup(purge):
+    from app.services.tts.normalization import _cache_key
+
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她的攻擊很凌厲。"},
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "他發出一聲嘆息。"},
+    ]
+    para = [a for a in purge.select_pronunciation_affected(rows) if a["unit"] == "paragraph"]
+
+    assert para[0]["key"] == _cache_key("她的攻擊很凌厲。他發出一聲嘆息。")
 
 
 def test_corpus_loader_skips_blank_lines_and_empty_text(purge, tmp_path):
@@ -382,7 +440,8 @@ def test_limit_caps_the_blast_radius(purge, monkeypatch):
     ])
     monkeypatch.setattr(
         purge, "select_pronunciation_affected",
-        lambda rows: [{"key": key, "text": "a"}, {"key": other, "text": "b"}],
+        lambda rows: [{"key": key, "text": "a", "unit": "sentence"},
+                      {"key": other, "text": "b", "unit": "sentence"}],
     )
 
     _run(purge, monkeypatch, bucket, ["--mode", "pronunciation", "--delete", "--limit", "1"])

--- a/backend/tests/test_purge_stale_tts_cache.py
+++ b/backend/tests/test_purge_stale_tts_cache.py
@@ -95,13 +95,92 @@ def test_polyphones_the_table_excludes_are_not_flagged(purge):
     assert purge.select_pronunciation_affected(rows) == []
 
 
-def test_selection_follows_the_live_table_not_a_copy(purge, monkeypatch):
-    """Empty the table and nothing is affected. A hardcoded word list here
-    would keep flagging sentences after the table is regenerated."""
-    monkeypatch.setattr(purge, "_has_phoneme_corrections", lambda text: False)
+def test_selection_follows_the_live_transform_not_a_copy(purge, monkeypatch):
+    """Make the transform a no-op and nothing is affected. A hardcoded word
+    list here would keep flagging sentences after the table is regenerated."""
+    monkeypatch.setattr(purge, "corrections_change_text", lambda text: False)
 
     rows = [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她的攻擊很凌厲。"}]
     assert purge.select_pronunciation_affected(rows) == []
+
+
+def test_the_he_conjunction_is_flagged(purge):
+    """#2661 added 和 → 漢 as its own branch inside _apply_phoneme_corrections,
+    not as a PHONEME_CORRECTIONS entry. Selecting on _has_phoneme_corrections
+    silently skipped every such sentence — including the one reported on L01 —
+    so this is the regression lock for asking the transform instead."""
+    rows = [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "向心力和向心加速度。"}]
+
+    affected = purge.select_pronunciation_affected(rows)
+
+    assert [a["text"] for a in affected] == ["向心力和向心加速度。"]
+
+
+def test_the_stale_predicate_would_have_missed_it(purge):
+    """States the defect as a fact, not a comment. If a future change makes
+    _has_phoneme_corrections complete again, this turns red and the test above
+    stops being interesting — that is the moment to simplify, deliberately."""
+    from app.services.tts.normalization import _has_phoneme_corrections
+
+    assert _has_phoneme_corrections("向心力和向心加速度。") is False
+    assert purge.corrections_change_text("向心力和向心加速度。") is True
+
+
+def test_he_inside_a_word_is_not_flagged(purge):
+    """和平 is ㄏㄜˊ and the exception list keeps it whole. Flagging it would
+    purge audio that is already correct — the count inflates, the bucket
+    churns, and nobody hears a difference."""
+    rows = [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "我們追求和平的生活。"}]
+
+    assert purge.select_pronunciation_affected(rows) == []
+
+
+def test_the_predicate_compares_the_exact_string_azure_is_sent(purge, monkeypatch):
+    """The point of escaping inside corrections_change_text is faithfulness:
+    it must evaluate the same bytes the synthesizer puts in the SSML body, so
+    the two can never answer different questions about the same sentence.
+
+    Asserted against the real request the provider builds, captured at the
+    urllib boundary — not against a re-implementation of the escaping here,
+    which would pass even if azure.py stopped escaping tomorrow.
+
+    Note on scope: no sentence in the shipped corpus contains an escapable
+    character, and none flips the boolean either way (verified across all 6515),
+    so this does not change which sentences get purged today. It is a lock on
+    the two paths staying identical, not a bug fix.
+    """
+    import urllib.request
+
+    from app.services.tts.normalization import (
+        _apply_phoneme_corrections,
+        escape_for_ssml,
+    )
+    from app.services.tts.providers import azure
+
+    sent = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b"audio"
+
+    def capture(req, timeout=None):
+        sent["body"] = req.data.decode("utf-8")
+        return FakeResponse()
+
+    monkeypatch.setattr(azure, "AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setattr(urllib.request, "urlopen", capture)
+
+    text = '他說「a & b」，向心力和向心加速度。'
+    azure._synthesize_azure(text)
+
+    assert _apply_phoneme_corrections(escape_for_ssml(text)) in sent["body"]
+    assert "&amp;" in sent["body"] and "a & b" not in sent["body"]
 
 
 def test_corpus_loader_skips_blank_lines_and_empty_text(purge, tmp_path):

--- a/backend/tests/test_purge_stale_tts_cache.py
+++ b/backend/tests/test_purge_stale_tts_cache.py
@@ -1,0 +1,340 @@
+"""TDD lock for backend/scripts/purge_stale_tts_cache.py (#2649 items 3 & 4a).
+
+The script deletes objects out of the production TTS bucket, so the tests that
+matter are the ones proving it deletes *only* what it flagged, and that what it
+flags is derived from the live correction table rather than a copy that can
+drift.
+
+Loaded via importlib.util (same pattern as test_audit_tts_objects.py) because
+it's a standalone script, not a package module. All tests run against fake
+Blob/Bucket doubles — never touches real GCS.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "purge_stale_tts_cache.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("purge_stale_tts_cache_under_test", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def purge():
+    return _load_module()
+
+
+class FakeBlob:
+    def __init__(self, name: str):
+        self.name = name
+        self.deleted = False
+
+    def delete(self) -> None:
+        if self.deleted:
+            from google.api_core.exceptions import NotFound
+            raise NotFound(self.name)
+        self.deleted = True
+
+
+class FakeBucket:
+    def __init__(self, names):
+        self._blobs = {n: FakeBlob(n) for n in names}
+
+    def list_blobs(self, prefix: str = ""):
+        return [b for n, b in self._blobs.items() if n.startswith(prefix)]
+
+    def blob(self, name: str):
+        return self._blobs.setdefault(name, FakeBlob(name))
+
+    def live(self):
+        return sorted(n for n, b in self._blobs.items() if not b.deleted)
+
+
+# --- selection -------------------------------------------------------------
+
+
+def test_flags_the_words_hans_reported_and_leaves_clean_sentences_alone(purge):
+    """攻擊 and 嘆息 are in the table since c53c68d3; a sentence with neither
+    must not be dragged in. Both halves matter — a selector that flags
+    everything would 'fix' the bug by re-synthesizing the whole corpus."""
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她的攻擊很凌厲。"},
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "他發出一聲嘆息。"},
+        {"lesson_id": 2, "paragraph_idx": 0, "sentence_idx": 0, "text": "今天天氣很好。"},
+    ]
+    affected = purge.select_pronunciation_affected(rows)
+
+    assert [a["text"] for a in affected] == ["她的攻擊很凌厲。", "他發出一聲嘆息。"]
+
+
+def test_key_matches_the_runtime_lookup(purge):
+    """A key computed any other way deletes nothing and reports success."""
+    from app.services.tts.normalization import _cache_key
+
+    rows = [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她的攻擊很凌厲。"}]
+    affected = purge.select_pronunciation_affected(rows)
+
+    assert affected[0]["key"] == _cache_key("她的攻擊很凌厲。")
+
+
+def test_polyphones_the_table_excludes_are_not_flagged(purge):
+    """摸不著 and 和 were deliberately left out — 著 has five readings, 和 six,
+    and correcting them blind fixes 摸不著 while breaking 顯著. If this ever
+    turns red, the table grew an unsafe entry, not the purger."""
+    rows = [
+        {"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "他摸不著頭緒。"},
+    ]
+    assert purge.select_pronunciation_affected(rows) == []
+
+
+def test_selection_follows_the_live_table_not_a_copy(purge, monkeypatch):
+    """Empty the table and nothing is affected. A hardcoded word list here
+    would keep flagging sentences after the table is regenerated."""
+    monkeypatch.setattr(purge, "_has_phoneme_corrections", lambda text: False)
+
+    rows = [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "她的攻擊很凌厲。"}]
+    assert purge.select_pronunciation_affected(rows) == []
+
+
+def test_corpus_loader_skips_blank_lines_and_empty_text(purge, tmp_path):
+    path = tmp_path / "sentences.jsonl"
+    path.write_text(
+        json.dumps({"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0, "text": "有字。"}, ensure_ascii=False)
+        + "\n\n"
+        + json.dumps({"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 1, "text": "   "}, ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert [r["text"] for r in purge.load_corpus_sentences(path)] == ["有字。"]
+
+
+def test_the_real_corpus_is_reachable_and_has_affected_sentences(purge):
+    """Positive control against the shipped data. Without it every other test
+    here passes on fixtures while the script points at a path that moved."""
+    sentences = purge.load_corpus_sentences()
+    affected = purge.select_pronunciation_affected(sentences)
+
+    assert len(sentences) > 6000
+    assert 0 < len(affected) < len(sentences), "table fires on none, or on everything"
+
+
+# --- what exists in the bucket --------------------------------------------
+
+
+def test_only_cached_sentences_are_flagged(purge):
+    """A sentence with a wrong reading but no cached object needs no delete —
+    it already synthesizes fresh."""
+    cached = purge._cache_key("她的攻擊很凌厲。")
+    uncached = purge._cache_key("他發出一聲嘆息。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{cached}.mp3"])
+
+    hits = purge.find_existing(
+        bucket,
+        [{"key": cached, "text": "她的攻擊很凌厲。"}, {"key": uncached, "text": "他發出一聲嘆息。"}],
+        [purge.AZURE_PREFIX],
+    )
+
+    assert [h["key"] for h in hits] == [cached]
+    assert hits[0]["paths"] == [f"{purge.AZURE_PREFIX}/{cached}.mp3"]
+
+
+def test_dormant_prefixes_are_left_out_unless_asked_for(purge):
+    """With cross-prefix read-through gone (abad95d7) only the azure copy can
+    reach a student. Deleting the others by default would throw away cache for
+    no listener-visible gain."""
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([
+        f"{purge.AZURE_PREFIX}/{key}.mp3",
+        f"{purge.GEMINI_PREFIX}/{key}.mp3",
+        f"{purge.GOOGLE_PREFIX}/{key}.mp3",
+    ])
+    cand = [{"key": key, "text": "她的攻擊很凌厲。"}]
+
+    default_only = purge.find_existing(bucket, cand, [purge.AZURE_PREFIX])
+    all_three = purge.find_existing(
+        bucket, cand, [purge.AZURE_PREFIX, purge.GEMINI_PREFIX, purge.GOOGLE_PREFIX]
+    )
+
+    assert default_only[0]["paths"] == [f"{purge.AZURE_PREFIX}/{key}.mp3"]
+    assert len(all_three[0]["paths"]) == 3
+
+
+def test_non_mp3_objects_are_ignored(purge):
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{key}.txt"])
+
+    assert purge.find_existing(bucket, [{"key": key, "text": "x"}], [purge.AZURE_PREFIX]) == []
+
+
+# --- mainland orphans ------------------------------------------------------
+
+
+def test_orphans_are_google_objects_with_no_azure_twin(purge):
+    """The 2026-08-08 outage wrote mainland-accent audio for sentences azure
+    never got. Those are the hazard."""
+    bucket = FakeBucket([
+        f"{purge.GOOGLE_PREFIX}/orphan.mp3",
+        f"{purge.GOOGLE_PREFIX}/shared.mp3",
+        f"{purge.AZURE_PREFIX}/shared.mp3",
+    ])
+
+    orphans = purge.select_mainland_orphans(bucket)
+
+    assert [o["key"] for o in orphans] == ["orphan"]
+
+
+def test_a_google_object_shadowed_by_azure_is_kept(purge):
+    """azure wins the lookup, so the google copy is dormant history. Deleting
+    it is not this script's call — it is not reaching anyone."""
+    bucket = FakeBucket([
+        f"{purge.GOOGLE_PREFIX}/shared.mp3",
+        f"{purge.AZURE_PREFIX}/shared.mp3",
+    ])
+
+    assert purge.select_mainland_orphans(bucket) == []
+
+
+# --- deleting --------------------------------------------------------------
+
+
+def test_delete_removes_exactly_the_flagged_paths(purge):
+    """The negative half is the point: an unflagged object in the same prefix
+    must survive. A prefix sweep would pass a 'did it delete' test and wipe
+    the bucket."""
+    bucket = FakeBucket([
+        f"{purge.AZURE_PREFIX}/flagged.mp3",
+        f"{purge.AZURE_PREFIX}/innocent.mp3",
+    ])
+
+    deleted = purge.apply_delete(bucket, [{"paths": [f"{purge.AZURE_PREFIX}/flagged.mp3"]}])
+
+    assert deleted == [f"{purge.AZURE_PREFIX}/flagged.mp3"]
+    assert bucket.live() == [f"{purge.AZURE_PREFIX}/innocent.mp3"]
+
+
+def test_already_deleted_object_is_not_an_error(purge):
+    """Second run, or a concurrent partial delete."""
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/gone.mp3"])
+    bucket.blob(f"{purge.AZURE_PREFIX}/gone.mp3").delete()
+
+    deleted = purge.apply_delete(bucket, [{"paths": [f"{purge.AZURE_PREFIX}/gone.mp3"]}])
+
+    assert deleted == []
+
+
+# --- the CLI contract ------------------------------------------------------
+
+
+def _run(purge, monkeypatch, bucket, argv):
+    monkeypatch.setattr(purge, "get_bucket", lambda name: bucket)
+    monkeypatch.setattr(
+        purge, "load_corpus_sentences",
+        lambda *a, **k: [{"lesson_id": 1, "paragraph_idx": 0, "sentence_idx": 0,
+                          "text": "她的攻擊很凌厲。"}],
+    )
+    return purge.main(argv)
+
+
+def test_dry_run_is_the_default(purge, monkeypatch):
+    """The most important test in the file. Nothing is destroyed by a plain
+    invocation — you have to ask."""
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{key}.mp3"])
+
+    assert _run(purge, monkeypatch, bucket, ["--mode", "pronunciation"]) == 0
+    assert bucket.live() == [f"{purge.AZURE_PREFIX}/{key}.mp3"]
+
+
+def test_delete_flag_actually_deletes(purge, monkeypatch):
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{key}.mp3"])
+
+    assert _run(purge, monkeypatch, bucket, ["--mode", "pronunciation", "--delete"]) == 0
+    assert bucket.live() == []
+
+
+def test_cli_default_purges_only_the_serving_prefix(purge, monkeypatch):
+    """The unit test above proves find_existing() can be narrowed; this proves
+    main() actually narrows it. Without this, widening the default to all three
+    prefixes passes every other test in the file."""
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([
+        f"{purge.AZURE_PREFIX}/{key}.mp3",
+        f"{purge.GEMINI_PREFIX}/{key}.mp3",
+        f"{purge.GOOGLE_PREFIX}/{key}.mp3",
+    ])
+
+    _run(purge, monkeypatch, bucket, ["--mode", "pronunciation", "--delete"])
+
+    assert bucket.live() == [f"{purge.GEMINI_PREFIX}/{key}.mp3", f"{purge.GOOGLE_PREFIX}/{key}.mp3"]
+
+
+def test_cli_can_opt_into_the_dormant_prefixes(purge, monkeypatch):
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([
+        f"{purge.AZURE_PREFIX}/{key}.mp3",
+        f"{purge.GEMINI_PREFIX}/{key}.mp3",
+        f"{purge.GOOGLE_PREFIX}/{key}.mp3",
+    ])
+
+    _run(purge, monkeypatch, bucket,
+         ["--mode", "pronunciation", "--delete", "--include-dormant-prefixes"])
+
+    assert bucket.live() == []
+
+
+def test_limit_caps_the_blast_radius(purge, monkeypatch):
+    """For a small first pass — listen to a handful before committing to the
+    whole set."""
+    key = purge._cache_key("她的攻擊很凌厲。")
+    other = "deadbeef"
+    bucket = FakeBucket([
+        f"{purge.AZURE_PREFIX}/{key}.mp3",
+        f"{purge.AZURE_PREFIX}/{other}.mp3",
+    ])
+    monkeypatch.setattr(
+        purge, "select_pronunciation_affected",
+        lambda rows: [{"key": key, "text": "a"}, {"key": other, "text": "b"}],
+    )
+
+    _run(purge, monkeypatch, bucket, ["--mode", "pronunciation", "--delete", "--limit", "1"])
+
+    assert bucket.live() == [f"{purge.AZURE_PREFIX}/{other}.mp3"]
+
+
+def test_report_names_every_deleted_object(purge, monkeypatch, tmp_path):
+    """Evidence, per the project's fail-closed rule: a run that claims success
+    has to say what it removed."""
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{key}.mp3"])
+    report = tmp_path / "report.json"
+
+    _run(purge, monkeypatch, bucket,
+         ["--mode", "pronunciation", "--delete", "--report", str(report)])
+
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["applied"] is True
+    assert data["deleted_objects"] == [f"{purge.AZURE_PREFIX}/{key}.mp3"]
+    assert data["items"][0]["text"] == "她的攻擊很凌厲。"
+
+
+def test_dry_run_report_records_that_nothing_was_applied(purge, monkeypatch, tmp_path):
+    key = purge._cache_key("她的攻擊很凌厲。")
+    bucket = FakeBucket([f"{purge.AZURE_PREFIX}/{key}.mp3"])
+    report = tmp_path / "report.json"
+
+    _run(purge, monkeypatch, bucket, ["--mode", "pronunciation", "--report", str(report)])
+
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["applied"] is False
+    assert data["deleted_objects"] == []
+    assert data["flagged_objects"] == 1


### PR DESCRIPTION
Closes #2655 item 1 & 2 ｜ #2649 item 3 & 4a

## 為什麼需要這個

c53c68d3 重建了台灣讀音校正表、#2661 又修了連接詞 `和`，Hans 報的字現在都會被正確合成。
**但那只改變「之後合成會產生什麼」，不動 bucket 裡已經存在的任何一個 byte。**

cache key 是 `sha256(送出去的文字)`，校正是在合成當下以 SSML `<sub>` 套用的 →
校正改了、key 沒改 → 舊物件永遠贏得查表。**刪掉物件是這個快取唯一的失效機制。**

## 數字：**1306 個 key**

```
corpus              : 6515 sentences in 705 paragraphs
affected keys       : 1306 unique
  sentence unit     : 952
  paragraph unit    : 354   (50% 的段落)
distinct lessons    : 162
```

這個數字在本 PR 期間改過三次，**每一次都是修掉一個選法缺陷，不是重新估算**：

| 版本 | 數字 | 為什麼是錯的 |
|---|---|---|
| #2649 原文 | 253 句 | 對的是 #2648 那版舊表 |
| 本 PR 初版 | 591 句 | 用 `_has_phoneme_corrections`（只查表）|
| 第二版 | 973 句 | 只列舉句子；且 key 未去重 |
| **現在** | **1306 key** | 句子 + 段落兩種粒度，key 去重 |

## 選誰刪：問「合成會不會改寫它」，不是問「表裡有沒有」

`corrections_change_text(text)` = `escape → apply → 比對前後不同`。

初版用 `_has_phoneme_corrections`（只查 `PHONEME_CORRECTIONS`）。#2661 把 `和` 那條規則加成
`_apply_phoneme_corrections` 裡的**獨立分支**、不是表的一筆，於是那個述詞對「合成器明明會改寫」的句子回答 `False` ——
**漏掉 382 句，含 L01 的「和」向心力，正是被回報的句子之一**。

改問 transform 之後，未來任何規則加在那個 pass 的任何位置都自動涵蓋，不用再回來改這支。

## 兩種粒度都要列舉

#2662 把合成單位改成**整段一次請求**（逐句會讓 pitch contour 每句重設，聽起來像唸清單），
#2663 又讓 prefetch 跟著抓整段。cache key 是 `sha256(送出的文字)`，所以段落物件與句子物件**並存**。

只列句子 = 同一種漏法往上一個單位：跑完顯示完成，段落物件仍在送舊讀音。
段落文字用 `canonical.join('').trim()` 重建 —— `ttsApi.ts` 送的就是這個。
用空白或換行 join 會 hash 出沒人查的 key，刪 0 筆然後回報成功。

> 連續兩次同一個根因：**選法必須跟著 runtime 實際會請求的東西走，而那不是常數。**

其餘兩個「不猜」的來源不變：

- 候選來自 `sentences.v2.jsonl` —— `build_lesson_tts_mapping()` 服務時讀的**同一份** corpus
- key 用同一個 `_cache_key`。用別的方法算 → 刪不到東西，然後回報成功

bucket 裡只有 sha256 檔名、反推不回文字，所以「從 corpus 推導」是唯一可稽核的作法。

## 第二個 mode：中國腔孤兒（item 4a）

列出 google prefix 中**沒有 azure 對應**的物件 —— 2026-08-08 Azure 掛掉那次寫進去的 22 句。
abad95d7 已經讓它們不再被送出，這裡是把物件本身移除，免得 provider 切換或哪天交叉回讀被加回來就復活。

**兩個 prefix 都有的物件不動**：azure 贏得查表，google 那份是休眠的歷史，不是活的危害。

## 刪除是 opt-in，而且窄

| 保護 | 行為 |
|---|---|
| 預設 dry-run | 不加 `--delete` 什麼都不會消失 |
| `--limit N` | 先小規模跑一批、聽過再決定要不要全上 |
| `--report x.json` | 寫出 evidence 檔，逐一列出刪了哪些物件 |
| 只碰 azure prefix | 交叉回讀已移除，其他 prefix 的複本碰不到學生。要刪要明確加 `--include-dormant-prefixes` |
| `apply_delete` 不自己選 | 只刪呼叫端已 flag 的路徑，永遠不做 prefix sweep |
| key 去重 | 回報的數字等於實際物件數 —— 對不上刪除數的計數沒人能查核 |

## 一併搬動的東西

`escape_for_ssml` 從 Azure provider 的 inline 區塊搬到 `normalization.py`，放在文件上就吃它輸出的
`_apply_phoneme_corrections` 旁邊。述詞必須跟 provider 用同一種 escape，否則回答的是沒人問的問題；
兩份五行 `.replace()` 必然漂移。

**誠實話**：escaping 今天不是 load-bearing —— 語料裡沒有任何一句含 escapable 字元，
也沒有任何一句會因此翻轉布林值（6515 句全查）。所以測試不假裝涵蓋它，而是斷言真正可驗證且要緊的事：
**述詞算的字串就是 azure 送出去的那段**，在 urllib 邊界攔請求驗，不是在測試裡重寫一份 escape。

## 測試

**28 個**，全跑 fake bucket double / fake urllib，**不碰真實 GCS、不發真實請求**。

| Mutation | 結果 |
|---|---|
| 改成預設就刪 | 2 紅 |
| `apply_delete` 改成 prefix sweep | 2 紅 |
| 預設 prefix 擴成三個 | 1 紅 |
| 每一句都 flag | 3 紅 |
| 選法改回查表述詞 | 4 紅 |
| provider 不再 escape | 1 紅 |
| 拿掉段落候選 | 2 紅 |
| 段落改用空白 join | 3 紅 |
| join 前不按 `sentence_idx` 排序 | 1 紅 |
| `corrections_change_text` 內拿掉 escape | 綠 —— equivalent mutant，docstring 已標明 |

最重要的仍是 dry-run 那個：**單純呼叫不會毀掉任何東西，你得主動要求。**

`get_bucket()` 是刻意留的 seam。第一版用 patch `sys.modules`，單獨跑綠、`pytest -k tts` 紅 ——
只要 session 內有別的測試 import 過真的 `google.cloud.storage`，`from google.cloud import storage`
就會走 package attribute 繞過 cache。現在兩種順序都驗過。

```
backend $ pytest tests/test_purge_stale_tts_cache.py -q
28 passed

backend $ pytest tests/ -k "tts or phoneme or pronunciation or he_conj" -q
6 failed, 227 passed, 5 skipped, 4 errors
```

**那 6 failed / 4 errors 是既有的**（rate-limit / regenerate / tts_auth 的 order pollution），
有沒有本 PR 完全相同。spec CI：gate 1 OK、gate 2 `751 passed / 4 xfailed`、
gate 3 `32 failed / 57 errors`（此容器無 DB，有沒有本 PR 一樣）。

GitHub CI（head `b4fe2004`）：Backend Tests ✅、Spec registry + contracts + legacy_tests ✅、
Deploy PR Preview ✅、pip-audit ✅、Gitleaks ✅、GitGuardian ✅、detect-changes ✅。
`Frontend npm audit` / `Audit summary` ❌ = **#2582 既有問題**，本 PR 沒動 `frontend/`。

## ⚠️ 這個 PR 沒有刪任何東西

script 還沒跑過 —— 這個容器沒有 GCS 憑證。merge 之後要有人在有 `gcloud` 的環境執行：

```bash
set -a; source backend/.env; set +a

# 先看要刪什麼
python backend/scripts/purge_stale_tts_cache.py --mode pronunciation

# 小規模試水溫，聽過再說
python backend/scripts/purge_stale_tts_cache.py --mode pronunciation --delete --limit 20

# 全上，留 evidence
python backend/scripts/purge_stale_tts_cache.py --mode pronunciation \
    --delete --report /tmp/purge-pronunciation.json
python backend/scripts/purge_stale_tts_cache.py --mode mainland-orphans \
    --delete --report /tmp/purge-orphans.json
```

刪完是 lazy 重合成（第一個聽到的人付延遲）。要 pre-warm 就接著跑 `batch_azure_tts.py`。
evidence JSON 請貼回 #2655。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169GC8yMtogKe3pVeYjTbxx