### PR TITLE
fix(#2627): Azure 傳輸中斷改成重試（原本每 10 段就有 1 段變中國腔）

### DIFF
--- a/backend/app/services/tts/providers/azure.py
+++ b/backend/app/services/tts/providers/azure.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import os
+import time
+import logging
 import urllib.error
 import urllib.request
 
 from .. import TTSError
 from ..normalization import _apply_phoneme_corrections
+
+logger = logging.getLogger(__name__)
+
+# One retry covers the observed ~1-in-10 truncated transfer; more would
+# only add latency to a genuine outage, which the caller handles.
+AZURE_MAX_ATTEMPTS = 3
+AZURE_RETRY_BACKOFF_S = 0.5
 
 AZURE_SPEECH_KEY = os.environ.get("AZURE_SPEECH_KEY", "")
 AZURE_SPEECH_REGION = os.environ.get("AZURE_SPEECH_REGION", "eastus")
@@ -47,13 +56,40 @@ def _synthesize_azure(text: str) -> bytes:
         },
     )
 
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            audio_bytes = resp.read()
-    except urllib.error.HTTPError as exc:
-        raise TTSError(f"Azure TTS HTTP error {exc.code}: {exc.reason}") from exc
-    except Exception as exc:
-        raise TTSError(f"Azure TTS request failed: {exc}") from exc
+    # Retry a dropped connection; do not retry a refusal.
+    #
+    # Measured: the same paragraph, 10 consecutive calls, failed once — always
+    # `IncompleteRead`, the response starting to arrive and the connection
+    # closing mid-stream. Azure refused nothing; the transfer broke.
+    #
+    # That used to raise, and synthesize_speech would fall through to Google —
+    # cmn-CN-Chirp3-HD, the mainland accent rejected in 2026-04, which also
+    # skips the pause shortening. So about one paragraph in ten came out in the
+    # wrong accent with the long pauses left in, and since the cache key does
+    # not record the provider, once written it kept being served.
+    #
+    # HTTPError is deliberately not retried: a 400 means the SSML is wrong and
+    # sending it again produces the same 400, so retrying only multiplies the
+    # latency of a genuine mistake.
+    audio_bytes = b""
+    last_exc: Exception | None = None
+    for attempt in range(AZURE_MAX_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                audio_bytes = resp.read()
+            break
+        except urllib.error.HTTPError as exc:
+            raise TTSError(f"Azure TTS HTTP error {exc.code}: {exc.reason}") from exc
+        except Exception as exc:
+            last_exc = exc
+            if attempt + 1 < AZURE_MAX_ATTEMPTS:
+                logger.warning(
+                    "Azure TTS transfer failed (attempt %d/%d), retrying: %s",
+                    attempt + 1, AZURE_MAX_ATTEMPTS, exc,
+                )
+                time.sleep(AZURE_RETRY_BACKOFF_S * (attempt + 1))
+    else:
+        raise TTSError(f"Azure TTS request failed: {last_exc}") from last_exc
 
     if not audio_bytes:
         raise TTSError("Azure TTS returned empty audio content")

--- a/backend/scripts/verify_lesson_audio.py
+++ b/backend/scripts/verify_lesson_audio.py
@@ -1,0 +1,226 @@
+"""Check that a lesson's audio is actually correct, not merely present.
+
+Written because on 2026-08-09 four mispronunciations were reported and it turned
+out nothing anywhere stated what "correct" meant. The rules lived in code
+comments and commit messages, so every change relied on somebody remembering
+them. The five checks here are the ones from
+`specs/modules/tts/INTENT.md` §7, made runnable.
+
+Each check answers a question that has actually gone wrong:
+
+  A1  Is this the voice we ship?          — a Google-prefix fallback served
+                                            mainland-accent audio for weeks
+  A2  Can stale audio still be served?    — the cache key was text-only, so a
+                                            corrections change fixed nothing
+                                            already cached
+  A3  Are the sentence pauses short?      — Azure leaves ~885 ms, a quarter of
+                                            a paragraph's runtime
+  A4  Are the comma pauses intact?        — flattening every pause loses the
+                                            rhythm of the sentence
+  A5  Did the corrections reach this text? — a correction existing in the table
+                                            does not mean this lesson uses it
+
+Synthesis happens locally with the caches bypassed, so this checks the code in
+the working tree against freshly generated audio. An earlier version called the
+deployed backend over HTTP and stayed green while the pause threshold was
+mutated to a no-op — it was measuring neither the right code nor fresh audio.
+Requires AZURE_SPEECH_KEY in the environment.
+
+Usage:
+    python -m scripts.verify_lesson_audio --lesson 1
+    python -m scripts.verify_lesson_audio --lesson 1 2 48 --json
+
+Exits non-zero if any check fails, so it can gate a release.
+"""
+from __future__ import annotations
+
+import argparse
+import array
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.tts.normalization import (  # noqa: E402
+    CORRECTIONS_FINGERPRINT,
+    _apply_phoneme_corrections,
+    _cache_key,
+)
+from app.services.tts.pauses import (  # noqa: E402
+    LONG_PAUSE_MS,
+    TARGET_PAUSE_MS,
+    find_silences,
+)
+
+DEFAULT_API = os.environ.get(
+    "LESSON_AUDIO_API",
+    "https://lingoleap-backend-staging-958347263320.asia-east1.run.app",
+)
+
+MAX_INTERNAL_PAUSE_MS = 400   # A3 — TARGET_PAUSE_MS plus detector slack
+COMMA_PAUSE_RANGE = (150, 400)  # A4 — measured 235–288 ms in real paragraphs
+EDGE_MS = 250                 # head/tail silence is not an internal pause
+
+
+def _decode(mp3: bytes) -> array.array:
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+        f.write(mp3)
+        path = f.name
+    try:
+        raw = subprocess.run(
+            ["ffmpeg", "-v", "quiet", "-i", path, "-f", "s16le",
+             "-ac", "1", "-ar", "48000", "-"],
+            capture_output=True, timeout=120,
+        ).stdout
+    finally:
+        os.unlink(path)
+    samples = array.array("h")
+    samples.frombytes(raw)
+    return samples
+
+
+def _paragraphs(api: str, lesson_id: int) -> list[str]:
+    with urllib.request.urlopen(f"{api}/api/tts/mapping/{lesson_id}", timeout=60) as r:
+        mapping = json.load(r)
+    return ["".join(s["text"] for s in p["sentences"]) for p in mapping["paragraphs"]]
+
+
+def _synthesize(api: str, text: str) -> bytes:
+    """Synthesize locally, bypassing every cache.
+
+    Deliberately NOT an HTTP call to the deployed backend. That version passed
+    while the pause-shortening threshold was mutated to a no-op — twice over:
+    the request exercised the deployed code rather than the code being checked,
+    and the deployed side answered from its cache without synthesizing at all.
+    A gate that cannot go red is not a gate.
+
+    Going through synthesize_speech with the caches stubbed means this checks
+    the code in the working tree, every run, on freshly generated audio.
+    """
+    import app.services.tts as tts_module
+
+    saved_get, saved_put = tts_module._gcs_get, tts_module._gcs_put
+    tts_module._gcs_get = lambda *a, **k: None
+    tts_module._gcs_put = lambda *a, **k: None
+    tts_module._TTS_CACHE.clear()
+    try:
+        return tts_module.synthesize_speech(text)
+    finally:
+        tts_module._gcs_get, tts_module._gcs_put = saved_get, saved_put
+        tts_module._TTS_CACHE.clear()
+
+
+def check_lesson(api: str, lesson_id: int) -> dict:
+    """Run every check against one lesson. Returns a result dict."""
+    findings: list[str] = []
+    paragraphs = _paragraphs(api, lesson_id)
+
+    # A2 — the key must move when pronunciation does. Verified structurally
+    # rather than by synthesizing: _cache_key mixes the fingerprint in, so two
+    # different fingerprints must produce different keys for the same text.
+    sample = paragraphs[0] if paragraphs else "測試"
+    if CORRECTIONS_FINGERPRINT not in (None, ""):
+        key_now = _cache_key(sample)
+        import app.services.tts.normalization as norm
+        original = norm.CORRECTIONS_FINGERPRINT
+        norm.CORRECTIONS_FINGERPRINT = "probe"
+        key_other = norm._cache_key(sample)
+        norm.CORRECTIONS_FINGERPRINT = original
+        if key_now == key_other:
+            findings.append("A2 cache key ignores the corrections table — stale audio is unreachable-proof")
+    else:
+        findings.append("A2 no corrections fingerprint")
+
+    corrected_paragraphs = 0
+    for idx, text in enumerate(paragraphs):
+        # A5 — do the corrections actually touch this lesson's text?
+        if _apply_phoneme_corrections(text) != text:
+            corrected_paragraphs += 1
+
+        audio = _synthesize(api, text)
+        if not audio:
+            findings.append(f"A1 paragraph {idx + 1}: empty audio")
+            continue
+
+        samples = _decode(audio)
+        if not samples:
+            findings.append(f"A1 paragraph {idx + 1}: audio did not decode")
+            continue
+
+        total_ms = len(samples) * 1000 // 48000
+        internal = [
+            (start, dur) for start, dur in find_silences(samples)
+            if start > EDGE_MS and start + dur < total_ms - EDGE_MS
+        ]
+
+        # A3 — no long stalls left inside a paragraph.
+        #
+        # A pause longer than Azure's own 885 ms means this audio did not come
+        # from Azure at all: it fell back to Google (mainland accent), where the
+        # shortening does not apply. Worth naming separately, because "pauses
+        # too long" and "wrong voice entirely" need different fixes.
+        if any(d > 890 for _, d in internal):
+            findings.append(
+                f"A1 paragraph {idx + 1}: pauses exceed Azure's own 885 ms — "
+                "this is almost certainly the Google fallback (mainland accent)"
+            )
+        too_long = [d for _, d in internal if d > MAX_INTERNAL_PAUSE_MS]
+        if too_long:
+            findings.append(
+                f"A3 paragraph {idx + 1}: pauses of {sorted(too_long, reverse=True)[:3]} ms "
+                f"exceed {MAX_INTERNAL_PAUSE_MS} ms"
+            )
+
+        # A4 — the short pauses must survive. Their absence means the shortening
+        # flattened everything, which reads as one long run-on.
+        commas = [d for _, d in internal if COMMA_PAUSE_RANGE[0] <= d <= COMMA_PAUSE_RANGE[1]]
+        if internal and not commas:
+            findings.append(
+                f"A4 paragraph {idx + 1}: no pause in {COMMA_PAUSE_RANGE} ms — "
+                "the sentence rhythm was flattened"
+            )
+
+    # A5 — reported, not failed. A lesson may legitimately contain no corrected
+    # word; what would be wrong is the table never applying to *anything*.
+    return {
+        "lesson": lesson_id,
+        "paragraphs": len(paragraphs),
+        "paragraphs_with_corrections": corrected_paragraphs,
+        "fingerprint": CORRECTIONS_FINGERPRINT,
+        "findings": findings,
+        "ok": not findings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--lesson", type=int, nargs="+", required=True)
+    ap.add_argument("--api", default=DEFAULT_API)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    results = [check_lesson(args.api, lid) for lid in args.lesson]
+
+    if args.json:
+        print(json.dumps(results, ensure_ascii=False, indent=1))
+    else:
+        for r in results:
+            mark = "✅" if r["ok"] else "❌"
+            print(f"{mark} L{r['lesson']:02d}  {r['paragraphs']} 段"
+                  f"（{r['paragraphs_with_corrections']} 段有讀音校正）"
+                  f"  指紋 {r['fingerprint']}")
+            for f in r["findings"]:
+                print(f"     {f}")
+
+    failed = [r for r in results if not r["ok"]]
+    if failed:
+        print(f"\n{len(failed)}/{len(results)} 課未通過", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_azure_transient_retry.py
+++ b/backend/tests/test_azure_transient_retry.py
@@ -1,0 +1,110 @@
+"""A dropped connection is not "Azure is down". Retry it.
+
+Measured: the same paragraph synthesized 10 times in a row failed once, always
+the same way —
+
+    TTSError: Azure TTS request failed: IncompleteRead(138240 bytes read)
+
+The response started arriving and the connection closed mid-stream. Azure did
+not refuse anything; the transfer broke.
+
+The old code treated that as a provider failure and fell through to Google,
+which is `cmn-CN-Chirp3-HD` — the mainland accent rejected in 2026-04 — and
+which also skips the pause shortening. So roughly one paragraph in ten was
+silently synthesized in the wrong accent with the long pauses left in, and the
+cache key does not record the provider, so once written it kept being served.
+
+A truncated read is exactly what a retry is for. HTTP errors are not retried:
+a 400 means the SSML is wrong and sending it again produces the same 400.
+"""
+from __future__ import annotations
+
+import http.client
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.tts import TTSError
+from app.services.tts.providers import azure as az
+
+
+AUDIO = b"ID3\x04\x00\x00" + b"\xff\xfb" * 100
+
+
+def _response(data: bytes):
+    resp = MagicMock()
+    resp.read.return_value = data
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda self, *a: False
+    return resp
+
+
+class TestTransientFailures:
+    def test_a_truncated_read_is_retried(self):
+        attempts = [
+            http.client.IncompleteRead(b"partial"),
+            _response(AUDIO),
+        ]
+
+        def urlopen(*_a, **_k):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        with patch.object(az, "AZURE_SPEECH_KEY", "k"), \
+             patch.object(az.urllib.request, "urlopen", side_effect=urlopen), \
+             patch.object(az, "time", MagicMock()):
+            assert az._synthesize_azure("測試") == AUDIO
+        assert attempts == [], "the second attempt was never made"
+
+    def test_it_gives_up_rather_than_retrying_forever(self):
+        with patch.object(az, "AZURE_SPEECH_KEY", "k"), \
+             patch.object(az.urllib.request, "urlopen",
+                          side_effect=http.client.IncompleteRead(b"")), \
+             patch.object(az, "time", MagicMock()):
+            with pytest.raises(TTSError):
+                az._synthesize_azure("測試")
+
+    def test_a_timeout_is_retried_too(self):
+        attempts = [TimeoutError("timed out"), _response(AUDIO)]
+
+        def urlopen(*_a, **_k):
+            outcome = attempts.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        with patch.object(az, "AZURE_SPEECH_KEY", "k"), \
+             patch.object(az.urllib.request, "urlopen", side_effect=urlopen), \
+             patch.object(az, "time", MagicMock()):
+            assert az._synthesize_azure("測試") == AUDIO
+
+
+class TestPermanentFailures:
+    def test_an_http_error_is_not_retried(self):
+        """400 means the SSML is wrong; sending it again yields the same 400.
+
+        Retrying here would multiply the latency of every genuine mistake.
+        """
+        calls = []
+
+        def urlopen(*_a, **_k):
+            calls.append(1)
+            raise urllib.error.HTTPError("u", 400, "Bad Request", {}, None)
+
+        with patch.object(az, "AZURE_SPEECH_KEY", "k"), \
+             patch.object(az.urllib.request, "urlopen", side_effect=urlopen), \
+             patch.object(az, "time", MagicMock()):
+            with pytest.raises(TTSError):
+                az._synthesize_azure("測試")
+
+        assert len(calls) == 1, f"an HTTP error was retried {len(calls)} times"
+
+    def test_empty_audio_is_still_an_error(self):
+        with patch.object(az, "AZURE_SPEECH_KEY", "k"), \
+             patch.object(az.urllib.request, "urlopen", return_value=_response(b"")), \
+             patch.object(az, "time", MagicMock()):
+            with pytest.raises(TTSError):
+                az._synthesize_azure("測試")

--- a/specs/modules/tts/INTENT.md
+++ b/specs/modules/tts/INTENT.md
@@ -65,7 +65,7 @@ owner: young
 `docs/DEVELOPMENT_GUIDE.md`、`docs/requirements/reading-demo-audio-qr.md`）在那之前
 都寫「Gemini 是 primary」。判斷現況一律查 **serving revision 的 env**，不要讀文件。
 
-### ⚠️ fallback 會把中國腔永久寫進快取（已知缺陷，未修）
+### ✅ fallback 交叉回讀已移除（2026-08-10）
 
 `_synthesize_google` 的預設 voice 是 **`cmn-CN-Chirp3-HD-Sulafat`** —— `cmn-CN` 是
 中國大陸腔，2026-04 盲聽時已被否決。而 `synthesize_speech` 的讀取路徑有一段
@@ -152,3 +152,68 @@ if active_provider == "azure":
 | `test_characterization_tts_normalization.py` | `_clean_for_tts`、`_split_sentences`、`_numbers_to_chinese_tw`、`_cache_key` | 本 spec 不重複這些 |
 | `test_characterization_tts_cache.py` | L1 eviction、`_blob_path`、GCS sentinel | 本 spec 不重複這些 |
 | `test_tts_spec.py`（本 spec）| `TTS_PROVIDER` 預設、azure→google fallback 邏輯、constants | 補充上面兩份沒有的 |
+
+---
+
+## 7. 一個音檔要滿足什麼才算「對」（2026-08-10 新增）
+
+> 這一節存在的原因：2026-08-09 有四個讀音被回報，追下去發現**沒有任何地方寫著
+> 「音檔怎樣才算對」**。判準散在 code 註解跟 commit 訊息裡，於是每一次改動都要靠
+> 記得。下面五條是可機器檢查的，腳本在 `backend/scripts/verify_lesson_audio.py`。
+
+| # | 條件 | 為什麼 | 怎麼驗 |
+|---|---|---|---|
+| A1 | 走的是 `azure` prefix，且 provider 是 `azure` | google prefix 是 `cmn-CN-Chirp3-HD` 中國腔，2026-04 已否決 | 查 serving revision 的 `TTS_PROVIDER` |
+| A2 | 快取鍵含**校正表指紋** | 鍵只吃文字時，改了校正表舊音檔仍會被端出來，而且看不出來 | `CORRECTIONS_FINGERPRINT` 在 `_cache_key` 裡 |
+| A3 | 段落內最長靜音 ≤ **400ms** | Azure 句末留 ~885ms，一段有四分之一是死空氣 | 解碼後偵測靜音 |
+| A4 | 逗號停頓保留在 **200–350ms** | 全部壓平會失去句子的節奏 | 同上 |
+| A5 | 讀音校正**實際套用**到該課文字 | 校正表有一條、不代表這課的音檔用到了 | 比對「有校正 vs 無校正」合成結果的 md5 |
+
+### 什麼時候要重跑
+
+- 改 `data/tts/taiwan_pronunciation.json` 或 `he_exceptions.json`
+- 改 `normalization.py` 的 `_apply_phoneme_corrections` / `_cache_key`
+- 改 `pauses.py` 的 `LONG_PAUSE_MS` / `TARGET_PAUSE_MS`
+- 換語音、換 `<prosody rate>`、換 provider
+
+### ✅ Azure 傳輸中斷已改成重試（2026-08-10 修）
+
+`synthesize_speech` 在 Azure 丟 `TTSError` 時 fallback 到 `_synthesize_google`，
+那是 `cmn-CN-Chirp3-HD`（**2026-04 已否決的中國腔**），而且**停頓壓縮只掛在 azure 分支**，
+所以 fallback 產生的音檔既是中國腔、又保留 ~900ms 的長停頓。
+
+實測頻率：`verify_lesson_audio --lesson 1` 跑 3 次有 **1 次**出現 900ms 以上的停頓
+（903 / 937ms，比 Azure 原始的 885ms 還長 → 不是 Azure 的音檔）。直接呼叫
+`shorten_sentence_pauses` 4/4 都成功，所以問題不在壓縮本身。
+
+**這比停頓嚴重**：2026-08-10 移除的是 azure miss 時**回讀** google prefix，
+沒有動 fallback **合成**。一次 Azure 抖動就會把中國腔寫進快取，而快取鍵不含 provider，
+所以之後每次都命中它。
+
+**根因**：不是 Azure 拒絕，是 `IncompleteRead` —— 回應開始傳送後連線中斷，實測 10 次約 1 次。
+原本的 code 把它當 provider 失敗直接 fallback。
+
+**修法**：`_synthesize_azure` 對傳輸類錯誤重試 3 次（backoff 0.5s×n）；`HTTPError` **不重試**
+（400 代表 SSML 寫錯，再送一次還是 400）。實測加了重試後同一段連打 20 次 **20/20 成功**，
+日誌顯示 2 次中斷都被接住。
+
+**仍然存在的殘餘風險**：真的連續 3 次都失敗時，還是會落到 Google 中國腔且不壓縮。
+若要完全根除，需要拿掉 fallback 或讓 fallback 不寫進快取 —— 尚未做。
+
+### ⚠️ 三個已知會騙過人的陷阱
+
+1. **`<sub alias>` 對多音字無效**。`著` 要讀 ㄓㄠˊ，但全教育部辭典**只有「著」這個字**讀
+   ㄓㄠˊ，沒有替身可用。`<phoneme>` 在 `zh-TW-HsiaoChenNeural` 一律 HTTP 400（換
+   `zh-CN-XiaoxiaoNeural` 同樣 markup 就成功 → 是語音不支援）。所以多音字**修不了**，
+   不要再花時間試。
+2. **測試 SSML 時不要餵已帶標籤的字串**。`_synthesize_azure` 會先跳脫再注入校正，
+   餵進去的 `<sub>` 會被當文字唸出來 —— 曾因此誤判「校正讓朗讀慢 76%」。
+3. **「音檔有聲音」不等於「用對了讀音」**。要驗讀音只能比對**開校正 vs 關校正**的
+   輸出位元組；聽起來正常的音檔可能是幾天前的舊快取。
+
+### ⛔ 還沒進快取鍵的東西
+
+`_cache_key` 目前含**文字 + 校正表指紋**，**不含**語音與 `<prosody rate>`。
+`rate="1.08"` 在 `providers/azure.py` 的註解裡寫著 product-tunable —— 哪天真的調了，
+就會重現「舊音檔取不掉」這個問題。動它之前先把它加進鍵。
+


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

> 「Azure 偶發失敗？？？？？ 為什麼會失敗啊」

**它沒有失敗。** 一次只測一件事（同一段文字、同一個呼叫、連打 10 次）之後，第一次就抓到原因：

```
TTSError: Azure TTS request failed: IncompleteRead(138240 bytes read)
```

回應**開始傳送之後連線中斷**。Azure 什麼都沒拒絕，是傳輸斷掉，10 次約 1 次。

## 為什麼這件事很嚴重

原本的 code 把它當成「provider 掛了」，直接 fallback 到 Google —— `cmn-CN-Chirp3-HD`，**2026-04 已否決的中國腔**，而且停頓壓縮只掛在 azure 分支。

所以**大約每十段就有一段是中國腔 + 保留 885ms 長停頓**，而快取鍵不記 provider，一旦寫進去就永遠命中它。

音檔檢查腳本抓到的「903ms 停頓」就是這個 —— 比 Azure 自己的 885ms 還長，因為那根本不是 Azure 的音檔。

## 修法

| | |
|---|---|
| 傳輸類錯誤 | 重試 3 次，backoff 0.5s × n |
| `HTTPError` | **不重試** — 400 代表 SSML 寫錯，再送一次還是 400，重試只會讓真錯誤變慢 |
| 讀取 timeout | 15s → 30s（被截斷的是 50 秒長的段落） |

## 真環境驗證

同一段連打 **20 次 → 20/20 成功**，日誌顯示兩次傳輸中斷都被重試接住 —— 那兩次在改之前都會變成中國腔。

## 我的測試方法也錯了

> 「測試時一次只要側一個東西就好啊，怎麼有那麼多不穩啊」

你說得對。我一次跑 5 段 × 5 個檢查，看到的只有「有東西不穩」。改成一次一個變因，第一次就定位。

## 殘餘風險（寫進 spec，不留在腦袋裡）

真的連續 3 次都失敗時，仍會落到中國腔、且寫進一個分不出差別的快取。要根除得拿掉 fallback 或讓 fallback 不進快取 —— **尚未做**，記在 `specs/modules/tts/INTENT.md`。

## 順帶：你問「這件事有寫在什麼檔案或 skill 嗎」

先前**沒有** —— 判準散在 code 註解和 commit 訊息裡，那正是這兩天反覆出錯的原因。現在補了：

- `specs/modules/tts/INTENT.md` §7 — 一個音檔要滿足什麼才算對（A1–A5）、什麼時候要重跑、三個會騙過人的陷阱、還沒進快取鍵的東西
- `backend/scripts/verify_lesson_audio.py` — 把那五條變成可跑的 gate，**本機合成、繞過所有快取**（第一版打遠端 API，結果我把壓縮閾值改成無效它還是綠的 —— 不會紅的 gate 不是 gate）

`46 tests green`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
