### PR TITLE
docs(prd): 課文身份鍵重整 + 175 課教材重建 (Fixes #2683)

### DIFF
--- a/docs/prd/2026-08-14-second-edition-reink.md
+++ b/docs/prd/2026-08-14-second-edition-reink.md
@@ -163,11 +163,67 @@ published:
 
 ---
 
+## 三之二、清理清單（全部實測盤過，逐項標明刪或留）
+
+> 原則：**舊資料不要了 → 該刪就刪，不留半條相容路徑。**
+> 唯一例外是與課文版本無關的快取。
+
+### repo 內
+
+| 對象 | 量 | 動作 | 理由 |
+|---|---|---|---|
+| `backend/data/lessons/L*.yml`（Layer-1） | 57 檔 | 🔴 **刪** | 2026-02 手工建，5/1 就該退役 |
+| `backend/data/lessons/_parsed_2026-05-01/`（Layer-2） | 152 檔 | 🔴 **刪** | 一修 parse 產物 |
+| `backend/data/lessons/_reparsed_2026-05-02/` | 3 檔 | 🔴 **刪** | 同上（被 4 處引用，要一起清） |
+| `backend/data/lessons/_ai_lessons/` | 8 檔 | 🔴 **刪** | 早期 AI 產物（被 2 處引用，要一起清） |
+| `backend/data/lessons/spotlight/catalog/` | 113 檔 | 🔴 **刪** | 檔名綁舊課號，重抽 |
+| `backend/data/lessons/spotlight/dev7/` | 8 檔 | 🔴 **刪** | 早期手工策展 7 課，二修後無意義 |
+| `backend/data/lessons/spotlight/test15/` | 15 檔 | 🔴 **刪** | 同上 |
+| `backend/data/curriculum/manifest.yml` | 158 筆 | 🔴 **重建** | 改成 `catalog_manifest.yml`（slot → uid+version） |
+| `backend/data/key_reading_passages.yml` | 134 條 | 🔴 **重建** | by 舊課號，且 32 條已是孤兒 |
+| `docs/lesson-schema-registry.yaml` | — | 🔴 **重建** | 由新 pipeline 產 |
+
+⚠️ `_ai_lessons` 與 `_reparsed_2026-05-02` 各有引用點（2 處 / 4 處），
+**刪之前要先跑反向依賴掃描**，不能直接 `rm -rf`。
+
+### GCS
+
+| 對象 | 量 | 動作 | 理由 |
+|---|---|---|---|
+| `gs://lingoleap-assets/worksheets/` | **458 物件** | 🔴 **清空重上** | 全一修，最後更新 6/16，檔名綁舊課號 |
+| `gs://lingoleap-assets/demo-reading/` | **444 物件** | 🔴 **清空重產** | 綁舊 story_id 的音檔 + QR |
+| `gs://lingoleap-assets/lessons-images/` | — | 🟡 **盤點後再定** | 圖片可能與課文版本無關，先查引用 |
+| `gs://lingoleap-assets/stories/` | — | 🟡 **盤點後再定** | 同上 |
+| `gs://lingoleap-assets/qa/`、`pr-screenshots/` | — | ⚪ **不動** | 與教材無關 |
+| **`gs://lingoleap-tts-cache/azure/`** | — | ✅ **保留** | 快取鍵是 `sha256(文字)`，與課號版本無關；刪＝重燒錢 |
+| `gs://lingoleap-tts-cache/gemini31-prompt-only-v2/` | — | 🟡 **可刪** | 已切 Azure，非現行 provider |
+| `gs://lingoleap-tts-cache/tts-cache/` | — | 🔴 **刪** | 中國腔 fallback 的來源，留著會被回讀汙染 |
+| `gs://lingoleap-tts-cache/_backup-*` ×3 | 22 / 340 / 235 物件 | 🟡 **可刪** | 8/10 修音時的備份，已無用 |
+
+### DB
+
+| 對象 | 動作 |
+|---|---|
+| 課文相關資料表（stories / lesson content） | 🔴 **清空重建** |
+| 學習紀錄（learning session / reading history） | 🔴 **清空** —— 都是內部測試資料，且舊紀錄綁舊 `lesson_id`，留著只會污染新版統計 |
+| 使用者 / 班級 / 作業 | ⚪ **不動** —— 與教材版本無關 |
+
+### 清理順序（不可顛倒）
+
+```
+1. 先掃反向依賴（_ai_lessons / _reparsed / dev7 / test15 的引用點）
+2. 先在 staging 清 + 重建 + 驗收
+3. 驗收過才動 prod
+4. tts-cache/azure/ 全程不碰
+```
+
+---
+
 ## 四、不做（本次範圍外）
 
 | 不做 | 為什麼 |
 |---|---|
-| **不刪 `tts-cache`** | 快取鍵是 `sha256(文字)`，與課號版本無關。刪掉等於重燒一次 TTS 費用 |
+| **不刪 `tts-cache/azure/`** | 快取鍵是 `sha256(文字)`，與課號版本無關。刪掉等於重燒一次 TTS 費用（其餘 prefix 見清理清單） |
 | **不動 prod** | staging 驗完才複製 |
 | **不上學生版下載** | Hans 轉換中，本次只上教師版抽出的平台內容 |
 | **不點亮未檢核的聚光燈** | 機制修好 ≠ 內容驗過，用 manifest 逐批開 |
@@ -209,7 +265,8 @@ uid 無重複、無重用。
 **驗收**：`build_ok` 175/175；失敗逐課列原因，不隱藏。
 
 ### Phase 5 — 落地 staging
-清 `catalog/` 113 檔、清 `assets/worksheets/` 458 檔、寫入新結構、deploy。
+照「三之二 清理清單」逐項執行：repo 內 356 檔 + GCS 902 物件 + DB 課文與學習紀錄，
+寫入新結構、deploy。**清理前先跑反向依賴掃描。**
 
 **驗收**：staging 抽 10 課真瀏覽器走完流程、0 console error。
 

--- a/docs/prd/2026-08-14-second-edition-reink.md
+++ b/docs/prd/2026-08-14-second-edition-reink.md
@@ -86,28 +86,59 @@ Drive 分佈：G4=20 / G5=28 / G6=29 / G7=30 / G8=23 / G9=23 / 文言文=12 / �
 
 **只有「發一次就不再改的號碼」四種情況全過。**
 
+### 四個要分開的概念（codex 審查後修正）
+
+第一版只有 `lesson_uid` 一層，**分不出一修/二修** —— `<uid>/spotlight.yml`
+沒有版本資訊。四個概念必須分開：
+
+| 概念 | 是什麼 | 會不會變 |
+|---|---|---|
+| `lesson_uid` | 這是哪一篇課文 | **永不變** |
+| `version_id` | 教材版本（一修/二修/三修） | 每次改版新增 |
+| `catalog_slot` | 當期排在哪（`G4-L10`） | 每次重排都變 |
+| `published_version` | 目前預設出哪一版 | 可切換、可回退 |
+
+**`catalog_slot` 不是身份** —— 它住在 manifest 裡，指向 `uid + version`，
+不可以變成資料夾名。
+
 ### 資料形狀
 
 ```
-backend/data/lessons/<lesson_uid>/
-  ├── lesson.yml        # 身份 + 屬性（見下）
+backend/data/lessons/<lesson_uid>/<version_id>/
+  ├── lesson.yml        # 屬性
   ├── passage.yml       # 課文
   ├── spotlight.yml     # 閱讀聚光燈
   ├── keypoints.yml     # 文章重點表
   ├── key_reading.yml   # 重點朗讀
-  └── assets/           # 圖片等
+  └── assets/
+
+backend/data/catalog_manifest.yml     # catalog_slot → uid + version + 各模組狀態
 ```
+
+`catalog_manifest.yml` 同時承擔 **partial publish** —— 一課可能課文已上、
+聚光燈未過 QA、講義待補，要能逐模組標狀態，不是整課全開或全關。
 
 `lesson.yml`：
 
 ```yaml
-lesson_uid: L0042          # 🔴 發一次，永不改、永不重用。QR 綁這個
+lesson_uid: L0042          # 🔴 registry 分配，永不改、永不重用。QR 綁這個
+version_id: v2             # 這個資料夾是哪一版
 title: 救援大隊的好幫手      # 屬性，可變
-codes:                     # 歷次課號，保留歷史
-  - {code: G4-L19, edition: 1}
-  - {code: G5-L11, edition: 2}   # 二修搬到五年級
 grade: 5                   # 屬性，可變
-edition: 2                 # 目前版本
+```
+
+`catalog_manifest.yml`：
+
+```yaml
+published:
+  G5-L11:                  # catalog_slot（每次重排都變）
+    lesson_uid: L0042
+    version_id: v2
+    modules:               # partial publish — 逐模組狀態
+      passage:    on
+      spotlight:  qa_pending
+      keypoints:  on
+      worksheet:  missing
 ```
 
 **課號、課名、年級、策略標籤 → 全部降級成屬性。**
@@ -195,7 +226,10 @@ uid 無重複、無重用。
 
 | 風險 | 處置 |
 |---|---|
-| 🔴 **Phase 2 改載入層是全域影響** | 最危險的一步。先在容器內驗，staging 先行，prod 不動 |
+| 🔴 **舊 `lesson_id` → 新 `uid/version` 的對照回填** | **最危險的一步，不是搬檔案。** 公開 URL、slug normalization、學習紀錄、OMO、TTS 都已把 integer `lesson_id` 當成事實（`lesson_loader.py:97`、`slug.py:73`、`stories.py:436`、`learning_reading_history.py:92`）。mapping 錯一筆，**API 照樣 200**，但學生紀錄、QR、音檔會接到錯課 —— 資料忠實度錯，一般測試抓不到。→ 對照表逐筆人工確認 + 寫回歸鎖 |
+| 🔴 **學習紀錄沒有版本欄位** | `learning_reading_history.py:92` 只存 `lesson_id`，查詢也只用 `student_id + lesson_id`（:135）。二修後舊紀錄會被新課文語意覆蓋，成績比較失真。→ 存紀錄時要一併寫入 `version_id` |
+| **Phase 2 改載入層是全域影響** | 先在容器內驗，staging 先行，prod 不動 |
+| **uid 不可自行推導** | 必須由 registry 分配。若有人從檔名生 uid，就又回到「檔名即身份」的老錯 |
 | pipeline 輸出格式要改 code | 已確認 `process_lesson()` 寫死扁平路徑，Phase 3 含這項改動 |
 | 二修課名/課號對不到舊課 | Phase 1 的 uid registry 逐筆人工確認，不自動猜 |
 | 誤刪 tts-cache | 明列不做；刪除指令先確認 bucket 名 |
@@ -208,12 +242,13 @@ uid 無重複、無重用。
 ## 七、驗收條件
 
 1. 175 課在 staging 可見且可完成學習流程
-2. 資料結構為 `<lesson_uid>/<模組>.yml`，loader 讀得到
+2. 資料結構為 `<lesson_uid>/<version_id>/<模組>.yml`，loader 讀得到
 3. **撞鍵組數 = 0**（現在 13）
 4. 容器內（非本機）驗證通過
 5. 講義下載指向二修版，或**明確關閉**（學生版未就位前不得指向一修）
 6. 聚光燈/重點表：過 QA 的已點亮，未過的已隱藏且列冊
 7. `tts-cache` 未被清空
+8. **學習紀錄寫入時帶 `version_id`**
 
 ---
 

--- a/docs/prd/2026-08-14-second-edition-reink.md
+++ b/docs/prd/2026-08-14-second-edition-reink.md
@@ -1,46 +1,57 @@
-# PRD — 二修教材全刷重建（Second-Edition Re-ink）
+# PRD — 教材重建與課文身份架構重整
 
-> 2026-08-14 ｜ 決策人：Young ｜ 來源：8/14 團隊會議逐字稿 + 當日實測查證
-> 狀態：待啟動
+> 2026-08-14 ｜ 決策人：Young ｜ 來源：8/14 會議逐字稿 + 當日實測
+> 取代目標：一次解決「每次改版都會亂」的結構問題，不只是這次的二修
 
 ---
 
-## 一、WHY — 為什麼要「全刷」而不是「增量修」
+## 一、WHY
 
-### 1. 內容改動幅度太大，增量不划算
+### 1. 二修改了 7~8 成，增量修不划算
 
-啟翔在 8/14 會議實測後回報：**二修改了 7~8 成的課**。
-在這個比例下，「找出一修與二修的差異、只改動到的部分」的成本高於直接重建，
-而且每一課都要人工確認差異，等於做了兩次工。
-
-Young 的原話：**「我根本不知道二修跟一修的差別，不如重刷。」**
+啟翔實測回報。Young：「我根本不知道二修跟一修的差別，不如重刷。」
 
 ### 2. 舊資料沒有保留價值
 
-平台**尚未進入真實教學現場**，目前所有資料都是內部測試產生的。
-沒有真實學生學習紀錄、沒有已發出的紙本、沒有對外承諾綁定任何一課。
-→ **一修資料的保留成本 > 保留價值**。
+平台**尚未進真實現場**，無學生紀錄、無已發紙本、無對外承諾綁課。
 
-### 3. 現行資料結構會讓每次改版都重痛一次
+### 3. 🔴 真正的病根：現在沒有任何可靠的「這是哪一課」的鍵
 
-啟翔的原話：
-> 「全部都在同一份 YAML 裡面，然後就很大份……我請他做某件事，他會一直去抓其他的，
-> 有關聯但又不全然有關聯，因為太多東西混在一起了。我人腦去看他給我的 output 也很痛苦。」
+載入層是**兩層合併**，而且是歷史意外不是設計：
 
-現況是**兩種結構並存**：
-- 舊：一課一個大 YAML，所有模組混在一起（設計目的是預先全載）
-- 新：聚光燈另外獨立成 `catalog/<課號>.spotlight.yml`
+```
+2026-02-26  Layer-1  backend/data/lessons/L*.yml            57 課，手工建
+2026-05-01  Layer-2  backend/data/lessons/_parsed_2026-05-01/  152 檔，DOCX 批次 parse
+```
 
-而且**聚光燈檔名是綁課號的**，二修重排課號後全部對不到。
+5/1 批次 parse 了 158 課，**沒有把舊的 57 課退役**，改寫一段「用課名去重 + enrich」
+把兩層黏起來（`lesson_indexes.py: build_all_lessons()`）。
 
-### 4. 一個擋了四個月的 bug 剛修好，正好是重建的前提
+**實測後果**：
 
-`backend/Dockerfile` 只 COPY `app/ data/ alembic/`，沒有 COPY `scripts/`
-（也複製不到 —— build context 是 `./backend`，`scripts/` 在上一層）。
-runtime 動態 import adapter 失敗 → fail-closed → **124 課有素材但只有 7 課吐得出內容**。
+| 用什麼當鍵 | 撞鍵組數 | 涉及課數 |
+|---|---|---|
+| 課名（正規化後） | 10 組 | 20 課 |
+| 正規化課號 | **13 組** | **26 課** |
 
-已修並 merged（`33b0532c`）。容器內實測：修前 7 課、修後 124 課。
-**沒有這個修復，重建出來的內容一樣顯示不出來。**
+```
+G4-L1   → ids=[1, 1001]      贏得喝采的輸家
+G5-L11  → ids=[11, 1038]     「拳」力出擊 vs 拳力出擊     ← 引號差異
+G6-L1   → ids=[14, 1055]     運動傷害，怎麼辦？ vs 怎麼辦  ← 問號差異
+文-L1   → ids=[44, 1149]
+```
+
+每一組都是「Layer-1 低 id」對上「Layer-2 的 1000+ id」。
+課名差一個標點 → enrich 失敗 → **Layer-1 那筆變空殼**。
+這就是 165 課裡有 20 課沒有聚光燈素材的真因（不是內容缺，是對應斷）。
+
+**課名會變、課號會變，兩個都不能當身份。** 不解掉這件事，三修四修還會再亂一次。
+
+### 4. adapter 進不了 image 的 bug 剛修好，是重建的前提
+
+`backend/Dockerfile` 只 COPY `app/ data/ alembic/`，沒 COPY `scripts/`（也複製不到，
+build context 是 `./backend`）→ runtime import 失敗 → fail-closed → **124 課有素材只有 7 課吐得出內容**。
+已 merged `33b0532c`；容器內實測：修前 7、修後 124。
 
 ---
 
@@ -48,162 +59,161 @@ runtime 動態 import adapter 失敗 → fail-closed → **124 課有素材但�
 
 | 項目 | 數字 | 取得方式 |
 |---|---|---|
-| Drive 新教材（SOT） | **175 課** docx | `rclone lsf` 該資料夾，扣掉 1 個 `~$` 暫存檔 |
-| 線上 DB 課數 | **165** | `/api/stories?page_size=300` 的 `total` |
-| 聚光燈 catalog 檔 | 113（manifest 列 108） | `ls` + 讀 manifest.json |
-| 有 `spotlight_v2` 素材 | 124 | 容器內跑 loader 統計 |
+| Drive 新教材（SOT） | **175 課** | `rclone lsf`，扣 1 個 `~$` 暫存檔 |
+| 線上 DB | **165**（= L1 57 + L2 108） | `/api/stories?page_size=300` |
+| 其中重複空殼 | **20~26 課** | 課名/課號撞鍵實測 |
+| 聚光燈 catalog | 113 檔（manifest 列 108） | `ls` + manifest |
+| 有 `spotlight_v2` 素材 | 124 | 容器內跑 loader |
 | `assets/worksheets/` | 458 檔，最後更新 **6/16** | `gcloud storage ls -l` |
 | `tts-cache` | **1523 MB** | `gcloud storage du` |
-| `reading-audio` ×2 | 0 MB（空） | 同上 |
 
-Drive 年級分佈：G4=20 / G5=28 / G6=29 / G7=30 / G8=23 / G9=23 / 文言文=12 / 體育生品格=11
-
-> ⚠️ 這解掉了會議上「159 還是 180 課」的爭議 —— **實際是 175**。
-> 比線上多 10 課，代表二修有新增課次。
+Drive 分佈：G4=20 / G5=28 / G6=29 / G7=30 / G8=23 / G9=23 / 文言文=12 / 體育生品格=11
+→ 解掉會議上「159 還是 180」的爭議：**是 175**。
 
 ---
 
-## 三、WHAT — 做什麼 / 不做什麼
+## 三、WHAT — 新的身份架構
 
-### 做
+### 核心原則：身份跟編號、名稱、內容全部脫鉤
 
-1. 以 Drive 175 課教師版 docx 為唯一來源，**重建全部課文內容**
-2. **改資料結構**：一課一個 folder，模組各自獨立 YAML，按需載入
-3. 清掉一修的 DB 資料、講義檔、聚光燈 catalog
-4. 重跑聚光燈、重點表、重點朗讀
-5. 朗讀改用 AI TTS（不再人工錄音）
-6. intro 頁移除全文朗讀鈕（全文朗讀統一在第二頁）
+| 候選鍵 | 課號重排 | 課名改標點 | 新增課文 | 同課出新版 |
+|---|---|---|---|---|
+| 課名 | ✅ | 🔴 | ✅ | 🔴 |
+| 課號 `G4-L1` | 🔴 | ✅ | ✅ | ✅ |
+| 年級+課次複合鍵 | 🔴 | ✅ | ✅ | ✅ |
+| 內容雜湊 | ✅ | ✅ | ✅ | 🔴 |
+| **不可變流水號** | ✅ | ✅ | ✅ | ✅ |
 
-### 不做（本次範圍外）
+**只有「發一次就不再改的號碼」四種情況全過。**
+
+### 資料形狀
+
+```
+backend/data/lessons/<lesson_uid>/
+  ├── lesson.yml        # 身份 + 屬性（見下）
+  ├── passage.yml       # 課文
+  ├── spotlight.yml     # 閱讀聚光燈
+  ├── keypoints.yml     # 文章重點表
+  ├── key_reading.yml   # 重點朗讀
+  └── assets/           # 圖片等
+```
+
+`lesson.yml`：
+
+```yaml
+lesson_uid: L0042          # 🔴 發一次，永不改、永不重用。QR 綁這個
+title: 救援大隊的好幫手      # 屬性，可變
+codes:                     # 歷次課號，保留歷史
+  - {code: G4-L19, edition: 1}
+  - {code: G5-L11, edition: 2}   # 二修搬到五年級
+grade: 5                   # 屬性，可變
+edition: 2                 # 目前版本
+```
+
+**課號、課名、年級、策略標籤 → 全部降級成屬性。**
+
+### 三個直接後果
+
+1. **課號重排 = 改屬性** —— 不搬檔、不改 folder、不動 QR
+2. **新增課文 = 發一個新 uid** —— 不影響任何既有課
+3. **同課出新版 = 同一個 uid 換 edition** —— 學習紀錄與 QR 都不斷
+
+### 為什麼 folder 用 uid 而不是課號
+
+現在聚光燈是 `catalog/G4-L11.spotlight.yml` —— 課號一改，113 個檔全部對不到。
+改用 uid 之後，**任何改版都不需要動檔名**。
+
+### 順帶解掉啟翔的痛點
+
+他的原話：「全部都在同一份 YAML 裡面……我請他做某件事，他會一直去抓其他的，
+太多東西混在一起了。」
+
+模組各自一檔 + 按需載入 → 做聚光燈時只看得到 `spotlight.yml`。
+
+---
+
+## 四、不做（本次範圍外）
 
 | 不做 | 為什麼 |
 |---|---|
-| **不刪 `tts-cache`** | 快取鍵是 `sha256(文字)`，與課號、版本無關。二修沒改到的句子會直接命中；刪掉等於重新燒一次 TTS 費用 |
-| **不動 prod** | 先在 staging 完成並驗收，prod 待 staging 驗過再複製 |
-| **不上學生版/解答版下載** | Hans 還在轉換中，本次只上教師版抽出的**平台內容** |
-| **不點亮未檢核的聚光燈** | 機制修好 ≠ 內容驗過。用 manifest 控制，逐批開 |
-| **不追教授正式審稿** | 會議已定調：雙方無合約義務，改以「模組完成即上線、未完成先隱藏」 |
-
----
-
-## 四、資料結構變更
-
-### 現況（會讓每次改版重痛）
-
-```
-backend/data/lessons/spotlight/catalog/G4-L11.spotlight.yml   ← 檔名綁課號
-backend/data/lessons/<某個大 YAML>                            ← 所有模組混在一起
-```
-
-### 目標
-
-```
-backend/data/lessons/<story_id>/
-  ├── meta.yml            # 課名、年級、課號、策略
-  ├── passage.yml         # 課文
-  ├── spotlight.yml       # 閱讀聚光燈
-  ├── keypoints.yml       # 文章重點表
-  ├── key_reading.yml     # 重點朗讀（念順順）
-  └── ...                 # 其他模組各自一份
-```
-
-**兩個關鍵設計**：
-
-1. **folder 用 `story_id` 不用課號** —— 課號會隨改版重排，`story_id` 不會。
-   這樣二修、三修、四修都不會再撞到「檔名對不到」的問題。
-2. **按需載入** —— 點到哪個關卡才讀那個模組的 YAML。
-   AI 做某個模組時只會看到那個模組的資料，不會再吃到別的模組（直接解掉啟翔的痛點）。
+| **不刪 `tts-cache`** | 快取鍵是 `sha256(文字)`，與課號版本無關。刪掉等於重燒一次 TTS 費用 |
+| **不動 prod** | staging 驗完才複製 |
+| **不上學生版下載** | Hans 轉換中，本次只上教師版抽出的平台內容 |
+| **不點亮未檢核的聚光燈** | 機制修好 ≠ 內容驗過，用 manifest 逐批開 |
+| **不追教授正式審稿** | 會議定調：雙方無合約義務，改「模組完成即上線、未完成先隱藏」 |
 
 ---
 
 ## 五、HOW — 手順
 
-> 每個階段都是一張 issue、一個 PR。**上一階段驗收通過才進下一階段。**
+> 每階段一張 issue、一個 PR。**上一階段驗收過才進下一階段。**
+> 驗收一律以**容器內**行為為準 —— adapter 那個 bug 就是本機綠、線上壞。
 
 ### Phase 0 — 前置（已完成）
+- [x] adapter 修復 merged（`33b0532c`）
+- [x] Drive SOT 就位，175 課
+- [x] 實習生 GCS 讀取權限開通
 
-- [x] adapter 進不了 image 的 bug 修復並 merged（`33b0532c`）
-- [x] Drive SOT 建立，175 課教師版就位
-- [x] 實習生 GCS 讀取權限開通（`objectViewer` + `legacyBucketReader`）
+### Phase 1 — 發 uid + 建對照表
+產出 `docs/curriculum/lesson-uid-registry.yml`：
+每課一個 `lesson_uid`，記錄 `舊 story_id / 舊課號 / 二修課號 / 課名 / Drive 路徑`。
 
-### Phase 1 — 對照表：175 課 ↔ 線上 165 課
+**驗收**：175 課全部有 uid；線上 165 課逐筆對到 uid 或標 `retire`；
+uid 無重複、無重用。
 
-**產出**：`docs/curriculum/second-edition-mapping.csv`
+### Phase 2 — 改載入層，單層化
+- 廢除 Layer-1/Layer-2 合併與課名 enrich
+- loader 改讀 `<lesson_uid>/` 單層
+- 舊的 57 個 `L*.yml` 退役
 
-| 欄位 | 說明 |
-|---|---|
-| `docx_path` | Drive 上的相對路徑 |
-| `new_code` | 從檔名解析的二修課號 |
-| `title` | 課名 |
-| `story_id` | 對應的線上 story_id（**沿用**）；查無對應則標 `NEW` |
-| `status` | `matched` / `new` / `online_only` |
+**驗收**：容器內 loader 讀得到；撞鍵組數 = **0**（現在是 13）。
 
-**為什麼要先做這張表**：165 → 175 之間有 10 課的差額，
-不知道哪些是新增、哪些是改名，就無法判斷「線上那課該保留還是該刪」。
+### Phase 3 — 抽取 5 課試跑
+`run_lesson_pipeline.py` 已實測可吃二修 DOCX（72 課 `build_ok` 72/72），
+但**輸出路徑是寫死的扁平結構**（`{lesson_id}.spotlight.yml`）→ 要改成寫進 `<uid>/`。
 
-**驗收**：`matched + new` 覆蓋全部 175 課；`online_only` 逐筆有處置決定。
+**驗收**：5 課在容器內能被讀到並吐出 `lesson_content`。
 
-### Phase 2 — 重建腳本（先跑 5 課，不碰線上）
+### Phase 4 — 全量 175 課
+**驗收**：`build_ok` 175/175；失敗逐課列原因，不隱藏。
 
-用既有的 `run_lesson_pipeline.py`（已實測可吃二修 DOCX，72 課 `build_ok` 72/72），
-輸出改寫成 Phase 4 的新 folder 結構。
+### Phase 5 — 落地 staging
+清 `catalog/` 113 檔、清 `assets/worksheets/` 458 檔、寫入新結構、deploy。
 
-**驗收**：5 課在**容器內**能被 loader 讀到並吐出 `lesson_content`。
-⛔ 本機綠不算 —— 這次的 adapter bug 就是本機綠、線上壞。
+**驗收**：staging 抽 10 課真瀏覽器走完流程、0 console error。
 
-### Phase 3 — 全量抽取 175 課（仍不碰線上）
+### Phase 6 — 朗讀 TTS
+**`tts-cache` 不清**，未改動的句子直接命中。
+**驗收**：抽 10 課有音檔且非瀏覽器機器音（回應約 177–197KB）。
 
-**驗收**：`build_ok` 175/175；失敗的逐課列出原因，不隱藏。
-
-### Phase 4 — 資料結構切換 + 落地 staging
-
-1. 清掉 `backend/data/lessons/spotlight/catalog/`（113 檔）
-2. 寫入新的 `<story_id>/` 結構
-3. loader 改讀新結構
-4. `assets/worksheets/` 458 檔清掉，改上二修教師版
-5. deploy staging
-
-**驗收**：staging 上抽驗 10 課，真瀏覽器走完學習流程、0 console error。
-
-### Phase 5 — 朗讀重生成
-
-AI TTS 重跑。**`tts-cache` 不清** —— 未改動的句子直接命中。
-
-**驗收**：抽驗 10 課有音檔且非瀏覽器機器音（看回應大小，Azure 約 177–197KB）。
-
-### Phase 6 — 聚光燈 / 重點表 QA 與逐批點亮
-
-由啟翔、靖杭 QA。用 `catalog/manifest.json` 控制開關 —— **驗過一批才加一批**。
-未通過的先隱藏，會議已定調「模組完成即上線，未完成先隱藏」。
-
-### Phase 7 — prod
-
-staging 驗收通過後複製到 prod。
+### Phase 7 — QA 逐批點亮 → prod
+啟翔（聚光燈）、靖杭（重點表/朗讀）。用 manifest 控制，驗過一批開一批。
 
 ---
 
-## 六、風險與回退
+## 六、風險
 
 | 風險 | 處置 |
 |---|---|
-| 抽取失敗率高於預期 | Phase 2 先跑 5 課即可發現；不進 Phase 3 |
-| 新資料結構讓 loader 壞掉 | Phase 4 前先在容器內驗過；staging 先行，prod 不動 |
-| 誤刪 tts-cache | **明列為不做事項**；任何刪除指令要先確認 bucket 名 |
-| 二修還有課沒給齊 | Hans 向明珠老師確認 175 是否為全部（會議 action item） |
-| 線上 10 課在 Drive 找不到對應 | Phase 1 的 `online_only` 逐筆決定：保留舊版 or 下架 |
+| 🔴 **Phase 2 改載入層是全域影響** | 最危險的一步。先在容器內驗，staging 先行，prod 不動 |
+| pipeline 輸出格式要改 code | 已確認 `process_lesson()` 寫死扁平路徑，Phase 3 含這項改動 |
+| 二修課名/課號對不到舊課 | Phase 1 的 uid registry 逐筆人工確認，不自動猜 |
+| 誤刪 tts-cache | 明列不做；刪除指令先確認 bucket 名 |
+| 175 課不是全部 | Hans 向明珠老師確認（會議 action item） |
 
-**回退路徑**：全程只動 staging；一修資料在 git 有完整歷史，隨時可還原。
+**回退**：全程只動 staging；一修資料 git 有完整歷史。
 
 ---
 
-## 七、驗收條件（全部達成才算完成）
+## 七、驗收條件
 
-1. Drive 175 課全部在 staging 可見且可完成學習流程
-2. 資料結構已切換成 `<story_id>/<模組>.yml`，loader 讀得到
-3. 容器內（非本機）驗證通過
-4. 講義下載指向二修版本，或**明確關閉**（學生版未就位前不得指向一修）
-5. 聚光燈/重點表：通過 QA 的已點亮，未通過的已隱藏且列冊
-6. `tts-cache` 未被清空
+1. 175 課在 staging 可見且可完成學習流程
+2. 資料結構為 `<lesson_uid>/<模組>.yml`，loader 讀得到
+3. **撞鍵組數 = 0**（現在 13）
+4. 容器內（非本機）驗證通過
+5. 講義下載指向二修版，或**明確關閉**（學生版未就位前不得指向一修）
+6. 聚光燈/重點表：過 QA 的已點亮，未過的已隱藏且列冊
+7. `tts-cache` 未被清空
 
 ---
 
@@ -211,19 +221,20 @@ staging 驗收通過後複製到 prod。
 
 | Phase | 主責 |
 |---|---|
-| 1–5 | Young（會議決定先自己跑一版，卡住再交接） |
-| 6 | 啟翔（聚光燈）、靖杭（重點表 / 朗讀） |
-| 學生版 + 解答版 docx | Hans（三版本轉換，8/31 前） |
-| 向明珠老師確認 175 是否為全部 | Hans |
+| 1–6 | Young（先自己跑一版，卡住再交接） |
+| 7 | 啟翔（聚光燈）、靖杭（重點表/朗讀） |
+| 學生版 + 解答版 docx | Hans，8/31 前 |
+| 確認 175 是否為全部 | Hans |
 
 ---
 
-## 附錄：本文件所有數字的取得方式
+## 附錄：本文所有數字的取得方式
 
-- Drive 課數 — `rclone lsf --drive-root-folder-id <id> gdrive: -R --files-only --include "*.docx"`
-- 線上課數 — `curl /api/stories?page_size=300` 讀 `total`（⚠️ 參數是 `page_size` 不是 `limit`）
-- 容器內行為 — `docker run --rm -i --entrypoint python <prod image digest> - < probe.py`
-- GCS 用量 — `gcloud storage du -s gs://<bucket>`
-- 一修最後改動 — `git log --since=2026-07-21 -- backend/data/curriculum/`（空 = 未動）
+- Drive — `rclone lsf --drive-root-folder-id <id> gdrive: -R --files-only --include "*.docx"`
+- 線上課數 — `curl /api/stories?page_size=300` 讀 `total`（參數是 `page_size` 不是 `limit`）
+- 撞鍵統計 — 載入 `_ALL_LESSONS` 後用課名正規化 / `normalize_manifest_code` 分別分組
+- 容器內行為 — `docker run --rm -i --entrypoint python <image digest> - < probe.py`
+- GCS — `gcloud storage du -s gs://<bucket>`
+- 兩層何時生的 — `git log --reverse -- backend/data/lessons/L01.yml` 與 `_parsed_2026-05-01/`
 
-⛔ 本文件不採用狀態檔、舊議程或記憶作為事實來源。
+⛔ 不採用狀態檔、舊議程或記憶作為事實來源。

--- a/docs/prd/2026-08-14-second-edition-reink.md
+++ b/docs/prd/2026-08-14-second-edition-reink.md
@@ -1,0 +1,229 @@
+# PRD — 二修教材全刷重建（Second-Edition Re-ink）
+
+> 2026-08-14 ｜ 決策人：Young ｜ 來源：8/14 團隊會議逐字稿 + 當日實測查證
+> 狀態：待啟動
+
+---
+
+## 一、WHY — 為什麼要「全刷」而不是「增量修」
+
+### 1. 內容改動幅度太大，增量不划算
+
+啟翔在 8/14 會議實測後回報：**二修改了 7~8 成的課**。
+在這個比例下，「找出一修與二修的差異、只改動到的部分」的成本高於直接重建，
+而且每一課都要人工確認差異，等於做了兩次工。
+
+Young 的原話：**「我根本不知道二修跟一修的差別，不如重刷。」**
+
+### 2. 舊資料沒有保留價值
+
+平台**尚未進入真實教學現場**，目前所有資料都是內部測試產生的。
+沒有真實學生學習紀錄、沒有已發出的紙本、沒有對外承諾綁定任何一課。
+→ **一修資料的保留成本 > 保留價值**。
+
+### 3. 現行資料結構會讓每次改版都重痛一次
+
+啟翔的原話：
+> 「全部都在同一份 YAML 裡面，然後就很大份……我請他做某件事，他會一直去抓其他的，
+> 有關聯但又不全然有關聯，因為太多東西混在一起了。我人腦去看他給我的 output 也很痛苦。」
+
+現況是**兩種結構並存**：
+- 舊：一課一個大 YAML，所有模組混在一起（設計目的是預先全載）
+- 新：聚光燈另外獨立成 `catalog/<課號>.spotlight.yml`
+
+而且**聚光燈檔名是綁課號的**，二修重排課號後全部對不到。
+
+### 4. 一個擋了四個月的 bug 剛修好，正好是重建的前提
+
+`backend/Dockerfile` 只 COPY `app/ data/ alembic/`，沒有 COPY `scripts/`
+（也複製不到 —— build context 是 `./backend`，`scripts/` 在上一層）。
+runtime 動態 import adapter 失敗 → fail-closed → **124 課有素材但只有 7 課吐得出內容**。
+
+已修並 merged（`33b0532c`）。容器內實測：修前 7 課、修後 124 課。
+**沒有這個修復，重建出來的內容一樣顯示不出來。**
+
+---
+
+## 二、現況（2026-08-14 實測，非文件推論）
+
+| 項目 | 數字 | 取得方式 |
+|---|---|---|
+| Drive 新教材（SOT） | **175 課** docx | `rclone lsf` 該資料夾，扣掉 1 個 `~$` 暫存檔 |
+| 線上 DB 課數 | **165** | `/api/stories?page_size=300` 的 `total` |
+| 聚光燈 catalog 檔 | 113（manifest 列 108） | `ls` + 讀 manifest.json |
+| 有 `spotlight_v2` 素材 | 124 | 容器內跑 loader 統計 |
+| `assets/worksheets/` | 458 檔，最後更新 **6/16** | `gcloud storage ls -l` |
+| `tts-cache` | **1523 MB** | `gcloud storage du` |
+| `reading-audio` ×2 | 0 MB（空） | 同上 |
+
+Drive 年級分佈：G4=20 / G5=28 / G6=29 / G7=30 / G8=23 / G9=23 / 文言文=12 / 體育生品格=11
+
+> ⚠️ 這解掉了會議上「159 還是 180 課」的爭議 —— **實際是 175**。
+> 比線上多 10 課，代表二修有新增課次。
+
+---
+
+## 三、WHAT — 做什麼 / 不做什麼
+
+### 做
+
+1. 以 Drive 175 課教師版 docx 為唯一來源，**重建全部課文內容**
+2. **改資料結構**：一課一個 folder，模組各自獨立 YAML，按需載入
+3. 清掉一修的 DB 資料、講義檔、聚光燈 catalog
+4. 重跑聚光燈、重點表、重點朗讀
+5. 朗讀改用 AI TTS（不再人工錄音）
+6. intro 頁移除全文朗讀鈕（全文朗讀統一在第二頁）
+
+### 不做（本次範圍外）
+
+| 不做 | 為什麼 |
+|---|---|
+| **不刪 `tts-cache`** | 快取鍵是 `sha256(文字)`，與課號、版本無關。二修沒改到的句子會直接命中；刪掉等於重新燒一次 TTS 費用 |
+| **不動 prod** | 先在 staging 完成並驗收，prod 待 staging 驗過再複製 |
+| **不上學生版/解答版下載** | Hans 還在轉換中，本次只上教師版抽出的**平台內容** |
+| **不點亮未檢核的聚光燈** | 機制修好 ≠ 內容驗過。用 manifest 控制，逐批開 |
+| **不追教授正式審稿** | 會議已定調：雙方無合約義務，改以「模組完成即上線、未完成先隱藏」 |
+
+---
+
+## 四、資料結構變更
+
+### 現況（會讓每次改版重痛）
+
+```
+backend/data/lessons/spotlight/catalog/G4-L11.spotlight.yml   ← 檔名綁課號
+backend/data/lessons/<某個大 YAML>                            ← 所有模組混在一起
+```
+
+### 目標
+
+```
+backend/data/lessons/<story_id>/
+  ├── meta.yml            # 課名、年級、課號、策略
+  ├── passage.yml         # 課文
+  ├── spotlight.yml       # 閱讀聚光燈
+  ├── keypoints.yml       # 文章重點表
+  ├── key_reading.yml     # 重點朗讀（念順順）
+  └── ...                 # 其他模組各自一份
+```
+
+**兩個關鍵設計**：
+
+1. **folder 用 `story_id` 不用課號** —— 課號會隨改版重排，`story_id` 不會。
+   這樣二修、三修、四修都不會再撞到「檔名對不到」的問題。
+2. **按需載入** —— 點到哪個關卡才讀那個模組的 YAML。
+   AI 做某個模組時只會看到那個模組的資料，不會再吃到別的模組（直接解掉啟翔的痛點）。
+
+---
+
+## 五、HOW — 手順
+
+> 每個階段都是一張 issue、一個 PR。**上一階段驗收通過才進下一階段。**
+
+### Phase 0 — 前置（已完成）
+
+- [x] adapter 進不了 image 的 bug 修復並 merged（`33b0532c`）
+- [x] Drive SOT 建立，175 課教師版就位
+- [x] 實習生 GCS 讀取權限開通（`objectViewer` + `legacyBucketReader`）
+
+### Phase 1 — 對照表：175 課 ↔ 線上 165 課
+
+**產出**：`docs/curriculum/second-edition-mapping.csv`
+
+| 欄位 | 說明 |
+|---|---|
+| `docx_path` | Drive 上的相對路徑 |
+| `new_code` | 從檔名解析的二修課號 |
+| `title` | 課名 |
+| `story_id` | 對應的線上 story_id（**沿用**）；查無對應則標 `NEW` |
+| `status` | `matched` / `new` / `online_only` |
+
+**為什麼要先做這張表**：165 → 175 之間有 10 課的差額，
+不知道哪些是新增、哪些是改名，就無法判斷「線上那課該保留還是該刪」。
+
+**驗收**：`matched + new` 覆蓋全部 175 課；`online_only` 逐筆有處置決定。
+
+### Phase 2 — 重建腳本（先跑 5 課，不碰線上）
+
+用既有的 `run_lesson_pipeline.py`（已實測可吃二修 DOCX，72 課 `build_ok` 72/72），
+輸出改寫成 Phase 4 的新 folder 結構。
+
+**驗收**：5 課在**容器內**能被 loader 讀到並吐出 `lesson_content`。
+⛔ 本機綠不算 —— 這次的 adapter bug 就是本機綠、線上壞。
+
+### Phase 3 — 全量抽取 175 課（仍不碰線上）
+
+**驗收**：`build_ok` 175/175；失敗的逐課列出原因，不隱藏。
+
+### Phase 4 — 資料結構切換 + 落地 staging
+
+1. 清掉 `backend/data/lessons/spotlight/catalog/`（113 檔）
+2. 寫入新的 `<story_id>/` 結構
+3. loader 改讀新結構
+4. `assets/worksheets/` 458 檔清掉，改上二修教師版
+5. deploy staging
+
+**驗收**：staging 上抽驗 10 課，真瀏覽器走完學習流程、0 console error。
+
+### Phase 5 — 朗讀重生成
+
+AI TTS 重跑。**`tts-cache` 不清** —— 未改動的句子直接命中。
+
+**驗收**：抽驗 10 課有音檔且非瀏覽器機器音（看回應大小，Azure 約 177–197KB）。
+
+### Phase 6 — 聚光燈 / 重點表 QA 與逐批點亮
+
+由啟翔、靖杭 QA。用 `catalog/manifest.json` 控制開關 —— **驗過一批才加一批**。
+未通過的先隱藏，會議已定調「模組完成即上線，未完成先隱藏」。
+
+### Phase 7 — prod
+
+staging 驗收通過後複製到 prod。
+
+---
+
+## 六、風險與回退
+
+| 風險 | 處置 |
+|---|---|
+| 抽取失敗率高於預期 | Phase 2 先跑 5 課即可發現；不進 Phase 3 |
+| 新資料結構讓 loader 壞掉 | Phase 4 前先在容器內驗過；staging 先行，prod 不動 |
+| 誤刪 tts-cache | **明列為不做事項**；任何刪除指令要先確認 bucket 名 |
+| 二修還有課沒給齊 | Hans 向明珠老師確認 175 是否為全部（會議 action item） |
+| 線上 10 課在 Drive 找不到對應 | Phase 1 的 `online_only` 逐筆決定：保留舊版 or 下架 |
+
+**回退路徑**：全程只動 staging；一修資料在 git 有完整歷史，隨時可還原。
+
+---
+
+## 七、驗收條件（全部達成才算完成）
+
+1. Drive 175 課全部在 staging 可見且可完成學習流程
+2. 資料結構已切換成 `<story_id>/<模組>.yml`，loader 讀得到
+3. 容器內（非本機）驗證通過
+4. 講義下載指向二修版本，或**明確關閉**（學生版未就位前不得指向一修）
+5. 聚光燈/重點表：通過 QA 的已點亮，未通過的已隱藏且列冊
+6. `tts-cache` 未被清空
+
+---
+
+## 八、分工
+
+| Phase | 主責 |
+|---|---|
+| 1–5 | Young（會議決定先自己跑一版，卡住再交接） |
+| 6 | 啟翔（聚光燈）、靖杭（重點表 / 朗讀） |
+| 學生版 + 解答版 docx | Hans（三版本轉換，8/31 前） |
+| 向明珠老師確認 175 是否為全部 | Hans |
+
+---
+
+## 附錄：本文件所有數字的取得方式
+
+- Drive 課數 — `rclone lsf --drive-root-folder-id <id> gdrive: -R --files-only --include "*.docx"`
+- 線上課數 — `curl /api/stories?page_size=300` 讀 `total`（⚠️ 參數是 `page_size` 不是 `limit`）
+- 容器內行為 — `docker run --rm -i --entrypoint python <prod image digest> - < probe.py`
+- GCS 用量 — `gcloud storage du -s gs://<bucket>`
+- 一修最後改動 — `git log --since=2026-07-21 -- backend/data/curriculum/`（空 = 未動）
+
+⛔ 本文件不採用狀態檔、舊議程或記憶作為事實來源。

--- a/docs/prd/2026-08-14-second-edition-reink.md
+++ b/docs/prd/2026-08-14-second-edition-reink.md
@@ -118,6 +118,10 @@ backend/data/catalog_manifest.yml     # catalog_slot → uid + version + 各模�
 `catalog_manifest.yml` 同時承擔 **partial publish** —— 一課可能課文已上、
 聚光燈未過 QA、講義待補，要能逐模組標狀態，不是整課全開或全關。
 
+**schema contract（fail-closed）**：合法狀態只有 `on` / `qa_pending` / `missing` / `off`。
+**只有 `on` 會被 loader 供應**；`qa_pending` 與 `missing` 一律當關閉，
+未知值也當關閉。⛔ 不可把 `qa_pending` 當 `on` 處理。
+
 `lesson.yml`：
 
 ```yaml
@@ -130,10 +134,15 @@ grade: 5                   # 屬性，可變
 `catalog_manifest.yml`：
 
 ```yaml
+lessons:
+  L0042:
+    published_version: v2  # 🔴 目前預設出哪版，切換與回退改這裡
+    versions: [v1, v2]
+
 published:
   G5-L11:                  # catalog_slot（每次重排都變）
     lesson_uid: L0042
-    version_id: v2
+    version_id: v2         # 通常 == published_version，可刻意釘舊版
     modules:               # partial publish — 逐模組狀態
       passage:    on
       spotlight:  qa_pending
@@ -241,40 +250,78 @@ published:
 - [x] Drive SOT 就位，175 課
 - [x] 實習生 GCS 讀取權限開通
 
-### Phase 1 — 發 uid + 建對照表
-產出 `docs/curriculum/lesson-uid-registry.yml`：
-每課一個 `lesson_uid`，記錄 `舊 story_id / 舊課號 / 二修課號 / 課名 / Drive 路徑`。
+### Phase 1 — 發 uid + 建對照表 + **Mapping Gate**
 
-**驗收**：175 課全部有 uid；線上 165 課逐筆對到 uid 或標 `retire`；
-uid 無重複、無重用。
+產出 `docs/curriculum/lesson-uid-registry.yml`。
 
-### Phase 2 — 改載入層，單層化
-- 廢除 Layer-1/Layer-2 合併與課名 enrich
-- loader 改讀 `<lesson_uid>/` 單層
-- 舊的 57 個 `L*.yml` 退役
+#### 🔴 Mapping Gate（可機器驗，CI 擋）
 
-**驗收**：容器內 loader 讀得到；撞鍵組數 = **0**（現在是 13）。
+「逐筆人工確認」**不是 gate** —— 175 課做不完，而且無法驗證有沒有真的看過。
+改成下列機器檢查，任一不過就 fail：
 
-### Phase 3 — 抽取 5 課試跑
+| # | 檢查 | 為什麼 |
+|---|---|---|
+| 1 | `lesson_uid` 全域唯一、格式固定、**永不重用**（比對歷史 registry） | 重用＝把兩課混成一課 |
+| 2 | 175 個 Drive 檔各有且僅有一筆 registry | 漏課 / 重複建 |
+| 3 | registry 存 **`drive_file_id`**（不是只有路徑） | 路徑會改名，file_id 不會 |
+| 4 | 每筆舊 `story_id` **exactly one of** `maps_to` / `retire` / `duplicate_of` | 沒對到或對兩次都會爆 |
+| 5 | 同一個 `old_story_id` **不可對多個 uid** | 學生紀錄會分裂 |
+| 6 | 同一個 `catalog_slot` **不可對多個 published uid+version** | 同一課號指到兩課 |
+| 7 | 課名／課號／normalized title／grade／舊正文 hash／新 DOCX fingerprint **任一不一致** → 自動進 `ambiguous_report` | 自動抓出需人工看的少數 |
+| 8 | 所有 ambiguous row 必須有 `reviewed_by` / `reviewed_at` / `reason` | 人工確認要留痕，CI 檢查 |
+
+**人工只看第 7 條篩出來的少數，不是 175 課全看。**
+
+**驗收**：上表 8 條全綠；撞鍵組數 = 0（現在 13，26 筆重複課須合併成單一 uid）。
+
+### Phase 2 — 抽取 5 課到新結構（先產生結構，還不動 loader）
 `run_lesson_pipeline.py` 已實測可吃二修 DOCX（72 課 `build_ok` 72/72），
-但**輸出路徑是寫死的扁平結構**（`{lesson_id}.spotlight.yml`）→ 要改成寫進 `<uid>/`。
+但 `process_lesson()` **輸出路徑是寫死的扁平結構**（`{lesson_id}.spotlight.yml`）
+→ 改成寫進 `<lesson_uid>/<version_id>/`。
 
-**驗收**：5 課在容器內能被讀到並吐出 `lesson_content`。
+⚠️ **順序理由**（codex 審查修正）：原本排「先改 loader 再抽內容」是錯的 ——
+抽內容才會產生新結構，先改 loader 等於切到一個不存在的目錄。
 
-### Phase 4 — 全量 175 課
-**驗收**：`build_ok` 175/175；失敗逐課列原因，不隱藏。
+**驗收**：5 課的 `<uid>/<version_id>/` 目錄實際產生且結構正確。
 
-### Phase 5 — 落地 staging
-照「三之二 清理清單」逐項執行：repo 內 356 檔 + GCS 902 物件 + DB 課文與學習紀錄，
-寫入新結構、deploy。**清理前先跑反向依賴掃描。**
+### Phase 3 — loader 支援新結構（雙路徑 / feature flag）
+loader **同時**讀舊的兩層與新的 `<uid>/<version_id>/`，用 flag 控制哪些課走新路徑。
+先只讓 Phase 2 那 5 課走新路。**此時不移除舊路徑。**
 
-**驗收**：staging 抽 10 課真瀏覽器走完流程、0 console error。
+**驗收**：容器內那 5 課走新路徑讀得到並吐出 `lesson_content`；其餘 165 課行為不變。
 
-### Phase 6 — 朗讀 TTS
-**`tts-cache` 不清**，未改動的句子直接命中。
+### Phase 4 — 全量抽取 175 課
+**驗收**：`build_ok` 175/175；失敗逐課列原因，不隱藏、不 fake pass。
+
+### Phase 5 — 切單層化，移除 Layer-1/Layer-2
+- 廢除兩層合併與課名 enrich
+- 舊的 57 個 `L*.yml` 退役
+- 移除雙路徑，只留新結構
+
+**驗收**：容器內 loader 讀得到；**撞鍵組數 = 0**（現在 13）。
+
+### Phase 6 — 🔴 清理舊資料（不可逆）+ 落地 staging
+照「三之二 清理清單」執行：repo 356 檔 + GCS 902 物件 + DB 課文與學習紀錄。
+
+**⛔ 每一個刪除動作執行前必須具備四件，缺一不得執行**：
+
+| | |
+|---|---|
+| **backup artifact** | 刪除對象的完整備份（GCS 用 `cp` 到 `_backup-<date>/`，repo 靠 git，DB 用 dump） |
+| **dry-run manifest** | 先列出「將要刪哪些」的清單檔，人看過才執行 |
+| **object count match** | 刪除後的數量 == 預期數量，不符就停 |
+| **restore plan** | 寫下「怎麼還原」的確切指令 |
+
+**清理前先跑反向依賴掃描**（`_ai_lessons` 2 處、`_reparsed_2026-05-02` 4 處引用）。
+
+**驗收**：staging 抽 10 課真瀏覽器走完流程、0 console error；
+`tts-cache/azure/` 物件數未減少。
+
+### Phase 7 — 朗讀 TTS
+**`tts-cache/azure/` 不清**，未改動的句子直接命中。
 **驗收**：抽 10 課有音檔且非瀏覽器機器音（回應約 177–197KB）。
 
-### Phase 7 — QA 逐批點亮 → prod
+### Phase 8 — QA 逐批點亮 → prod
 啟翔（聚光燈）、靖杭（重點表/朗讀）。用 manifest 控制，驗過一批開一批。
 
 ---
@@ -284,7 +331,7 @@ uid 無重複、無重用。
 | 風險 | 處置 |
 |---|---|
 | 🔴 **舊 `lesson_id` → 新 `uid/version` 的對照回填** | **最危險的一步，不是搬檔案。** 公開 URL、slug normalization、學習紀錄、OMO、TTS 都已把 integer `lesson_id` 當成事實（`lesson_loader.py:97`、`slug.py:73`、`stories.py:436`、`learning_reading_history.py:92`）。mapping 錯一筆，**API 照樣 200**，但學生紀錄、QR、音檔會接到錯課 —— 資料忠實度錯，一般測試抓不到。→ 對照表逐筆人工確認 + 寫回歸鎖 |
-| 🔴 **學習紀錄沒有版本欄位** | `learning_reading_history.py:92` 只存 `lesson_id`，查詢也只用 `student_id + lesson_id`（:135）。二修後舊紀錄會被新課文語意覆蓋，成績比較失真。→ 存紀錄時要一併寫入 `version_id` |
+| 🔴 **學習紀錄沒有版本欄位** | `learning_reading_history.py:92` 只存 `lesson_id`，查詢也只用 `student_id + lesson_id`（:135）。二修後舊紀錄會被新課文語意覆蓋，成績比較失真。→ 存紀錄時要一併寫入 **`lesson_uid` + `version_id`**（只寫 version_id 無法識別是哪一課） |
 | **Phase 2 改載入層是全域影響** | 先在容器內驗，staging 先行，prod 不動 |
 | **uid 不可自行推導** | 必須由 registry 分配。若有人從檔名生 uid，就又回到「檔名即身份」的老錯 |
 | pipeline 輸出格式要改 code | 已確認 `process_lesson()` 寫死扁平路徑，Phase 3 含這項改動 |
@@ -305,7 +352,7 @@ uid 無重複、無重用。
 5. 講義下載指向二修版，或**明確關閉**（學生版未就位前不得指向一修）
 6. 聚光燈/重點表：過 QA 的已點亮，未過的已隱藏且列冊
 7. `tts-cache` 未被清空
-8. **學習紀錄寫入時帶 `version_id`**
+8. **學習紀錄寫入時帶 `lesson_uid` + `version_id`**（只帶 version_id 沒意義 —— 每課都叫 `v2`）
 
 ---
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

取代 #2682（那版把問題定義成「二修要重刷」，只講對一半）。

## 真正的病根

載入層兩層合併，**歷史意外不是設計**：

```
2026-02-26  Layer-1  L*.yml        57 課，手工建
2026-05-01  Layer-2  _parsed/      152 檔，DOCX 批次 parse
```

5/1 批次 parse 完沒把舊的 57 課退役，改寫「用課名去重 + enrich」黏起來。

**實測撞鍵**：課名 10 組/20 課、正規化課號 **13 組/26 課**。
課名差一個標點（`「拳」力` vs `拳力`、`怎麼辦？` vs `怎麼辦`）就 enrich 失敗
→ Layer-1 那筆變空殼。**這是 165 課裡 20 課沒有聚光燈素材的真因。**

## 解法：四層概念

| 概念 | 是什麼 | 變不變 |
|---|---|---|
| `lesson_uid` | 這是哪一篇課文 | **永不變**，QR 綁這個 |
| `version_id` | 教材版本 | 每次改版新增 |
| `catalog_slot` | 當期排在哪（`G4-L10`） | 每次重排都變 |
| `published_version` | 目前預設出哪版 | 可切換可回退 |

四種情境（課號重排／課名改標點／新增課文／同課出新版）只有不可變流水號全過。

## codex 對抗式審查抓到的兩個 P0

1. **最危險的不是搬檔案，是 mapping 回填** —— 公開 URL、slug、學習紀錄、
   OMO、TTS 都已把 integer `lesson_id` 當事實。錯一筆 **API 照樣 200**，
   但學生紀錄與 QR 接到錯課，一般測試抓不到
2. **學習紀錄沒有版本欄位** —— `learning_reading_history.py:92` 只存
   `lesson_id`，二修後舊紀錄被新課文語意覆蓋，成績比較失真

## ⚠️ 明列不做

**不刪 `tts-cache`（1523 MB）** —— 快取鍵是 `sha256(文字)`，與課號版本無關，
刪掉等於重燒一次 TTS 費用。

## 驗收（可機器驗）

**撞鍵組數 = 0**（現在 13）／容器內驗證通過／學習紀錄帶 `version_id`