### PR TITLE
fix(#2649): 段落 QR 掃進去不再撞登入牆

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -78,4 +78,6 @@ jobs:
             src/components/reading-steps/FullTextAnnotate.hideAnnotation.test.tsx \
             src/hooks/useFullTextTtsQueue.test.ts \
             src/services/ttsApi.prefetch.test.ts \
-            src/pages/admin/lesson-audio/paragraphGap.test.ts
+            src/pages/admin/lesson-audio/paragraphGap.test.ts \
+            src/pages/GuestReadingPage.passage.test.tsx \
+            src/components/auth/publicSteps.test.ts

--- a/frontend/src/components/auth/LearningRouteGate.test.tsx
+++ b/frontend/src/components/auth/LearningRouteGate.test.tsx
@@ -75,8 +75,16 @@ describe('LearningRouteGate', () => {
       expect(await screen.findByText('GUEST-READER')).toBeInTheDocument();
     });
 
+    it('opens key-passage-reading too — the 段落 QR points there', async () => {
+      // It used to redirect, which made the second code on every printed
+      // worksheet useless. The step both plays the passage and records the
+      // student; anonymous visitors get the listening half only, and the guest
+      // reader is what enforces that (see GuestReadingPage.passage.test.tsx).
+      renderAt('/learn/1/key-passage-reading');
+      expect(await screen.findByText('GUEST-READER')).toBeInTheDocument();
+    });
+
     it.each([
-      ['key-passage-reading', 'recording is scored against a user'],
       ['character-practice', 'writes practice results'],
       ['report', 'shows one specific student’s data'],
       ['lesson-intro', 'not the step the QR code targets'],

--- a/frontend/src/components/auth/publicSteps.test.ts
+++ b/frontend/src/components/auth/publicSteps.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Which learning steps a QR-code visitor may open.
+ *
+ * The paper worksheets carry two codes: one for the whole text and one for the
+ * 念順順 key passage. The whole-text one worked anonymously; the passage one
+ * walked straight into a login box, which makes it useless on paper.
+ *
+ * The owner's rule is 聽=免登入, 練習=要登入, and the passage step is both — it
+ * plays the passage *and* records the student reading it. So the step opens
+ * anonymously in a listen-only form; the recording half stays behind the login.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { isPublicLearningStep, PUBLIC_LEARNING_STEPS } from '../../config/stepConfig';
+
+describe('isPublicLearningStep', () => {
+  it('opens both steps a QR code can point at', () => {
+    expect(isPublicLearningStep('full-text-annotate')).toBe(true);
+    expect(isPublicLearningStep('key-passage-reading')).toBe(true);
+  });
+
+  it('accepts the legacy ids still printed on paper', () => {
+    expect(isPublicLearningStep('reading-annotation')).toBe(true);
+    expect(isPublicLearningStep('full-reading')).toBe(true);
+  });
+
+  it.each([
+    ['character-practice', 'writes practice results'],
+    ['dictation', 'writes練習 results'],
+    ['report', "shows one student's own data"],
+    ['comprehension', 'answers are scored against a user'],
+    ['lesson-intro', 'no QR code points here'],
+    ['paragraph-reading', 'disabled step, records audio'],
+  ])('keeps %s private (%s)', (step) => {
+    expect(isPublicLearningStep(step)).toBe(false);
+  });
+
+  it('stays small — every entry needs the 聽=免登入 argument made for it', () => {
+    // A guard against the set quietly growing. Adding one is a decision about
+    // what an anonymous visitor may reach, not a config tweak.
+    expect(PUBLIC_LEARNING_STEPS.size).toBe(2);
+  });
+});

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -427,7 +427,14 @@ export function resolveStepId(id: string): string {
  *
  * Keep this set at one entry unless the same argument can be made again.
  */
-export const PUBLIC_LEARNING_STEPS: ReadonlySet<string> = new Set(['full-text-annotate']);
+export const PUBLIC_LEARNING_STEPS: ReadonlySet<string> = new Set([
+  'full-text-annotate',
+  // The 念順順 passage. Its own step both plays the passage and records the
+  // student reading it, so anonymous visitors get a listen-only view of it —
+  // the recording half still needs an account to belong to. Without this the
+  // 段落 QR printed on the worksheet walked straight into a login box.
+  'key-passage-reading',
+]);
 
 /** True when `id` (canonical or legacy) is openable without logging in. */
 export function isPublicLearningStep(id: string): boolean {

--- a/frontend/src/pages/GuestReadingPage.passage.test.tsx
+++ b/frontend/src/pages/GuestReadingPage.passage.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * The guest reader has to serve both codes on the worksheet.
+ *
+ * 全文 QR  → /learn/{id}/full-text-annotate   — the whole lesson
+ * 段落 QR  → /learn/{id}/key-passage-reading  — just the 念順順 passage
+ *
+ * The second one used to hit a login box, which makes a printed QR code
+ * useless. Both now land on this page; what differs is how much text it shows.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const STORY = {
+  id: '1',
+  title: '贏得喝采的輸家',
+  content: ['第一段落的文字。', '第二段落的文字。', '第三段落的文字。'],
+  keyReading: { passage: '第二段落的文字。' },
+  vocabulary: [],
+  images: [],
+  grade: 4,
+  level: 4,
+  category: 'story',
+};
+
+vi.mock('../services/api', () => ({ fetchStory: vi.fn(async () => STORY) }));
+vi.mock('../context/ZhuyinContext', () => ({
+  useZhuyin: () => ({ isZhuyinAny: false, zhuyinActive: false, processLinesSelective: (l: string[]) => l }),
+}));
+vi.mock('../hooks/useFullTextTtsQueue', () => ({
+  useFullTextTtsQueue: () => ({
+    currentParagraphIdx: null, isPlaying: false, isPaused: false,
+    play: vi.fn(), pause: vi.fn(), resume: vi.fn(), stop: vi.fn(),
+  }),
+}));
+
+import GuestReadingPage from './GuestReadingPage';
+
+function renderAt(step: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/learn/1/${step}`]}>
+      <Routes>
+        {/* Mirrors the real tree: the gate renders this page on the PARENT
+            route, so `step` is not a param — the page has to read the path. A
+            child-route wrapper here would let a broken lookup pass. */}
+        <Route path="/learn/:storyId/*" element={<GuestReadingPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('GuestReadingPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the whole lesson for the 全文 code', async () => {
+    renderAt('full-text-annotate');
+    await waitFor(() => expect(screen.getByText(/第一段落的文字/)).toBeInTheDocument());
+    expect(screen.getByText(/第三段落的文字/)).toBeInTheDocument();
+  });
+
+  it('shows only the passage for the 段落 code', async () => {
+    renderAt('key-passage-reading');
+    await waitFor(() => expect(screen.getByText(/第二段落的文字/)).toBeInTheDocument());
+    // The paragraphs either side of the passage must not be there — showing the
+    // whole lesson would make the two codes indistinguishable, which is how the
+    // admin panel's 全文/段落 buttons went wrong before.
+    expect(screen.queryByText(/第一段落的文字/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/第三段落的文字/)).not.toBeInTheDocument();
+  });
+
+  it('offers a player in both modes — listening is the point of the QR code', async () => {
+    renderAt('key-passage-reading');
+    await waitFor(() => expect(screen.getByTestId('reading-player')).toBeInTheDocument());
+  });
+
+  it('never offers the recording practice to someone who cannot be scored', async () => {
+    renderAt('key-passage-reading');
+    await waitFor(() => screen.getByTestId('reading-player'));
+    expect(screen.queryByText(/開始朗讀|開始錄音/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/GuestReadingPage.tsx
+++ b/frontend/src/pages/GuestReadingPage.tsx
@@ -25,14 +25,19 @@
  * drift.
  */
 import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, useLocation, Link } from 'react-router-dom';
 
 import ReadingAnnotation from '../components/reading-steps/FullTextAnnotate';
+import { resolveStepId } from '../config/stepConfig';
 import { fetchStory } from '../services/api';
 import type { Story } from '../types';
 
 const GuestReadingPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
+  // The step is NOT a route param here. The gate that renders this page sits on
+  // /learn/:storyId, so the step is the third path segment — read it from the
+  // location, exactly as LearningRouteGate does when deciding to render us.
+  const step = useLocation().pathname.split('/')[3] ?? '';
   const [story, setStory] = useState<Story | null>(null);
   const [failed, setFailed] = useState(false);
 
@@ -71,6 +76,15 @@ const GuestReadingPage: React.FC = () => {
     );
   }
 
+  // The worksheet carries two codes and they must not show the same thing.
+  // 段落 shows only the 念順順 passage; 全文 shows the lesson. When a lesson has
+  // no passage recorded, the passage code falls back to the whole text rather
+  // than showing an empty page.
+  const wantsPassage = resolveStepId(step) === 'key-passage-reading';
+  const passage = story.keyReading?.passage?.trim();
+  const shown: Story =
+    wantsPassage && passage ? { ...story, content: [passage] } : story;
+
   return (
     <div className="min-h-screen bg-surface" data-testid="guest-reading-page">
       {/* Top bar — the player lives here so it stays reachable while reading. */}
@@ -80,7 +94,9 @@ const GuestReadingPage: React.FC = () => {
             <h1 className="font-headline font-bold text-lg text-on-surface truncate">
               {story.title}
             </h1>
-            <p className="text-xs text-on-surface-variant">課文朗讀</p>
+            <p className="text-xs text-on-surface-variant">
+              {wantsPassage && passage ? '重點段落朗讀' : '課文朗讀'}
+            </p>
           </div>
 
           <div className="flex items-center gap-3 shrink-0">
@@ -94,7 +110,7 @@ const GuestReadingPage: React.FC = () => {
         </div>
       </div>
 
-      <ReadingAnnotation story={story} onFinish={() => {}} hideAnnotation />
+      <ReadingAnnotation story={shown} onFinish={() => {}} hideAnnotation />
     </div>
   );
 };


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

每張學習單上印兩個 QR：**全文**那個掃得進去，**段落**那個掃進去是登入畫面 —— 對一個坐在位子上、沒有帳號也沒辦法申請的學生來說，那個碼等於沒有。

規格是「**聽=免登入、練習=要登入**」，但先前只套用到兩個碼裡的一個。

## 改了什麼

`key-passage-reading` 現在同樣以**只能聽**的形式公開：訪客看到念順順的重點段落、可以播放；錄音與評分那一半維持原樣，留在登入牆後面。

段落頁只顯示**重點段**、不是整課，所以兩個碼掃出來的東西仍然不同（避免重蹈後台「全文跟段落一樣」的覆轍）。沒有登錄重點段的課，段落碼退回顯示全文，而不是給一個空白頁。

## 一個值得記下來的陷阱

這一頁的 step **不是 route param**。gate 掛在 `/learn/:storyId`，所以 `useParams` 只有 `storyId`，用它讀 step 會**靜默拿到 undefined** —— 結果每個訪客都會拿到全文模式，而測試照樣全綠，因為我第一版測試把頁面包在一個真實路由樹裡並不存在的子路由底下。

現在頁面用跟 gate 同一個方式讀路徑，測試也改成鏡射真實結構。

## 驗證

Mutation 三個，各自都紅：關掉段落模式、把 step 查詢清空、段落模式回傳整課。

`lint 0 errors` · `vite build ✓` · `151 tests green`（新增兩支已釘進 CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
