### PR TITLE
fix(#2627): 預抓要抓整段，不是第一句

### DIFF
--- a/frontend/src/services/ttsApi.paragraph.test.ts
+++ b/frontend/src/services/ttsApi.paragraph.test.ts
@@ -112,4 +112,18 @@ describe('paragraph-level synthesis', () => {
 
     expect(synthesized.length).toBeGreaterThan(1);
   });
+
+  it('prefetches the same unit playback will ask for', async () => {
+    // The bug this catches shipped: prefetch warmed the next paragraph's first
+    // *sentence* while playback requested the whole *paragraph*. Different cache
+    // keys, so the warm-up bought nothing and paid for an extra synthesis on
+    // top. Visible on staging as 8 requests for a 5-paragraph lesson —
+    // alternating one long and one short — and 13% of playback silent.
+    const { prefetchText } = await import('./ttsApi');
+    prefetchText(PARAGRAPH, 1, 0);
+    await vi.waitFor(() => expect(synthesized.length).toBeGreaterThan(0));
+
+    expect(synthesized).toContain(PARAGRAPH);
+    expect(synthesized).not.toContain('第一句話。');
+  });
 });

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -155,12 +155,19 @@ export function prefetchText(text: string | undefined, lessonId?: number, paragr
       if (lessonId !== undefined && paragraphIdx !== undefined) {
         sentences = await _fetchLessonSentences(lessonId, paragraphIdx);
       }
-      const list = sentences ?? _splitSentences(_cleanForTts(text));
-      // Only the opening sentence. That is the one the listener is waiting on;
-      // the rest are covered by the in-loop prefetch once playback starts, and
-      // fetching more here would compete with the audio currently playing.
-      const first = list.find((x) => x.trim());
-      if (first) await _fetchAudioUrl(first);
+      // Warm exactly what playback will ask for, or the warm-up is wasted and
+      // pays for a second synthesis on top. When there is lesson context that
+      // is the whole paragraph — reassembled the same way _speakViaBackend
+      // reassembles it — not its first sentence. Getting this wrong was
+      // measurable on staging: 8 synthesis requests for a 5-paragraph lesson,
+      // alternating one long (the paragraph) and one short (a first sentence
+      // nothing would ever play), and 13% of playback silent because every
+      // paragraph still started cold.
+      const unit =
+        sentences !== null && sentences !== undefined
+          ? sentences.join('').trim()
+          : _splitSentences(_cleanForTts(text)).find((x) => x.trim());
+      if (unit) await _fetchAudioUrl(unit);
     } catch {
       // deliberately silent — see doc comment
     }


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

一小時前上的段落級合成有缺陷，在 staging 上抓到。

合成單位改成段落之後，**預抓還停在抓下一段的第一句** —— 兩者的快取鍵不同，所以預抓什麼都沒暖到，還額外付一次合成費。

數字看得很清楚：5 個段落的課發了 **8 次**合成請求，一長一短交替（長的是段落 76–243 字，短的是永遠不會被播的第一句 15–31 字），而且 **13% 的播放時間是無聲的** —— 因為每一段仍然是冷啟動。

預抓現在用跟播放**完全相同**的方式組回段落。

## 既有測試為什麼沒抓到

它們只斷言「有沒有預抓」和「預抓的是第幾段」，**從來沒有斷言預抓的文字等於將要播放的文字**。補上這條，並用 mutation 驗過：把舊的第一句版本放回去，它會紅。

`lint 0 errors` · `vite build ✓` · CI 清單連跑兩次 `153 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)