### PR TITLE
perf(#2627): 句間停頓 889ms→350ms；快取鍵改成會隨校正表失效

### DIFF
--- a/backend/app/services/tts/__init__.py
+++ b/backend/app/services/tts/__init__.py
@@ -35,6 +35,7 @@ from .lesson_mapping import (  # noqa: E402
     build_lesson_tts_mapping,
     synthesize_sentence,
 )
+from .pauses import shorten_sentence_pauses
 from .normalization import (  # noqa: E402
     MAX_SENTENCE_LEN,
     PHONEME_CORRECTIONS,
@@ -307,6 +308,11 @@ def synthesize_speech(text: str) -> bytes:
                 len(cleaned), AZURE_TTS_VOICE,
             )
             audio_bytes = _synthesize_azure(cleaned)
+            # Azure leaves ~885 ms of silence at every sentence end — a quarter
+            # of a paragraph's runtime is dead air, and it is what makes a
+            # whole-lesson reading drag. Shortened here, once, on the way into
+            # the cache, so no listener ever waits for the re-encode.
+            audio_bytes = shorten_sentence_pauses(audio_bytes)
             used_provider = "azure"
         except TTSError as exc:
             logger.warning("Azure TTS failed, falling back to Google: %s", exc)

--- a/backend/app/services/tts/normalization.py
+++ b/backend/app/services/tts/normalization.py
@@ -247,8 +247,44 @@ def _clean_for_tts(text: str) -> str:
     return text
 
 
+def _compute_corrections_fingerprint() -> str:
+    """A short digest of the pronunciation table.
+
+    Sorted first, so the fingerprint tracks the table's *content* and not the
+    order it happens to be in. PHONEME_CORRECTIONS is sorted by length, and a
+    tie between two same-length entries could reorder between runs — that must
+    not invalidate the entire cache for a change nobody made.
+    """
+    body = "\u0000".join(f"{k}\u0001{v}" for k, v in sorted(PHONEME_CORRECTIONS))
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()[:12]
+
+
+CORRECTIONS_FINGERPRINT = _compute_corrections_fingerprint()
+
+
 def _cache_key(text: str) -> str:
-    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+    """Cache key for a piece of synthesized speech.
+
+    Includes how the text is *pronounced*, not just what it says. The key used
+    to be the text alone, which meant adding a correction fixed nothing already
+    cached: every stored clip containing that word kept serving the old reading
+    forever, because its key had not moved. The only escape was deleting those
+    objects by hand — and the person who forgets is the person who just changed
+    the table.
+
+    That is the mechanism behind the mispronunciations that got reported, not a
+    hypothetical. With the fingerprint in the key, a corrections change makes
+    the old audio *unreachable* instead of *wrong*, and the next request
+    regenerates it. Regenerating the whole corpus costs about $2.
+
+    Not yet included: the voice and the prosody rate. Both are currently fixed,
+    but the rate is commented "product-tunable" in azure.py, so changing it
+    would resurrect exactly this bug. Add them here when either becomes a
+    variable.
+    """
+    return hashlib.sha256(
+        f"{CORRECTIONS_FINGERPRINT}\u0000{text.strip()}".encode("utf-8")
+    ).hexdigest()
 
 
 def _numbers_to_chinese_tw(text: str) -> str:

--- a/backend/app/services/tts/pauses.py
+++ b/backend/app/services/tts/pauses.py
@@ -1,0 +1,186 @@
+"""Shorten the silence Azure leaves at every sentence end.
+
+Measured on a real 139-character paragraph: 29.90 s of audio holding 7.57 s of
+silence — a quarter of the runtime — in two cleanly separated groups.
+
+    comma pauses     235–288 ms   (5)
+    sentence pauses  878–889 ms   (6)
+
+The comma pauses are the rhythm of the sentence. The sentence pauses are nearly
+a second each, and they are what makes a whole-lesson reading drag: 「現在句子
+跟句子之間停頓接近一秒誒」.
+
+I reached the wrong conclusion here once by taking Azure's own timing as the
+target — our per-sentence gap measured 763 ms against Azure's 873 ms, so I
+argued there was nothing to fix and deleted a working trim. What that missed is
+that natural for a news reader is not right for a child following the text in a
+book. The number to aim at comes from the reading task, not from the engine.
+
+This module only *plans* the cuts. Splicing them out of the audio is the
+caller's job, so the arithmetic is testable without decoding anything.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+# Anything at least this long is a sentence boundary rather than a comma.
+# The two groups are 600 ms apart, so the threshold sits comfortably between
+# them and does not need to be precise.
+LONG_PAUSE_MS = 600
+
+# What a sentence boundary is shortened to. Long enough to still hear the
+# sentence end — remove it entirely and the sentences run together, which is
+# harder to follow than the original problem — short enough that a 6-sentence
+# paragraph stops losing 5 seconds to dead air.
+TARGET_PAUSE_MS = 350
+
+# Silence at the very start or end of a clip is not an internal pause: the head
+# is the onset (cutting into it clips the first syllable) and the tail is the
+# gap to the next paragraph, where a pause belongs.
+EDGE_GUARD_MS = 250
+
+
+def plan_pause_cuts(
+    silences: list[tuple[int, int]],
+    total_ms: int,
+) -> list[tuple[int, int]]:
+    """Decide which stretches of silence to remove.
+
+    Args:
+        silences: (start_ms, duration_ms) for each detected run, any order.
+        total_ms: length of the whole clip, used to recognise the trailing run.
+
+    Returns:
+        (start_ms, duration_ms) stretches to delete, in playback order and
+        non-overlapping, so a caller can splice them out by walking forward.
+    """
+    cuts: list[tuple[int, int]] = []
+
+    for start, duration in sorted(silences):
+        if duration < LONG_PAUSE_MS:
+            continue
+        if start <= EDGE_GUARD_MS:
+            continue  # leading silence — the clip's onset
+        if start + duration >= total_ms - EDGE_GUARD_MS:
+            continue  # trailing silence — the gap to the next paragraph
+        excess = duration - TARGET_PAUSE_MS
+        if excess <= 0:
+            continue
+        # Keep the first TARGET_PAUSE_MS of the run and drop the remainder, so
+        # the boundary still lands where the speech actually stopped.
+        cuts.append((start + TARGET_PAUSE_MS, excess))
+
+    return cuts
+
+
+# ── Applying the plan to real audio ─────────────────────────────────────────
+#
+# Detection and splicing both work on decoded PCM, because MP3 frames are 24 ms
+# and a pause boundary does not land on one. The clip is re-encoded once at the
+# original bitrate; this runs offline into a cache, so the cost is paid once per
+# paragraph and never on a listener's request.
+
+SILENCE_THRESHOLD = 300      # |sample| below this counts as silence (16-bit)
+MIN_RUN_MS = 150             # shorter dips are articulation, not a pause
+SAMPLE_RATE = 48000
+
+
+def find_silences(samples, sample_rate: int = SAMPLE_RATE) -> list[tuple[int, int]]:
+    """Locate silent runs as (start_ms, duration_ms)."""
+    runs: list[tuple[int, int]] = []
+    min_run = MIN_RUN_MS * sample_rate // 1000
+    run = 0
+    for i, v in enumerate(samples):
+        if -SILENCE_THRESHOLD < v < SILENCE_THRESHOLD:
+            run += 1
+        else:
+            if run >= min_run:
+                runs.append(((i - run) * 1000 // sample_rate, run * 1000 // sample_rate))
+            run = 0
+    if run >= min_run:
+        n = len(samples)
+        runs.append(((n - run) * 1000 // sample_rate, run * 1000 // sample_rate))
+    return runs
+
+
+def splice_out(samples, cuts: list[tuple[int, int]], sample_rate: int = SAMPLE_RATE):
+    """Remove the planned stretches. `cuts` must be ordered and non-overlapping."""
+    if not cuts:
+        return samples
+    out = samples[:0]   # same array type, empty
+    pos = 0
+    for start_ms, dur_ms in cuts:
+        a = start_ms * sample_rate // 1000
+        b = (start_ms + dur_ms) * sample_rate // 1000
+        if a > pos:
+            out.extend(samples[pos:a])
+        pos = max(pos, b)
+    out.extend(samples[pos:])
+    return out
+
+
+def shorten_sentence_pauses(mp3_bytes: bytes) -> bytes:
+    """Shorten the ~885 ms Azure leaves at each sentence end. Never raises.
+
+    Decodes, splices, re-encodes at the original bitrate. That is one lossy
+    generation, which is the price of cutting at a pause boundary — MP3 frames
+    are 24 ms and a pause does not land on one.
+
+    It runs once per paragraph, on the way into the cache, so no listener ever
+    waits for it. If ffmpeg is missing or anything goes wrong the original is
+    returned unchanged: a slightly draggy reading is a far better failure than
+    no audio.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+    from array import array
+
+    if not mp3_bytes or not shutil.which("ffmpeg"):
+        return mp3_bytes
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            f.write(mp3_bytes)
+            src = f.name
+        try:
+            raw = subprocess.run(
+                ["ffmpeg", "-v", "quiet", "-i", src, "-f", "s16le",
+                 "-ac", "1", "-ar", str(SAMPLE_RATE), "-"],
+                capture_output=True, timeout=60,
+            ).stdout
+            if not raw:
+                return mp3_bytes
+
+            samples = array("h")
+            samples.frombytes(raw)
+            total_ms = len(samples) * 1000 // SAMPLE_RATE
+            cuts = plan_pause_cuts(find_silences(samples), total_ms)
+            if not cuts:
+                return mp3_bytes
+
+            trimmed = splice_out(samples, cuts)
+            encoded = subprocess.run(
+                ["ffmpeg", "-v", "quiet", "-f", "s16le", "-ac", "1",
+                 "-ar", str(SAMPLE_RATE), "-i", "-", "-b:a", "192k",
+                 "-f", "mp3", "-"],
+                input=trimmed.tobytes(), capture_output=True, timeout=60,
+            ).stdout
+            # An empty or absurdly small result means the encode failed in a way
+            # ffmpeg did not report; keep the original rather than ship silence.
+            if len(encoded) < len(mp3_bytes) // 4:
+                return mp3_bytes
+            logger.info(
+                "Shortened %d sentence pauses (%.2fs → %.2fs)",
+                len(cuts), len(samples) / SAMPLE_RATE, len(trimmed) / SAMPLE_RATE,
+            )
+            return encoded
+        finally:
+            os.unlink(src)
+    except Exception as exc:  # noqa: BLE001 - never break synthesis over this
+        logger.warning("Pause shortening skipped: %s", exc)
+        return mp3_bytes

--- a/backend/tests/test_cache_key_invalidation.py
+++ b/backend/tests/test_cache_key_invalidation.py
@@ -1,0 +1,72 @@
+"""Changing how a sentence is pronounced must change its cache key.
+
+The key was `sha256(text)` alone. Nothing else — not the voice, not the
+`<prosody rate="1.08">` the code itself calls "product-tunable", and not the
+pronunciation correction table.
+
+So adding a correction fixed nothing that was already cached. Every stored clip
+containing that word kept serving the old, wrong reading forever, because its
+key had not moved. The only escape was remembering to delete those objects by
+hand, and the person who forgets is the person who just changed the table.
+
+That is not hypothetical here: it is the mechanism behind the mispronunciations
+that were reported. A pre-generated file predated a fix by two days and nobody
+could tell by looking.
+
+Putting a fingerprint of the corrections into the key makes stale audio
+*unreachable* rather than *wrong*. Regenerating the whole corpus costs roughly
+$2, which is not a number worth designing around.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.services.tts import normalization as norm
+
+
+class TestKeyDependsOnPronunciation:
+    def test_same_text_same_table_is_stable(self):
+        """Otherwise every deploy would silently re-synthesize everything."""
+        assert norm._cache_key("小戴相信攻擊。") == norm._cache_key("小戴相信攻擊。")
+
+    def test_changing_the_table_changes_the_key(self):
+        before = norm._cache_key("小戴相信攻擊。")
+
+        with patch.object(norm, "CORRECTIONS_FINGERPRINT", "different"):
+            after = norm._cache_key("小戴相信攻擊。")
+
+        assert before != after, (
+            "a corrections change left the key untouched — every already-cached "
+            "clip would keep serving the old reading"
+        )
+
+    def test_different_text_still_differs(self):
+        assert norm._cache_key("第一句。") != norm._cache_key("第二句。")
+
+    def test_whitespace_is_still_ignored(self):
+        # Pre-existing behaviour: surrounding whitespace must not fork the cache.
+        assert norm._cache_key("  你好  ") == norm._cache_key("你好")
+
+
+class TestFingerprint:
+    def test_it_actually_reflects_the_table(self):
+        """A constant would satisfy every test above while doing nothing."""
+        original = norm.CORRECTIONS_FINGERPRINT
+
+        with patch.object(norm, "PHONEME_CORRECTIONS", norm.PHONEME_CORRECTIONS[:-1]):
+            recomputed = norm._compute_corrections_fingerprint()
+
+        assert recomputed != original, (
+            "dropping an entry did not move the fingerprint — it is not derived "
+            "from the table"
+        )
+
+    def test_it_is_short_enough_to_read_in_a_path(self):
+        assert 8 <= len(norm.CORRECTIONS_FINGERPRINT) <= 16
+
+    def test_order_does_not_matter(self):
+        """The table is sorted by length; a tie could reorder between runs and
+        must not invalidate the entire cache for nothing."""
+        shuffled = list(reversed(norm.PHONEME_CORRECTIONS))
+        with patch.object(norm, "PHONEME_CORRECTIONS", shuffled):
+            assert norm._compute_corrections_fingerprint() == norm.CORRECTIONS_FINGERPRINT

--- a/backend/tests/test_shorten_pauses.py
+++ b/backend/tests/test_shorten_pauses.py
@@ -1,0 +1,97 @@
+"""Azure leaves ~885 ms of silence at every sentence end. Shorten it.
+
+Measured on a real 139-character paragraph: 29.90 s of audio containing 7.57 s
+of silence — 25% of the runtime — in two cleanly separated groups.
+
+    comma pauses     235–288 ms   (5 of them)
+    sentence pauses  878–889 ms   (6 of them)
+
+The comma pauses are fine. The sentence pauses are nearly a full second each,
+and that is what the owner hears: 「現在句子跟句子之間停頓接近一秒誒」.
+
+I got this wrong once already by treating Azure's own timing as the target —
+"our gap is shorter than Azure's natural pause, so leave it alone". Natural for
+a news reader is not right for a child following along in a book. The number to
+aim at is what sounds right for reading practice, not what the engine defaults
+to.
+
+Only long silences are touched, and only down to a floor: a sentence boundary
+still needs a beat, or the reading runs together and becomes harder to follow
+than it was.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.tts.pauses import (
+    LONG_PAUSE_MS,
+    TARGET_PAUSE_MS,
+    plan_pause_cuts,
+)
+
+
+def silence(ms: int) -> tuple[int, int]:
+    """A (start_ms, duration_ms) silence run, positioned arbitrarily."""
+    return (1000, ms)
+
+
+class TestWhatGetsCut:
+    def test_a_sentence_pause_is_shortened_to_the_target(self):
+        cuts = plan_pause_cuts([(5000, 885)], total_ms=30000)
+        assert cuts == [(5000 + TARGET_PAUSE_MS, 885 - TARGET_PAUSE_MS)]
+
+    def test_a_comma_pause_is_left_alone(self):
+        # 235–288 ms measured; these are the rhythm of the sentence, not dead air.
+        assert plan_pause_cuts([(5000, 288)], total_ms=30000) == []
+
+    @pytest.mark.parametrize("ms", [289, 400, LONG_PAUSE_MS - 1])
+    def test_nothing_below_the_threshold_is_touched(self, ms):
+        assert plan_pause_cuts([(5000, ms)], total_ms=30000) == []
+
+    def test_every_long_pause_in_a_paragraph_is_handled(self):
+        runs = [(2160, 288), (4380, 885), (8920, 884), (13040, 878)]
+        cuts = plan_pause_cuts(runs, total_ms=29900)
+        assert len(cuts) == 3, "the three sentence pauses, not the comma"
+
+
+class TestWhatIsProtected:
+    def test_the_leading_silence_is_kept(self):
+        """68 ms of head padding is the clip's onset; cutting into it clips the
+        first syllable."""
+        assert plan_pause_cuts([(0, 900)], total_ms=30000) == []
+
+    def test_the_trailing_silence_is_kept(self):
+        """The tail is the gap to the next paragraph, and a paragraph boundary
+        is a place a pause belongs."""
+        assert plan_pause_cuts([(29110, 792)], total_ms=29900) == []
+
+    def test_a_pause_is_never_removed_entirely(self):
+        """A sentence boundary has to stay audible.
+
+        Asserting `kept >= TARGET_PAUSE_MS` is not enough — it holds trivially
+        when TARGET_PAUSE_MS is 0, which is exactly the setting that glues the
+        sentences together. The floor has to be a number this test owns.
+        """
+        FLOOR_MS = 200
+        assert TARGET_PAUSE_MS >= FLOOR_MS, (
+            f"{TARGET_PAUSE_MS} ms leaves no audible sentence boundary"
+        )
+        for run in [(5000, 885), (5000, 2000), (5000, 5000)]:
+            for start, dur in plan_pause_cuts([run], total_ms=30000):
+                kept = start - run[0]
+                assert kept >= FLOOR_MS, "sentences would run together"
+
+
+class TestOrdering:
+    def test_cuts_come_back_in_playback_order(self):
+        """The caller splices by walking forward; out-of-order cuts would
+        corrupt the offsets silently."""
+        runs = [(13040, 878), (4380, 885), (8920, 884)]
+        cuts = plan_pause_cuts(runs, total_ms=29900)
+        assert [c[0] for c in cuts] == sorted(c[0] for c in cuts)
+
+    def test_cuts_never_overlap(self):
+        runs = [(4380, 885), (8920, 884), (13040, 878)]
+        cuts = plan_pause_cuts(runs, total_ms=29900)
+        for (s1, d1), (s2, _) in zip(cuts, cuts[1:]):
+            assert s1 + d1 <= s2


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

> 「現在句子跟句子之間停頓接近一秒誒」

你是對的，而且**停頓這件事我先前什麼都沒做**。我還論證過反面 —— 逐句播放的間隔 763ms 比 Azure 自己的 873ms 短，所以我說「已經比自然的緊了」、把寫好的裁切刪掉，然後改成段落合成，等於把那 885ms 原封不動裝回去。

用「自然」當標準是錯的。**播報員的自然不等於小學生跟讀的合適。**

## 量到的

真實 139 字段落：29.90 秒音檔裡有 **7.57 秒是靜音（25%）**，而且分兩群、界線乾淨：

| | 長度 | 次數 | 處理 |
|---|---|---|---|
| 逗號停頓 | 235–288ms | 5 | **不動** — 那是句子的節奏 |
| 句號停頓 | 878–889ms | 6 | **壓到 350ms** |

頭尾的靜音保護：開頭是起音（切進去會削掉第一個字），結尾是到下一段的間隔，那裡本來就該停。

## 端到端結果（走真實合成路徑，非單元測試）

```
段落內最長停頓   889ms → 350ms
段落長度         29.90s → 26.74s
逗號停頓         276ms / 288ms（原封不動）
```

在合成寫進快取的路上跑一次，**沒有任何聽眾會等這個重編碼**；任何失敗都原樣回傳原音檔 —— 稍微拖一點的朗讀遠好過沒有聲音。ffmpeg 已在 image 裡（`Dockerfile` 第 2 行），所以不會靜默失效。

## 順帶修掉一個更嚴重的：快取鍵無法失效

你問「會不會前台還有 cache」，查下去發現真正的問題在後端：`_cache_key` **只吃文字**，不含語音、語速、也不含讀音校正表。

意思是：改了校正表，**已經快取的音檔鍵不變 → 永遠端出舊發音**，除非有人記得手動去刪。而會忘記的人，正是剛改完表的那個人。這就是你這兩天聽到錯音的機制。

現在把校正表的指紋放進鍵：表一改，鍵就變，舊音檔變成**取不到**而不是**錯的**。代價是既有 6005 個物件成為孤兒、全部重新合成一次，成本約 **$3**。

## Mutation

三個，其中一個第一次沒抓到：「絕不把停頓完全移除」原本斷言 `kept >= TARGET_PAUSE_MS`，而 `TARGET_PAUSE_MS = 0` 時它恆為真 —— 正是會讓句子黏在一起的那個設定。門檻改成測試自己持有的數字後才紅。

`41 tests green`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
