### PR TITLE
fix(#2649): consolidate six shadowed TTS cache helpers into cache.py

### DIFF
--- a/backend/app/services/tts/__init__.py
+++ b/backend/app/services/tts/__init__.py
@@ -19,11 +19,14 @@ from .cache import (  # noqa: E402
     CACHE_MAX_ENTRIES,
     TTS_GCS_BUCKET,
     _GCS_UNAVAILABLE,
+    _PROVIDERS,
     _TTS_CACHE,
+    _blob_path,
     _gcs_client,
     _gcs_get,
     _gcs_put,
     _get_gcs_bucket,
+    _l1_key,
     _l1_put,
     delete_tts_cache,
     get_cached_tts,
@@ -68,129 +71,17 @@ from .providers.google import (  # noqa: E402
 )
 
 
-def _blob_path(key: str, provider: str = "google") -> str:
-    if provider == "azure":
-        return f"azure/sentences/{key}.mp3"
-    if provider == "gemini31":
-        return f"gemini31-prompt-only-v2/sentences/{key}.mp3"
-    return f"tts-cache/{key}.mp3"
-
-
-def _get_gcs_bucket():
-    global _gcs_client
-    if _gcs_client is _GCS_UNAVAILABLE:
-        return None
-    if _gcs_client is None:
-        try:
-            import google.cloud.storage as storage
-            client = storage.Client()
-            _gcs_client = client.bucket(TTS_GCS_BUCKET)
-            logger.info("GCS TTS cache bucket: %s", TTS_GCS_BUCKET)
-        except Exception as exc:
-            logger.warning("GCS cache unavailable, falling back to API-only: %s", exc)
-            _gcs_client = _GCS_UNAVAILABLE
-            return None
-    return _gcs_client
-
-
-def _gcs_get(key: str, provider: str = "google") -> Optional[bytes]:
-    bucket = _get_gcs_bucket()
-    if bucket is None:
-        return None
-    blob_path = _blob_path(key, provider)
-    try:
-        blob = bucket.blob(blob_path)
-        if blob.exists():
-            data = blob.download_as_bytes()
-            logger.debug("GCS cache hit (provider=%s, key=%s, bytes=%d)", provider, key[:8], len(data))
-            return data
-    except Exception as exc:
-        logger.warning("GCS cache read error: %s", exc)
-    return None
-
-
-def _gcs_put(key: str, audio_bytes: bytes, provider: str = "google") -> None:
-    bucket = _get_gcs_bucket()
-    if bucket is None:
-        return
-    blob_path = _blob_path(key, provider)
-    try:
-        blob = bucket.blob(blob_path)
-        blob.upload_from_string(audio_bytes, content_type="audio/mpeg")
-        logger.debug("GCS cache write (provider=%s, key=%s, bytes=%d)", provider, key[:8], len(audio_bytes))
-    except Exception as exc:
-        logger.warning("GCS cache write error: %s", exc)
-
-
-_PROVIDERS = ("azure", "gemini31", "google")
-
-
-def _l1_key(key: str, provider: str) -> str:
-    """Namespace an L1 entry by the provider that produced it (#2649 item 1).
-
-    Without this, L1 is provider-blind: a momentary Azure failure falls back
-    to Google, writes the mainland-accent bytes under the bare text key, and
-    every later request — even long after Azure recovers, and without ever
-    touching the provider chain again — reads them straight back out. GCS
-    already avoids exactly this with a provider-specific blob path
-    (_blob_path); this gives the in-process cache the same property, so an
-    azure-active lookup can never be satisfied by a google-produced entry.
-    """
-    return f"{provider} {key}"
-
-
-def _l1_put(key: str, audio_bytes: bytes, provider: str) -> None:
-    l1_key = _l1_key(key, provider)
-    if l1_key not in _TTS_CACHE and len(_TTS_CACHE) >= CACHE_MAX_ENTRIES:
-        oldest_key = next(iter(_TTS_CACHE))
-        del _TTS_CACHE[oldest_key]
-    _TTS_CACHE[l1_key] = audio_bytes
-
-
-def get_cached_tts(text: str, provider: str) -> Optional[bytes]:
-    """L1 lookup scoped to *provider* — see _l1_key.
-
-    Callers must pass the provider they intend to serve (normally the
-    module's active TTS_PROVIDER); there is no provider-blind overload,
-    because a provider-blind read is exactly the bug this exists to close.
-    """
-    key = _cache_key(text)
-    return _TTS_CACHE.get(_l1_key(key, provider))
-
-
-def delete_tts_cache(text: str) -> dict:
-    key = _cache_key(text)
-    deleted_paths: list[str] = []
-
-    l1_deleted = False
-    for provider in _PROVIDERS:
-        l1_key = _l1_key(key, provider)
-        if l1_key in _TTS_CACHE:
-            del _TTS_CACHE[l1_key]
-            l1_deleted = True
-            logger.info("L1 cache evicted (key=%s, provider=%s)", key[:8], provider)
-
-    bucket = _get_gcs_bucket()
-    if bucket is not None:
-        for provider in _PROVIDERS:
-            blob_path = _blob_path(key, provider)
-            try:
-                blob = bucket.blob(blob_path)
-                if blob.exists():
-                    blob.delete()
-                    deleted_paths.append(blob_path)
-                    logger.info("GCS cache deleted: %s", blob_path)
-            except Exception as exc:
-                logger.warning("GCS cache delete error (%s): %s", blob_path, exc)
-
-    return {
-        "key": key,
-        "l1_deleted": l1_deleted,
-        "gcs_deleted": deleted_paths,
-    }
 # NOTE: _synthesize_azure lives in providers/azure.py and is imported above.
 # A second copy used to be defined here, which silently shadowed the import —
 # every fix made to the provider file did nothing at runtime. Do not re-add it.
+#
+# The same thing happened to six cache helpers (_gcs_get, _gcs_put,
+# _get_gcs_bucket, _l1_put, get_cached_tts, delete_tts_cache): this module
+# imported them from .cache above, then redefined all six further down,
+# so the import was dead and cache.py's copies were unreachable dead code.
+# Consolidated into cache.py (#2649) — this module now only imports and
+# re-exports them. Do not redefine any of them here again;
+# tests/test_no_duplicate_azure_impl.py fails if you do.
 
 
 def _get_tts_client():

--- a/backend/app/services/tts/cache.py
+++ b/backend/app/services/tts/cache.py
@@ -16,6 +16,8 @@ TTS_GCS_BUCKET = os.environ.get("TTS_GCS_BUCKET", "lingoleap-tts-cache")
 _GCS_UNAVAILABLE = object()
 _gcs_client: object = None
 
+_PROVIDERS = ("azure", "gemini31", "google")
+
 
 def _blob_path(key: str, provider: str = "google") -> str:
     if provider == "azure":
@@ -31,7 +33,7 @@ def _get_gcs_bucket():
         return None
     if _gcs_client is None:
         try:
-            from google.cloud import storage
+            import google.cloud.storage as storage
             client = storage.Client()
             _gcs_client = client.bucket(TTS_GCS_BUCKET)
             logger.info("GCS TTS cache bucket: %s", TTS_GCS_BUCKET)
@@ -71,30 +73,54 @@ def _gcs_put(key: str, audio_bytes: bytes, provider: str = "google") -> None:
         logger.warning("GCS cache write error: %s", exc)
 
 
-def _l1_put(key: str, audio_bytes: bytes) -> None:
-    if len(_TTS_CACHE) >= CACHE_MAX_ENTRIES:
+def _l1_key(key: str, provider: str) -> str:
+    """Namespace an L1 entry by the provider that produced it (#2649 item 1).
+
+    Without this, L1 is provider-blind: a momentary Azure failure falls back
+    to Google, writes the mainland-accent bytes under the bare text key, and
+    every later request — even long after Azure recovers, and without ever
+    touching the provider chain again — reads them straight back out. GCS
+    already avoids exactly this with a provider-specific blob path
+    (_blob_path); this gives the in-process cache the same property, so an
+    azure-active lookup can never be satisfied by a google-produced entry.
+    """
+    return f"{provider} {key}"
+
+
+def _l1_put(key: str, audio_bytes: bytes, provider: str) -> None:
+    l1_key = _l1_key(key, provider)
+    if l1_key not in _TTS_CACHE and len(_TTS_CACHE) >= CACHE_MAX_ENTRIES:
         oldest_key = next(iter(_TTS_CACHE))
         del _TTS_CACHE[oldest_key]
-    _TTS_CACHE[key] = audio_bytes
+    _TTS_CACHE[l1_key] = audio_bytes
 
 
-def get_cached_tts(text: str) -> Optional[bytes]:
+def get_cached_tts(text: str, provider: str) -> Optional[bytes]:
+    """L1 lookup scoped to *provider* — see _l1_key.
+
+    Callers must pass the provider they intend to serve (normally the
+    module's active TTS_PROVIDER); there is no provider-blind overload,
+    because a provider-blind read is exactly the bug this exists to close.
+    """
     key = _cache_key(text)
-    return _TTS_CACHE.get(key)
+    return _TTS_CACHE.get(_l1_key(key, provider))
 
 
 def delete_tts_cache(text: str) -> dict:
     key = _cache_key(text)
     deleted_paths: list[str] = []
 
-    l1_deleted = key in _TTS_CACHE
-    if l1_deleted:
-        del _TTS_CACHE[key]
-        logger.info("L1 cache evicted (key=%s)", key[:8])
+    l1_deleted = False
+    for provider in _PROVIDERS:
+        l1_key = _l1_key(key, provider)
+        if l1_key in _TTS_CACHE:
+            del _TTS_CACHE[l1_key]
+            l1_deleted = True
+            logger.info("L1 cache evicted (key=%s, provider=%s)", key[:8], provider)
 
     bucket = _get_gcs_bucket()
     if bucket is not None:
-        for provider in ("azure", "gemini31", "google"):
+        for provider in _PROVIDERS:
             blob_path = _blob_path(key, provider)
             try:
                 blob = bucket.blob(blob_path)

--- a/backend/tests/test_characterization_tts_cache.py
+++ b/backend/tests/test_characterization_tts_cache.py
@@ -1,8 +1,21 @@
 """
-Characterization tests for backend/app/services/tts/cache.py (refactor #1833).
+Characterization tests for backend/app/services/tts/cache.py.
+
+Until #2649, cache.py's _l1_put/get_cached_tts/delete_tts_cache/_get_gcs_bucket
+were dead code: __init__.py imported them and then redefined all six further
+down the same file, so these tests exercised the *shadowed* copy, not the one
+production actually ran. They still passed the whole time — a duplicate like
+that cannot be caught by testing either file on its own (see
+tests/test_no_duplicate_azure_impl.py).
+
+cache.py is now the single, canonical home for all six; __init__.py only
+imports and re-exports them. These tests exercise the real, running
+implementation, which is why _l1_put/get_cached_tts now take a mandatory
+`provider` argument instead of a bare text key — see _l1_key's docstring in
+cache.py for why a provider-blind L1 was itself a production bug (#2649 item 1).
 
 Verifies:
-  - L1 in-memory cache eviction at CACHE_MAX_ENTRIES
+  - L1 in-memory cache eviction at CACHE_MAX_ENTRIES, scoped by provider
   - _blob_path returns correct GCS path per provider
   - GCS unavailability sentinel (no retry after first failure)
   - get_cached_tts and _l1_put behavior
@@ -56,7 +69,8 @@ class TestBlobPath:
 # ---------------------------------------------------------------------------
 
 class TestL1Cache:
-    """L1 in-memory cache must store and retrieve audio bytes by text."""
+    """L1 in-memory cache must store and retrieve audio bytes by text,
+    scoped to the provider that produced them (#2649 item 1)."""
 
     def setup_method(self):
         """Clear L1 cache before each test to avoid cross-test pollution."""
@@ -70,14 +84,30 @@ class TestL1Cache:
 
         text = "測試L1快取"
         key = _cache_key(text)
-        _l1_put(key, b"AUDIO_DATA")
+        _l1_put(key, b"AUDIO_DATA", provider="azure")
 
-        result = get_cached_tts(text)
+        result = get_cached_tts(text, provider="azure")
         assert result == b"AUDIO_DATA"
+
+    def test_l1_put_is_scoped_to_the_provider_it_was_written_under(self):
+        """Positive control for the provider argument itself: without it,
+        this file used to test a bare-key cache that could not tell an
+        Azure entry from a Google one — exactly the bug #2649 item 1 fixed
+        in the copy that actually runs. get_cached_tts must not find this
+        entry under a different provider for the identical text."""
+        from app.services.tts.cache import _l1_put, get_cached_tts
+        from app.services.tts.normalization import _cache_key
+
+        text = "測試provider隔離"
+        key = _cache_key(text)
+        _l1_put(key, b"AZURE_AUDIO", provider="azure")
+
+        assert get_cached_tts(text, provider="azure") == b"AZURE_AUDIO"
+        assert get_cached_tts(text, provider="google") is None
 
     def test_cache_miss_returns_none(self):
         from app.services.tts.cache import get_cached_tts
-        result = get_cached_tts("這段文字沒有在快取")
+        result = get_cached_tts("這段文字沒有在快取", provider="azure")
         assert result is None
 
     def test_l1_evicts_oldest_when_at_max(self):
@@ -88,20 +118,20 @@ class TestL1Cache:
 
         # Fill cache exactly to max
         first_key = _cache_key("第一個進來的")
-        _l1_put(first_key, b"FIRST")
+        _l1_put(first_key, b"FIRST", provider="azure")
 
         # Fill up remaining slots
         for i in range(CACHE_MAX_ENTRIES - 1):
-            _l1_put(_cache_key(f"fill_{i}"), b"FILLER")
+            _l1_put(_cache_key(f"fill_{i}"), b"FILLER", provider="azure")
 
         # Cache should be at max
         assert len(cache_mod._TTS_CACHE) == CACHE_MAX_ENTRIES
 
         # Add one more — oldest (first_key) should be evicted
-        _l1_put(_cache_key("最新進來的"), b"NEW")
+        _l1_put(_cache_key("最新進來的"), b"NEW", provider="azure")
 
         assert len(cache_mod._TTS_CACHE) == CACHE_MAX_ENTRIES
-        assert first_key not in cache_mod._TTS_CACHE
+        assert cache_mod._l1_key(first_key, "azure") not in cache_mod._TTS_CACHE
 
     def test_tautology_break_cache_must_not_return_wrong_audio(self):
         """MUST fail if L1 cache returns audio for wrong key."""
@@ -109,8 +139,8 @@ class TestL1Cache:
         from app.services.tts.cache import _l1_put, get_cached_tts
         from app.services.tts.normalization import _cache_key
 
-        _l1_put(_cache_key("text A"), b"AUDIO_A")
-        result = get_cached_tts("text B")
+        _l1_put(_cache_key("text A"), b"AUDIO_A", provider="azure")
+        result = get_cached_tts("text B", provider="azure")
         assert result != b"AUDIO_A"
 
 

--- a/backend/tests/test_no_duplicate_azure_impl.py
+++ b/backend/tests/test_no_duplicate_azure_impl.py
@@ -44,16 +44,11 @@ def test_init_does_not_redefine_what_it_imports():
     shadowed = sorted(imported & defined)
 
     # Six cache helpers (_gcs_get, _gcs_put, _get_gcs_bucket, _l1_put,
-    # get_cached_tts, delete_tts_cache) are shadowed the same way. They are
-    # known and tracked in specs/modules/tts/INTENT.md; removing them is a
-    # separate change with its own blast radius, and pretending otherwise by
-    # deleting them in passing is how the audio broke in the first place.
-    #
-    # Anything NOT on this list is new, and new is what this test is for.
-    KNOWN = {
-        "_gcs_get", "_gcs_put", "_get_gcs_bucket",
-        "_l1_put", "get_cached_tts", "delete_tts_cache",
-    }
+    # get_cached_tts, delete_tts_cache) used to be shadowed the same way.
+    # Consolidated into cache.py (#2649): __init__.py now only imports and
+    # re-exports them, so KNOWN is empty — any future shadowing of *any*
+    # imported name in this file, including these six again, must fail here.
+    KNOWN: set[str] = set()
     new_shadows = sorted(set(shadowed) - KNOWN)
 
     assert not new_shadows, (

--- a/backend/tests/test_tts_l1_cache_not_provider_blind.py
+++ b/backend/tests/test_tts_l1_cache_not_provider_blind.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 import pytest
 
 from app.services import tts as tts_module
+from app.services.tts import cache as tts_cache_module
 
 
 AZURE_BYTES = b"AZURE-zh-TW-HsiaoChenNeural-BYTES"
@@ -103,7 +104,11 @@ class TestDeleteTtsCacheClearsEveryProvider:
         key = tts_module._cache_key("被 regenerate 的句子")
         tts_module._l1_put(key, GOOGLE_BYTES, provider="google")
 
-        with patch.object(tts_module, "_get_gcs_bucket", return_value=None):
+        # delete_tts_cache is defined in app.services.tts.cache and resolves
+        # _get_gcs_bucket against that module's own globals — patching
+        # tts_module (the __init__.py re-export) is inert post-#2649
+        # consolidation and would let a real GCS client run here.
+        with patch.object(tts_cache_module, "_get_gcs_bucket", return_value=None):
             result = tts_module.delete_tts_cache("被 regenerate 的句子")
 
         assert result["l1_deleted"] is True
@@ -111,6 +116,6 @@ class TestDeleteTtsCacheClearsEveryProvider:
             assert tts_module._TTS_CACHE.get(tts_module._l1_key(key, provider)) is None
 
     def test_l1_deleted_false_when_nothing_was_cached(self):
-        with patch.object(tts_module, "_get_gcs_bucket", return_value=None):
+        with patch.object(tts_cache_module, "_get_gcs_bucket", return_value=None):
             result = tts_module.delete_tts_cache("從來沒被合成過的句子")
         assert result["l1_deleted"] is False

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -112,7 +112,7 @@ class TestTTSServiceSynthesize:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_returns_bytes_for_valid_text(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import synthesize_speech
@@ -127,7 +127,7 @@ class TestTTSServiceSynthesize:
     @patch("app.services.tts_service.TTS_PROVIDER", "google")
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_cache_prevents_second_api_call(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         # TTS_PROVIDER pinned to "google" so both calls land under the same
@@ -149,7 +149,7 @@ class TestTTSServiceSynthesize:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_different_texts_each_call_api(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import synthesize_speech
@@ -164,7 +164,7 @@ class TestTTSServiceSynthesize:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_raises_on_empty_audio(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import TTSError, synthesize_speech
@@ -177,7 +177,7 @@ class TestTTSServiceSynthesize:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_raises_on_api_exception(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import TTSError, synthesize_speech
@@ -197,12 +197,19 @@ class TestGCSSentinel:
     """After GCS init fails once, _get_gcs_bucket returns None immediately."""
 
     def test_gcs_init_failure_sets_sentinel(self):
+        # _get_gcs_bucket is defined in app.services.tts.cache and rebinds
+        # that module's own _gcs_client via `global` (#2649 consolidation).
+        # tts_mod._gcs_client (app.services.tts_service / tts_module) is a
+        # separate name bound once at import time — setting or reading it
+        # here would silently diverge from what _get_gcs_bucket actually
+        # updates, so this test operates on the canonical cache module.
         import app.services.tts_service as tts_mod
+        from app.services.tts import cache as cache_mod
         from app.services.tts.providers import azure as az_mod
 
         # Reset state
-        original = tts_mod._gcs_client
-        tts_mod._gcs_client = None  # force re-init
+        original = cache_mod._gcs_client
+        cache_mod._gcs_client = None  # force re-init
 
         try:
             with patch("app.services.tts_service.storage", create=True) as mock_storage_mod:
@@ -212,16 +219,19 @@ class TestGCSSentinel:
                 )}):
                     result = tts_mod._get_gcs_bucket()
                     assert result is None
-                    assert tts_mod._gcs_client is tts_mod._GCS_UNAVAILABLE
+                    assert cache_mod._gcs_client is cache_mod._GCS_UNAVAILABLE
         finally:
-            tts_mod._gcs_client = original
+            cache_mod._gcs_client = original
 
     def test_gcs_sentinel_skips_retry(self):
+        # See test_gcs_init_failure_sets_sentinel: operate on the canonical
+        # cache module, not the tts_service re-export.
         import app.services.tts_service as tts_mod
+        from app.services.tts import cache as cache_mod
         from app.services.tts.providers import azure as az_mod
 
-        original = tts_mod._gcs_client
-        tts_mod._gcs_client = tts_mod._GCS_UNAVAILABLE
+        original = cache_mod._gcs_client
+        cache_mod._gcs_client = cache_mod._GCS_UNAVAILABLE
 
         try:
             # Should return None immediately without attempting import
@@ -233,7 +243,7 @@ class TestGCSSentinel:
                 mock_storage = sys.modules["google.cloud.storage"]
                 mock_storage.Client.assert_not_called()
         finally:
-            tts_mod._gcs_client = original
+            cache_mod._gcs_client = original
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +296,7 @@ class TestEmptyAudioResponse:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_none_audio_content_raises(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import TTSError, synthesize_speech
@@ -301,7 +311,7 @@ class TestEmptyAudioResponse:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_empty_bytes_audio_content_raises(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from app.services.tts_service import TTSError, synthesize_speech
@@ -391,7 +401,7 @@ class TestSentenceSplitting:
 
         with patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put"), \
-             patch("app.services.tts_service._TTS_CACHE", {}), \
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True), \
              patch("app.services.tts_service._get_tts_client", return_value=mock_client):
             result = synthesize_speech(long_text)
 
@@ -413,7 +423,7 @@ class TestCostProtection:
         return resp
 
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_gcs_hit_skips_api_call(self, mock_get_client, mock_gcs_put):
         """L2 GCS cache hit → Cloud TTS API must NOT be called (saves money)."""
@@ -429,7 +439,7 @@ class TestCostProtection:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_api_result_saved_to_gcs(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         """After API call, result MUST be saved to GCS (prevents paying again)."""
@@ -448,7 +458,7 @@ class TestCostProtection:
         assert args[1] == b"NEW_AUDIO"
 
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_gcs_hit_also_populates_l1(self, mock_get_client, mock_gcs_put):
         """GCS hit should populate L1 so next call doesn't even hit GCS."""
@@ -499,7 +509,7 @@ class TestTTSRoute:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
     @patch("app.services.tts_service._get_tts_client")
     def test_synthesize_returns_audio_response(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from fastapi.testclient import TestClient
@@ -641,7 +651,7 @@ class TestAzureTTSSynthesis:
              patch.object(az_mod.requests, "post", return_value=fake_response), \
              patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put") as mock_put, \
-             patch("app.services.tts_service._TTS_CACHE", {}):
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True):
             tts_mod.synthesize_speech("你好")
 
         mock_put.assert_called_once()
@@ -673,7 +683,7 @@ class TestAzureGoogleFallback:
              patch.object(az_mod, "AZURE_SPEECH_KEY", ""), \
              patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put"), \
-             patch("app.services.tts_service._TTS_CACHE", {}), \
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True), \
              patch("app.services.tts_service._get_tts_client", return_value=mock_google_client):
             result = synthesize_speech("你好世界")
 
@@ -690,7 +700,7 @@ class TestAzureGoogleFallback:
              patch.object(az_mod, "AZURE_SPEECH_KEY", ""), \
              patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put"), \
-             patch("app.services.tts_service._TTS_CACHE", {}), \
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True), \
              patch("app.services.tts_service._get_tts_client",
                    side_effect=TTSError("Google also failed")):
             with pytest.raises(TTSError):
@@ -710,7 +720,7 @@ class TestAzureGoogleFallback:
         with patch.object(az_mod, "AZURE_SPEECH_KEY", ""), \
              patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put"), \
-             patch("app.services.tts_service._TTS_CACHE", {}), \
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True), \
              patch("app.services.tts_service._get_tts_client", return_value=mock_google_client), \
              patch("urllib.request.urlopen") as mock_urlopen:
             result = synthesize_speech("你好")
@@ -734,7 +744,7 @@ class TestAzureGoogleFallback:
              patch.object(az_mod, "AZURE_SPEECH_KEY", ""), \
              patch("app.services.tts_service._gcs_get", return_value=None), \
              patch("app.services.tts_service._gcs_put") as mock_put, \
-             patch("app.services.tts_service._TTS_CACHE", {}), \
+             patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True), \
              patch("app.services.tts_service._get_tts_client", return_value=mock_google_client):
             synthesize_speech("你好")
 
@@ -1000,7 +1010,13 @@ class TestDeleteTtsCache:
         key = _cache_key(text)
         tts_mod._l1_put(key, b"CACHED", provider="azure")
 
-        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+        # delete_tts_cache is defined in app.services.tts.cache and resolves
+        # _get_gcs_bucket against that module's own globals, not
+        # app.services.tts_service's — patching the latter is inert here
+        # (#2649 cache consolidation: the two used to be separate shadowing
+        # copies, so this patch target used to be correct; now there is one
+        # canonical function and it must be patched where it actually lives).
+        with patch("app.services.tts.cache._get_gcs_bucket", return_value=None):
             result = delete_tts_cache(text)
 
         assert result["l1_deleted"] is True
@@ -1016,7 +1032,9 @@ class TestDeleteTtsCache:
         key = _cache_key(text)
         tts_mod._TTS_CACHE.pop(key, None)  # ensure not present
 
-        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+        # See test_l1_eviction_when_present: delete_tts_cache now lives in
+        # app.services.tts.cache, so _get_gcs_bucket must be patched there.
+        with patch("app.services.tts.cache._get_gcs_bucket", return_value=None):
             result = delete_tts_cache(text)
 
         assert result["l1_deleted"] is False
@@ -1037,7 +1055,8 @@ class TestDeleteTtsCache:
         mock_bucket = MagicMock()
         mock_bucket.blob.return_value = mock_blob
 
-        with patch("app.services.tts_service._get_gcs_bucket", return_value=mock_bucket):
+        # See test_l1_eviction_when_present: patch the canonical module.
+        with patch("app.services.tts.cache._get_gcs_bucket", return_value=mock_bucket):
             result = delete_tts_cache(text)
 
         assert mock_blob.delete.call_count >= 1
@@ -1047,7 +1066,8 @@ class TestDeleteTtsCache:
         """If GCS bucket is None, delete_tts_cache should succeed silently."""
         from app.services.tts_service import delete_tts_cache
 
-        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+        # See test_l1_eviction_when_present: patch the canonical module.
+        with patch("app.services.tts.cache._get_gcs_bucket", return_value=None):
             result = delete_tts_cache("任何文字")
 
         assert "key" in result
@@ -1073,8 +1093,12 @@ class TestRegenerateEndpoint:
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")
-    @patch("app.services.tts_service._TTS_CACHE", {})
-    @patch("app.services.tts_service._get_gcs_bucket", return_value=None)
+    @patch.dict("app.services.tts_service._TTS_CACHE", {}, clear=True)
+    # The route calls delete_tts_cache, which lives in app.services.tts.cache
+    # and resolves _get_gcs_bucket against that module's globals — patching
+    # app.services.tts_service._get_gcs_bucket (as before the #2649
+    # consolidation) would be inert and let the real GCS client run.
+    @patch("app.services.tts.cache._get_gcs_bucket", return_value=None)
     def test_regenerate_returns_ok(self, mock_bucket, mock_gcs_put, mock_gcs_get):
         """POST /api/tts/regenerate must return 200 with status=ok (uses Azure path)."""
         import app.services.tts_service as tts_mod

--- a/specs/modules/tts/INTENT.md
+++ b/specs/modules/tts/INTENT.md
@@ -6,6 +6,7 @@ stability: active
 canonical_source: backend/app/services/tts/__init__.py
 owns_code:
   - backend/app/services/tts/__init__.py
+  - backend/app/services/tts/cache.py
   - backend/app/services/tts/providers/azure.py
   - backend/app/services/tts/providers/gemini.py
   - backend/app/services/tts/providers/google.py
@@ -13,10 +14,12 @@ owns_code:
 owns_data: []
 spec_tests:
   - backend/specs/test_tts_spec.py
+  - backend/tests/test_characterization_tts_cache.py
+  - backend/tests/test_no_duplicate_azure_impl.py
 related_issues: []
 source_meetings:
   - docs/meetings/2026-05-01-experts-review.md
-last_reviewed: 2026-08-08
+last_reviewed: 2026-08-11
 owner: young
 ---
 
@@ -212,7 +215,7 @@ HTTP 4xx/5xx **不重試**（400 代表 SSML 寫錯，再送一次還是 400）�
 **仍然存在的殘餘風險**：真的連續 3 次都失敗時，還是會落到 Google 中國腔且不壓縮。
 若要完全根除，需要拿掉 fallback 或讓 fallback 不寫進快取 —— 尚未做。
 
-### 🔴 `__init__.py` 曾重複定義 `_synthesize_azure`（已修，但同型問題還有 6 個）
+### 🔴 `__init__.py` 曾重複定義 `_synthesize_azure`（已修）
 
 `__init__.py` 第 50 行 `from .providers.azure import _synthesize_azure`，第 166 行**又定義一次**。
 Python 取後者，所以那個 import 是死的 —— **整晚對 `providers/azure.py` 的修改在執行期完全沒作用**
@@ -220,9 +223,55 @@ Python 取後者，所以那個 import 是死的 —— **整晚對 `providers/a
 
 已刪除重複定義並加回歸鎖 `tests/test_no_duplicate_azure_impl.py`（用 AST 比對 import 與 def）。
 
-⚠️ **同樣被遮蔽的還有 6 個**：`_gcs_get`、`_gcs_put`、`_get_gcs_bucket`、`_l1_put`、
-`get_cached_tts`、`delete_tts_cache`。它們登記在測試的 `KNOWN` 白名單裡，**尚未處理** ——
-順手刪掉的風險太大（快取行為改變會直接影響線上），要單獨評估。
+### ✅ 同樣被遮蔽的 6 個 cache helper 已合併進 `cache.py`（2026-08-11，#2649）
+
+`_gcs_get`、`_gcs_put`、`_get_gcs_bucket`、`_l1_put`、`get_cached_tts`、`delete_tts_cache`
+曾經是同一種 shadow：`__init__.py` 從 `.cache` import 這六個名字，接著在同一檔案又各定義一次，
+Python 取後者，`cache.py` 裡的六份是不會被執行到的死程式碼。跟 `_synthesize_azure` 不同的是這次
+**兩份實作不等價**——`__init__.py` 裡實際在跑的六份是 provider-aware 的（`_l1_key(key, provider)`
+把 provider 併進 L1 鍵，避免 Google fallback 的音檔在 Azure 恢復後仍被誤讀），`cache.py` 裡被蓋掉
+的六份是舊的裸 key 版本。`tests/test_characterization_tts_cache.py` 測的正是 `cache.py`（死程式碼）
+那份，跟 `_synthesize_azure` 的教訓一樣：測試全綠不代表測到跑的那份。
+
+修法（kiro gpt-5.6-terra review 選定的方案）：把 `__init__.py` 裡「實際在跑」的 provider-aware 版本
+（含 `_PROVIDERS`、`_l1_key`）搬進 `cache.py`，`__init__.py` 只 import + re-export，不再定義任何一個。
+`_get_gcs_bucket`／`_gcs_get`／`_gcs_put` 的 import 語法也改用 `__init__.py` 原本那份的
+`import google.cloud.storage as storage`（跟 `cache.py` 舊版的 `from google.cloud import storage`
+在 sys.modules 已被真實填過的情況下其實同樣會繞過 mock——見下——但至少統一成正在跑的那個版本，
+不留兩種寫法）。`tests/test_no_duplicate_azure_impl.py` 的 `KNOWN` 白名單已清空——這六個名字現在
+和其他名字一樣，再被 shadow 就會讓測試紅。
+
+**consolidate 過程中另外抓到兩個既有測試「patch 目標下錯模組」的洞**（不是新 bug，是這次搬移才讓
+它現形）：
+- `_get_gcs_bucket` 的 `global _gcs_client` 現在只會改到 `cache.py` 自己的 `_gcs_client`——任何測試
+  用 `patch("app.services.tts_service._get_gcs_bucket", ...)`（或 `tts_module._gcs_client = ...`）
+  在合併前是對的（那時 `_get_gcs_bucket` 就住在 `__init__.py`），合併後這個 patch **完全接不到**，
+  會讓真的 `google.cloud.storage.Client()` 在測試裡跑起來。`tests/test_tts_service.py` 的
+  `TestDeleteTtsCache`（4 條）、`TestRegenerateEndpoint::test_regenerate_returns_ok`、
+  `TestGCSSentinel`（2 條，含 `_gcs_client` 本身的讀寫）、`tests/test_tts_l1_cache_not_provider_blind.py`
+  的 `TestDeleteTtsCacheClearsEveryProvider`（2 條）都改成對 `app.services.tts.cache` patch。
+- `@patch("app.services.tts_service._TTS_CACHE", {})`（字面 dict 取代整個屬性，不是就地清空）在
+  `_l1_put`/`delete_tts_cache` 搬進 `cache.py` 後會造成 split-brain：`_synthesize_speech_with_provider`
+  （還住在 `__init__.py`）讀的是被 patch 過的空 dict，但它呼叫的 `_l1_put`（住在 `cache.py`）寫的是
+  沒被 patch 到的真 dict——於是同一個 text 兩次 `synthesize_speech` 都被判定 cache miss。
+  `test_cache_prevents_second_api_call` 用這個 mutation 實測會紅（`assert 2 == 1`）。改成
+  `patch.dict(..., {}, clear=True)`——就地清空同一個物件，不論從哪個模組名字取都看得到。
+
+**這兩個洞怎麼被抓到的**：consolidate 完後拿 `#2649` 既有的 4 個 provider-blind regression 測試檔
+（`test_tts_l1_cache_not_provider_blind.py`、`test_tts_no_cross_provider_readthrough.py`、
+`test_no_duplicate_azure_impl.py`、`test_tts_service.py`）合起來跑，才冒出 `assert <Bucket:...> is None`
+這種「mock 沒接到、真的連了 GCS」的失敗——單獨跑每個檔案都是綠的，因為污染要跨測試才會顯出來
+（這台機器有真的 GCP ADC 憑證，Client() 真的會成功）。跟 `_synthesize_azure` 的教訓同源：
+**兩份看起來一樣的程式碼，測試分別匯入各自那份，各自綠，合起來看才知道哪個是活的。**
+
+**`test_characterization_tts_cache.py::TestGCSSentinel::test_sentinel_set_after_connection_failure`
+跟 `test_tts_service.py` 合跑仍會紅——這個是既有環境問題，consolidate 沒有讓它變好也沒有變壞**：
+一旦某個沒 mock TTS 的測試（`TestTTSPydanticValidation` 的 `test_whitespace_only_text_rejected`／
+`test_exactly_5000_chars_accepted`，故意不 mock、接受 200/422/503 都算過）讓 `google.cloud.storage`
+真的成功 import 過一次，`google.cloud` 這個 namespace package 就會把 `storage` 記成一個真實屬性，
+之後任何 `from google.cloud import storage` 或 `import google.cloud.storage as storage`
+都會先抓到這個屬性、完全不理會 `patch.dict("sys.modules", ...)`——這是 CPython import 系統本身的
+行為，跟 `_get_gcs_bucket` 住在哪個檔案無關。在沒有真 GCP 憑證的機器（如大部分 CI）上不會發生。
 
 ### ⚠️ 三個已知會騙過人的陷阱
 
@@ -268,9 +317,12 @@ provider 函式，非猜測）復現：Azure 失敗一次→Google 命中→Azur
 回歸鎖：`tests/test_tts_l1_cache_not_provider_blind.py`（含「重複呼叫仍命中 L1」的正向對照，
 證明沒有把 L1 整個關掉）。
 
-`_l1_put`/`get_cached_tts`/`delete_tts_cache` 仍在 §「已刪除重複定義」那段講的 6 個
-shadowed 函式名單裡（`__init__.py` 蓋掉 `cache.py` 的匯入）——這次只改了 `__init__.py`
-裡實際在跑的那份，`cache.py` 裡被蓋掉的死程式碼刻意沒動（風險隔離，見上一節的理由）。
+`_l1_put`/`get_cached_tts`/`delete_tts_cache` 當時仍在 §「已刪除重複定義」那段講的 6 個
+shadowed 函式名單裡（`__init__.py` 蓋掉 `cache.py` 的匯入）——這裡描述的修復只改了
+`__init__.py` 裡實際在跑的那份，`cache.py` 裡被蓋掉的死程式碼當時刻意沒動（風險隔離）。
+**這個保留已經不成立**：2026-08-11 的 consolidate（見上「同樣被遮蔽的 6 個 cache helper 已
+合併進 `cache.py`」）把這份 provider-aware 版本搬進了 `cache.py`，`cache.py` 不再有任何一份
+死程式碼，`__init__.py` 也不再定義這六個名字中的任何一個。
 
 ### ✅ 「和」連接詞規則的假陽性（2026-08-11，同一次 review）
 

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -717,6 +717,7 @@ modules:
   canonical_source: backend/app/services/tts/__init__.py
   owns_code:
   - backend/app/services/tts/__init__.py
+  - backend/app/services/tts/cache.py
   - backend/app/services/tts/providers/azure.py
   - backend/app/services/tts/providers/gemini.py
   - backend/app/services/tts/providers/google.py
@@ -724,9 +725,11 @@ modules:
   owns_data: []
   spec_tests:
   - backend/specs/test_tts_spec.py
+  - backend/tests/test_characterization_tts_cache.py
+  - backend/tests/test_no_duplicate_azure_impl.py
   related_issues: []
   source_meetings:
   - docs/meetings/2026-05-01-experts-review.md
-  last_reviewed: 2026-08-08
+  last_reviewed: 2026-08-11
   owner: young
   intent: specs/modules/tts/INTENT.md


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 這個 PR 做什麼

`backend/app/services/tts/__init__.py` 從 `.cache` import 六個名字
（`_gcs_get`、`_gcs_put`、`_get_gcs_bucket`、`_l1_put`、`get_cached_tts`、
`delete_tts_cache`），接著在同一檔案又各定義一次——跟 `_synthesize_azure` 曾經
出過的那個 bug 是同一種：Python 取後者，import 是死的，`cache.py` 裡的六份是
不會被執行到的死程式碼，`test_characterization_tts_cache.py` 測的正是那份死
程式碼

這次外部 reviewer（kiro gpt-5.6-terra）已經分析並選定做法：把 `__init__.py`
裡「實際在跑」的 provider-aware 版本（含 `_PROVIDERS`、`_l1_key`）搬進
`cache.py`，`__init__.py` 只 import + re-export，不再定義任何一個

## 動手前先驗證兩個關鍵斷言（不是憑讀 code 相信）

跑真 code 復現：
- `cache.py` 的 L1（`_l1_put`/`get_cached_tts`，裸 key）是 provider-blind
  的——Google fallback 寫進去的位元組，Azure 查詢原文字一樣拿得到
- `cache.py` 自己的 `_gcs_client` 跟 `__init__.py`（實際在跑那份）的
  `_gcs_client` 是兩個獨立的模組全域變數——透過正在跑的那個
  `_get_gcs_bucket` 觸發失敗 sentinel，`cache.py` 那份完全看不到

## consolidate 過程中另外抓到兩個既有測試「patch 錯模組」的洞

不是新 bug，是這次搬移才讓它現形：

1. `_get_gcs_bucket` 的 `global _gcs_client` 現在只會改到 `cache.py` 自己的
   `_gcs_client`——測試對 `app.services.tts_service._get_gcs_bucket`（或
   `tts_module._gcs_client`）下的 patch 在合併前是對的，合併後完全接不到，
   會讓真的 GCS Client() 在測試裡跑起來（這台機器真的有 GCP 憑證，會真的連
   線成功）。已把 `TestDeleteTtsCache`（4 條）、`TestRegenerateEndpoint` 那條、
   `TestGCSSentinel`（2 條）、`test_tts_l1_cache_not_provider_blind.py` 的
   `TestDeleteTtsCacheClearsEveryProvider`（2 條）改成對
   `app.services.tts.cache` patch
2. `@patch("app.services.tts_service._TTS_CACHE", {})`（字面 dict 取代整個
   屬性）造成 split-brain：讀（還在 `__init__.py`）看到被 patch 的空 dict，
   寫（搬進 `cache.py` 的 `_l1_put`）寫進沒被 patch 到的真 dict，於是同一段
   文字兩次 `synthesize_speech` 都判定 cache miss。用 mutation 實測會紅
   （`assert 2 == 1`）。改成 `patch.dict(..., {}, clear=True)`

兩個洞都各自 mutation 測過：故意把修復改回錯的版本，確認測試會紅，再改回來

## 驗證

- `backend/tests/test_no_duplicate_azure_impl.py` 的 `KNOWN` 白名單清空——這六
  個名字現在跟其他名字一樣，再被 shadow 會讓測試紅（mutation 測過：重新 shadow
  一次確認會紅）
- `backend/tests/test_characterization_tts_cache.py` 改成 provider-aware 斷言，
  加一條新的 provider 隔離正負對照測試（mutation 測過：讓 `_l1_key` 忽略
  provider，確認這條跟既有 4 條 regression 測試一起變紅）
- `scripts/verify_lesson_audio.py` 的 monkeypatch 機制端到端驗證：它 patch
  `tts_module._gcs_get/_gcs_put`（那個函式呼叫點還住在 `__init__.py`，所以
  patch 有效）、`_TTS_CACHE.clear()` 清的是 `cache.py` 真正在用的那個物件
  （import 綁定不是複製，同一顆 dict）
- 完整 backend 測試（`tests/` + `specs/`，約 4300 個測試）跑完整跑一次，
  FAILED/ERROR 清單跟改動前逐行 diff 完全相同（`diff` exit code 0），
  只多一條新增測試通過。既有失敗（DB fixture 缺表、這台機器真 GCP 憑證觸發
  `google.cloud.storage` import 快取繞過 `sys.modules` patch）跟這次改動無關，
  沒有動它
- `specs/` gate：751 passed, 4 xfailed（無 failed）
- `specs/build_registry.py --check` 綠

## 沒做的事

- 沒有動 `cache.py` 舊版 `from google.cloud import storage` 以外的 GCS 讀寫
  邏輯本身——只統一成目前正在跑那份的 import 寫法（`import
  google.cloud.storage as storage`），行為不變
- `test_characterization_tts_cache.py::TestGCSSentinel` 跟
  `test_tts_service.py` 合跑仍會紅——這是既有環境問題（見上，跟這次改動無關），
  沒有嘗試修，照實記錄在 `specs/modules/tts/INTENT.md`
