### PR TITLE
docs(#2649): 多音字為什麼修不了 — 查證結果與判斷交給你

### DIFF
--- a/backend/data/tts/taiwan_pronunciation.json
+++ b/backend/data/tts/taiwan_pronunciation.json
@@ -1858,5 +1858,27 @@
    "why": "教育部單讀音，但找不到同讀音且夠常見的單讀音替身字"
   }
  ],
- "_not_covered": "多音字不在此表：正確讀音要看上下文，而這張表看不到上下文。Hans 回報的 摸不著(ㄓㄠˊ) 與 和(連接詞讀ㄏㄢˋ) 屬此類，需要另一種機制。"
+ "_not_covered": "多音字（著、和…）無法用這張表修：正確讀音要看上下文，而這張表看不到上下文。Hans 2026-08-09 回報的 摸不著(ㄓㄠˊ) 與 和(連接詞讀ㄏㄢˋ) 屬此類。",
+ "_polyphone_mechanisms_tested": {
+  "date": "2026-08-10",
+  "verdict": "以目前的語音 zh-TW-HsiaoChenNeural，沒有可用的 markup 手段",
+  "results": [
+   {
+    "mechanism": "<sub alias>",
+    "works": true,
+    "why_not_enough": "需要一個同音同調的單讀音替身字。ㄓㄠˊ 在中文裡幾乎只有『著』本身，找不到替身"
+   },
+   {
+    "mechanism": "<phoneme alphabet=sapi|ipa|x-sampa>",
+    "works": false,
+    "evidence": "zh-TW-HsiaoChenNeural 一律回 HTTP 400；同一段 markup 換成 zh-CN-XiaoxiaoNeural 就成功（55872B）。與 xml:lang 無關（zh-TW/zh-CN 都試過）→ 是語音本身不支援，不是我們送錯格式"
+   },
+   {
+    "mechanism": "<lexicon uri>",
+    "works": null,
+    "evidence": "SSML 接受這個元素（不會 400），但指向不存在的 URL 時輸出與無 lexicon 位元組相同 → Azure 靜默忽略。尚未用真實託管的 PLS 檔驗證是否真的生效"
+   }
+  ],
+  "if_this_matters": "要修多音字就得換語音（zh-CN 系列支援 <phoneme>，但那是中國腔，2026-04 已否決），或接受由人工逐句改寫文字。"
+ }
 }


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

`摸不著` 和 `和` 原本只寫「不涵蓋」，沒說是**做不到**還是**還沒做**。實測後是前者，現在檔案裡寫明是哪一種、憑什麼這樣說。

| 手段 | 可行？ | 證據 |
|---|---|---|
| `<sub alias>` | 部分 | 需要同音**同調**的單讀音替身字。ㄓㄠˊ 在中文裡幾乎只有「著」本身，沒有東西可以替 |
| `<phoneme>` | ❌ | `zh-TW-HsiaoChenNeural` 對 sapi / ipa / x-sampa 一律 **HTTP 400**；同一段 markup 換 `zh-CN-XiaoxiaoNeural` 就成功（55872B）。`xml:lang` 換 zh-TW / zh-CN 都試過 → **是語音本身不支援**，不是我們送錯格式 |
| `<lexicon uri>` | 未知 | SSML 接受這個元素（不會 400），但指向不存在的 URL 時輸出與不帶 lexicon **位元組完全相同** → Azure 靜默忽略。真實託管的 PLS 檔會不會生效**尚未驗證**，檔案裡照實寫「未驗證」而不是寫成「已排除」 |

**結論**：用現在這個聲音，多音字沒有任何 markup 路可走。要改就得換語音 —— 而支援 `<phoneme>` 的 zh-CN 系列正是 2026-04 已經否決的中國腔。這個取捨是你的決定，所以我把它寫進檔案而不是默默讓兩個詞繼續錯。

順帶清掉那個測寫入權限留下的殘檔。先前說「刪不掉」是我判斷錯：CLI 的 rm 會先做 objects.get 才失敗，而我的角色是 bucket 級的 legacyBucketOwner，含刪除但不含 get —— 直接呼叫 delete 就過了。已用 positive control 確認查法有效後驗證殘留為 0。

`8 tests green`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
