### PR TITLE
perf(#2627): 段落一次合成 — 修的是語調不是時間

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -80,4 +80,5 @@ jobs:
             src/services/ttsApi.prefetch.test.ts \
             src/pages/admin/lesson-audio/paragraphGap.test.ts \
             src/pages/GuestReadingPage.passage.test.tsx \
-            src/components/auth/publicSteps.test.ts
+            src/components/auth/publicSteps.test.ts \
+            src/services/ttsApi.paragraph.test.ts

--- a/frontend/src/services/ttsApi.paragraph.test.ts
+++ b/frontend/src/services/ttsApi.paragraph.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A paragraph is synthesized as one request, not sentence by sentence.
+ *
+ * Measured, and it inverts the obvious theory. Splitting a paragraph into
+ * sentences and playing the clips back to back costs almost nothing in timing:
+ *
+ *   one request for three sentences   5.33 s
+ *   three clips concatenated          5.50 s   (+84 ms per seam)
+ *
+ * and the pause it produces (763 ms) is if anything shorter than the pause
+ * Azure renders itself between two sentences in one request (873–883 ms). So
+ * the choppiness the owner hears is not gaps, and trimming the 665 ms of
+ * padding Azure appends — which I had already built — would have made the
+ * reading more rushed, not smoother.
+ *
+ * What per-sentence synthesis actually loses is prosody. Each clip is generated
+ * in isolation, so the pitch contour resets at every sentence: no declination
+ * across the paragraph, no anticipation of what follows. It sounds like a list
+ * of sentences rather than someone reading. Only a larger synthesis unit fixes
+ * that.
+ *
+ * Paragraph rather than whole lesson: a paragraph boundary is a place a pause
+ * belongs, one paragraph can be regenerated without invalidating the rest, and
+ * the highlight already tracks paragraphs — one clip now maps to exactly one
+ * highlighted block.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const PARAGRAPH = '第一句話。第二句話。第三句話。';
+let synthesized: string[] = [];
+
+function installMocks() {
+  synthesized = [];
+  global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes('/api/tts/mapping/')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          lesson_id: 1,
+          paragraphs: [{
+            index: 0,
+            sentences: [
+              { text: '第一句話。', hash: 'h0', chars: 5 },
+              { text: '第二句話。', hash: 'h1', chars: 5 },
+              { text: '第三句話。', hash: 'h2', chars: 5 },
+            ],
+          }],
+        }),
+      } as unknown as Response;
+    }
+    const body = JSON.parse(String(init?.body ?? '{}'));
+    if (body.text) synthesized.push(body.text);
+    return {
+      ok: true, status: 200,
+      headers: { get: () => null },
+      blob: async () => ({ size: 64 }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+
+  global.URL.createObjectURL = vi.fn(() => 'blob:stub');
+  global.URL.revokeObjectURL = vi.fn();
+
+  class StubAudio {
+    src = '';
+    currentTime = 0;
+    paused = false;
+    onended: (() => void) | null = null;
+    private h: Record<string, Array<() => void>> = {};
+    constructor(src?: string) { this.src = src ?? ''; }
+    addEventListener(ev: string, fn: () => void) { (this.h[ev] ||= []).push(fn); }
+    removeEventListener() {}
+    pause() { this.paused = true; }
+    play() {
+      // Finish immediately so the walk runs to completion inside the test.
+      queueMicrotask(() => { (this.h.ended || []).forEach((f) => f()); this.onended?.(); });
+      return Promise.resolve();
+    }
+  }
+  vi.stubGlobal('Audio', StubAudio as unknown as typeof Audio);
+}
+
+describe('paragraph-level synthesis', () => {
+  beforeEach(() => { vi.resetModules(); installMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+  it('sends the paragraph as a single request', async () => {
+    const { speakText } = await import('./ttsApi');
+    await speakText(PARAGRAPH, 1, 0);
+
+    const paragraphRequests = synthesized.filter((t) => t === PARAGRAPH);
+    expect(paragraphRequests).toHaveLength(1);
+  });
+
+  it('does not send the sentences individually', async () => {
+    const { speakText } = await import('./ttsApi');
+    await speakText(PARAGRAPH, 1, 0);
+
+    // The mapping's sentences must not become separate synthesis calls — that
+    // is the prosody reset this change exists to remove.
+    for (const sentence of ['第一句話。', '第二句話。', '第三句話。']) {
+      expect(synthesized).not.toContain(sentence);
+    }
+  });
+
+  it('still splits when there is no lesson context to address', async () => {
+    // Ad-hoc text (a definition, a hint) has no paragraph to synthesize as a
+    // unit, and long text has to be chunked to stay inside the request limit.
+    const { speakText } = await import('./ttsApi');
+    await speakText('第一句話。第二句話。');
+
+    expect(synthesized.length).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -406,10 +406,22 @@ async function _speakViaBackend(
 ): Promise<void> {
   let sentences: string[];
 
-  // Prefer canonical v2 sentences to guarantee GCS cache hits (Issue #1208).
+  // A paragraph is one synthesis unit, not a list of sentences.
+  //
+  // Splitting it costs almost nothing in timing — measured, three sentences as
+  // one request run 5.33 s against 5.50 s concatenated, and the resulting pause
+  // (763 ms) is shorter than the one Azure renders itself between sentences in
+  // a single request (873–883 ms). What splitting loses is prosody: each clip
+  // is generated in isolation, so the pitch contour resets at every sentence
+  // and the reading sounds like a list rather than someone reading aloud.
+  //
+  // The canonical sentence list is still fetched, but only to reconstruct the
+  // paragraph exactly as the backend split it, so the text sent matches the
+  // text the mapping describes.
   if (lessonId !== undefined && paragraphIdx !== undefined) {
     const canonical = await _fetchLessonSentences(lessonId, paragraphIdx);
-    sentences = canonical ?? _splitSentences(_cleanForTts(text));
+    const paragraph = (canonical?.join('') || _cleanForTts(text)).trim();
+    sentences = paragraph ? [paragraph] : [];
   } else {
     const cleaned = _cleanForTts(text);
     if (!cleaned) return;
@@ -464,10 +476,22 @@ async function _speakViaBackendWithProgress(
 ): Promise<void> {
   let sentences: string[];
 
-  // Prefer canonical v2 sentences to guarantee GCS cache hits (Issue #1208).
+  // A paragraph is one synthesis unit, not a list of sentences.
+  //
+  // Splitting it costs almost nothing in timing — measured, three sentences as
+  // one request run 5.33 s against 5.50 s concatenated, and the resulting pause
+  // (763 ms) is shorter than the one Azure renders itself between sentences in
+  // a single request (873–883 ms). What splitting loses is prosody: each clip
+  // is generated in isolation, so the pitch contour resets at every sentence
+  // and the reading sounds like a list rather than someone reading aloud.
+  //
+  // The canonical sentence list is still fetched, but only to reconstruct the
+  // paragraph exactly as the backend split it, so the text sent matches the
+  // text the mapping describes.
   if (lessonId !== undefined && paragraphIdx !== undefined) {
     const canonical = await _fetchLessonSentences(lessonId, paragraphIdx);
-    sentences = canonical ?? _splitSentences(_cleanForTts(text));
+    const paragraph = (canonical?.join('') || _cleanForTts(text)).trim();
+    sentences = paragraph ? [paragraph] : [];
   } else {
     const cleaned = _cleanForTts(text);
     if (!cleaned) return;


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

全文朗讀聽起來一句一句的。三個看似合理的原因，實測後**全部排除**：

| 假設 | 實測 | |
|---|---|---|
| JS 切換太慢 | 快取請求 28–133ms；播放期間無聲只佔 1% | ❌ |
| Azure 尾端 665ms 靜音太長 | 固定值（30 句實測，與長度相關性 r = −0.06） | ❌ |
| 從逗號切句造成句中卡住 | 2382 個正規句子裡只有 **1%** 不是句號結尾 | ❌ |

而且那個 padding **根本不算長**：Azure 自己在一次請求裡渲染的句間停頓是 **873–883ms**，我們逐句播出來是 **763ms** —— 本來就比自然的短。

我已經寫好並測完一版「位元組層裁掉 padding」的修法，量到這個數字之後**直接刪掉不送** —— 它只會讓朗讀更趕。

## 時間從來不是問題

```
三句一次合成      5.33s
三句分開再串接    5.50s      → 每個接縫只差 84ms
```

**逐句合成真正失去的是語調。** 每個音檔獨立生成，語調輪廓每句重設 —— 沒有跨句的語勢下降、沒有對下一句的預期。聽起來就是「一句一句唸」而不是「有人在讀一篇文章」。

## 所以合成單位改成「段落」

不是整課，理由有三：

- 段落邊界**本來就該停**，接縫是免費的
- 改一段不必重做整課
- 高亮本來就是以段落為單位 —— 現在**一個音檔剛好等於一個高亮區塊**

正規句子清單仍然會抓，但只用來把段落**照後端切法還原**，確保送去合成的文字跟 mapping 描述的一致。沒有課文脈絡的臨時文字（提示、解釋）維持原本切句，因為它沒有「整段」可言、也得守請求長度上限。

快取鍵是 `sha256(文字)`，所以段落長度的項目跟句子項目自然共存 —— **不需要作廢任何東西、不必刪任何檔**。

## 驗證

Mutation 兩個都紅：退回逐句合成、把段落組好之後又切一次。

`lint 0 errors` · `vite build ✓` · `230 tests green`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
